### PR TITLE
Create CRD Registration in helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.exe
 cover.out
 i3o
+!i3o/
 /dist/
 .vscode
 vendor

--- a/helm/chart/i3o/templates/hooks/crd-route-hook.yaml
+++ b/helm/chart/i3o/templates/hooks/crd-route-hook.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ingressroutes.traefik.containo.us
+  annotations:
+    "helm.sh/hook": crd-install
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: ingressroutes
+    singular: ingressroute
+    kind: IngressRoute
+    shortNames:
+    - ir

--- a/helm/chart/i3o/templates/hooks/crd-route-tcp-hook.yaml
+++ b/helm/chart/i3o/templates/hooks/crd-route-tcp-hook.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ingressroutetcps.traefik.containo.us
+  annotations:
+    "helm.sh/hook": crd-install
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: ingressroutetcps
+    singular: ingressroutetcp
+    kind: IngressRouteTCP
+    shortNames:
+    - irtcp


### PR DESCRIPTION
This creates the registration via helm hooks, so that we don't have to worry about code permissions to create it.

Fixes #23 