### PR TITLE
Add debug logging for CLI args

### DIFF
--- a/cmd/patch.go
+++ b/cmd/patch.go
@@ -30,6 +30,10 @@ func patchCommand() func(cmd *cobra.Command, args []string) {
 			log.SetLevel(log.DebugLevel)
 		}
 
+		log.Debugln("Starting i3o patch...")
+		log.Debugf("Using masterURL: %q", masterURL)
+		log.Debugf("Using kubeconfig: %q", kubeconfig)
+
 		clients, err := utils.BuildClients(masterURL, kubeconfig)
 		if err != nil {
 			log.Fatalf("Error building clients: %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,10 @@ func runCommand() func(cmd *cobra.Command, args []string) {
 		// set up signals so we handle the first shutdown signal gracefully
 		stopCh := signals.SetupSignalHandler()
 
+		log.Debugln("Starting i3o controller...")
+		log.Debugf("Using masterURL: %q", masterURL)
+		log.Debugf("Using kubeconfig: %q", kubeconfig)
+
 		clients, err := utils.BuildClients(masterURL, kubeconfig)
 		if err != nil {
 			log.Fatalf("Error building clients: %v", err)


### PR DESCRIPTION
These args mirror the configured endpoints in debug mode for debugging in/out of cluster options.

Fixes #31 