### PR TITLE
Configurable mesh mode and TCP Routing

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -16,8 +16,11 @@ type I3oConfiguration struct {
 // NewI3oConfiguration creates a I3oConfiguration with default values.
 func NewI3oConfiguration() *I3oConfiguration {
 	return &I3oConfiguration{
-		ConfigFile: "",
-		KubeConfig: os.Getenv("KUBECONFIG"),
+		ConfigFile:  "",
+		KubeConfig:  os.Getenv("KUBECONFIG"),
+		Debug:       false,
+		SMI:         false,
+		DefaultMode: "http",
 	}
 }
 
@@ -31,5 +34,6 @@ type PatchConfig struct {
 func NewPatchConfig() *PatchConfig {
 	return &PatchConfig{
 		KubeConfig: os.Getenv("KUBECONFIG"),
+		Debug:      false,
 	}
 }

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -77,7 +77,7 @@ func (m *Controller) Init() error {
 	m.kubernetesFactory.Core().V1().Endpoints().Informer().AddEventHandler(m.handler)
 	m.kubernetesFactory.Core().V1().Pods().Informer().AddEventHandler(m.handler)
 
-	m.kubernetesProvider = kubernetes.New(m.clients)
+	m.kubernetesProvider = kubernetes.New(m.clients, m.defaultMode)
 
 	// configurationQueue is used to process configurations from the providers
 	// and deal with pushing them to mesh nodes
@@ -105,6 +105,10 @@ func (m *Controller) Init() error {
 		HTTP: &config.HTTPConfiguration{
 			Routers:  map[string]*config.Router{},
 			Services: map[string]*config.Service{},
+		},
+		TCP: &config.TCPConfiguration{
+			Routers:  map[string]*config.TCPRouter{},
+			Services: map[string]*config.TCPService{},
 		},
 	}
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"time"
 
 	smiAccessv1alpha1 "github.com/deislabs/smi-sdk-go/pkg/apis/access/v1alpha1"
 	smiSpecsv1alpha1 "github.com/deislabs/smi-sdk-go/pkg/apis/specs/v1alpha1"
@@ -84,10 +83,6 @@ type IgnoreWrapper struct {
 	Namespaces Namespaces
 	Services   Services
 }
-
-const (
-	ResyncPeriod = 5 * time.Minute
-)
 
 // NewClientWrapper creates and returns both a kubernetes client, and a CRD client.
 func NewClientWrapper(url string, kubeConfig string) (*ClientWrapper, error) {

--- a/internal/k8s/constants.go
+++ b/internal/k8s/constants.go
@@ -1,0 +1,14 @@
+package k8s
+
+import (
+	"time"
+)
+
+const (
+	ResyncPeriod                 = 5 * time.Minute
+	MeshNamespace         string = "traefik-mesh"
+	baseAnnotation        string = "i3o.containo.us/"
+	AnnotationServiceType        = baseAnnotation + "i3o-traffic-type"
+	ServiceTypeHTTP       string = "http"
+	ServiceTypeTCP        string = "tcp"
+)

--- a/internal/k8s/namespace.go
+++ b/internal/k8s/namespace.go
@@ -4,10 +4,6 @@ import (
 	"strings"
 )
 
-const (
-	MeshNamespace string = "traefik-mesh"
-)
-
 // Namespaces holds namespace name.
 type Namespaces []string
 

--- a/internal/providers/kubernetes/provider_test.go
+++ b/internal/providers/kubernetes/provider_test.go
@@ -19,7 +19,7 @@ func TestBuildRouter(t *testing.T) {
 		Service:     "bar",
 	}
 
-	provider := New(nil)
+	provider := New(nil, k8s.ServiceTypeHTTP)
 
 	name := "test"
 	namespace := "foo"
@@ -31,6 +31,23 @@ func TestBuildRouter(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestBuildTCPRouter(t *testing.T) {
+	expected := &config.TCPRouter{
+		Rule:        "HostSNI(`*`)",
+		EntryPoints: []string{"ingress-80"},
+		Service:     "bar",
+	}
+
+	provider := New(nil, k8s.ServiceTypeTCP)
+
+	port := 80
+	associatedService := "bar"
+
+	actual := provider.buildTCPRouter(port, associatedService)
+	assert.Equal(t, expected, actual)
+
+}
+
 func TestBuildConfiguration(t *testing.T) {
 	testCases := []struct {
 		desc           string
@@ -39,6 +56,7 @@ func TestBuildConfiguration(t *testing.T) {
 		provided       *config.Configuration
 		expected       *config.Configuration
 		endpointsError bool
+		serviceError   bool
 	}{
 		{
 			desc:     "simple configuration build with empty event",
@@ -48,16 +66,24 @@ func TestBuildConfiguration(t *testing.T) {
 					Routers:  map[string]*config.Router{},
 					Services: map[string]*config.Service{},
 				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
 			},
 			provided: &config.Configuration{
 				HTTP: &config.HTTPConfiguration{
 					Routers:  map[string]*config.Router{},
 					Services: map[string]*config.Service{},
 				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
 			},
 		},
 		{
-			desc:     "simple configuration build with service event",
+			desc:     "simple configuration build with HTTP service event",
 			mockFile: "build_configuration_simple.yaml",
 			expected: &config.Configuration{
 				HTTP: &config.HTTPConfiguration{
@@ -88,11 +114,19 @@ func TestBuildConfiguration(t *testing.T) {
 						},
 					},
 				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
 			},
 			provided: &config.Configuration{
 				HTTP: &config.HTTPConfiguration{
 					Routers:  map[string]*config.Router{},
 					Services: map[string]*config.Service{},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
 				},
 			},
 			event: message.Message{
@@ -116,12 +150,35 @@ func TestBuildConfiguration(t *testing.T) {
 			},
 		},
 		{
-			desc:     "endpoints error",
+			desc:     "simple configuration build with TCP service event",
 			mockFile: "build_configuration_simple.yaml",
 			expected: &config.Configuration{
 				HTTP: &config.HTTPConfiguration{
 					Routers:  map[string]*config.Router{},
 					Services: map[string]*config.Service{},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers: map[string]*config.TCPRouter{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							EntryPoints: []string{"ingress-5000"},
+							Service:     "6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839",
+							Rule:        "HostSNI(`*`)",
+						},
+					},
+					Services: map[string]*config.TCPService{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							LoadBalancer: &config.TCPLoadBalancerService{
+								Servers: []config.TCPServer{
+									{
+										Address: "10.0.0.1:80",
+									},
+									{
+										Address: "10.0.0.2:80",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			provided: &config.Configuration{
@@ -129,9 +186,387 @@ func TestBuildConfiguration(t *testing.T) {
 					Routers:  map[string]*config.Router{},
 					Services: map[string]*config.Service{},
 				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
+			},
+			event: message.Message{
+				Object: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "foo",
+						Annotations: map[string]string{
+							k8s.AnnotationServiceType: k8s.ServiceTypeTCP,
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "10.1.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:     "test",
+								Port:     80,
+								Protocol: "TCP",
+							},
+						},
+					},
+				},
+				Action: message.TypeCreated,
+			},
+		},
+		{
+			desc:     "endpoints error",
+			mockFile: "build_configuration_simple.yaml",
+			expected: &config.Configuration{
+				HTTP: &config.HTTPConfiguration{
+					Routers:  map[string]*config.Router{},
+					Services: map[string]*config.Service{},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
+			},
+			provided: &config.Configuration{
+				HTTP: &config.HTTPConfiguration{
+					Routers:  map[string]*config.Router{},
+					Services: map[string]*config.Service{},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
+			},
+			event: message.Message{
+				Object: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "foo",
+					},
+				},
+				Action: message.TypeCreated,
 			},
 
 			endpointsError: true,
+		},
+		{
+			desc:     "endpoints not exist error",
+			mockFile: "build_configuration_simple.yaml",
+			expected: &config.Configuration{
+				HTTP: &config.HTTPConfiguration{
+					Routers:  map[string]*config.Router{},
+					Services: map[string]*config.Service{},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
+			},
+			provided: &config.Configuration{
+				HTTP: &config.HTTPConfiguration{
+					Routers:  map[string]*config.Router{},
+					Services: map[string]*config.Service{},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
+			},
+			event: message.Message{
+				Object: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "bar",
+					},
+				},
+				Action: message.TypeCreated,
+			},
+		},
+		{
+			desc:     "service error",
+			mockFile: "build_configuration_simple.yaml",
+			expected: &config.Configuration{
+				HTTP: &config.HTTPConfiguration{
+					Routers:  map[string]*config.Router{},
+					Services: map[string]*config.Service{},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
+			},
+			provided: &config.Configuration{
+				HTTP: &config.HTTPConfiguration{
+					Routers:  map[string]*config.Router{},
+					Services: map[string]*config.Service{},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
+			},
+			event: message.Message{
+				Object: &corev1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "foo",
+					},
+				},
+				Action: message.TypeUpdated,
+			},
+
+			serviceError: true,
+		},
+		{
+			desc:     "service not exist error",
+			mockFile: "build_configuration_simple.yaml",
+			expected: &config.Configuration{
+				HTTP: &config.HTTPConfiguration{
+					Routers:  map[string]*config.Router{},
+					Services: map[string]*config.Service{},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
+			},
+			provided: &config.Configuration{
+				HTTP: &config.HTTPConfiguration{
+					Routers:  map[string]*config.Router{},
+					Services: map[string]*config.Service{},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
+			},
+			event: message.Message{
+				Object: &corev1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "bar",
+					},
+				},
+				Action: message.TypeUpdated,
+			},
+		},
+		{
+			desc:     "simple configuration delete HTTP service event",
+			mockFile: "build_configuration_simple.yaml",
+			expected: &config.Configuration{
+				HTTP: &config.HTTPConfiguration{
+					Routers:  map[string]*config.Router{},
+					Services: map[string]*config.Service{},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers: map[string]*config.TCPRouter{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							EntryPoints: []string{"ingress-5000"},
+							Service:     "6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839",
+							Rule:        "HostSNI(`*`)",
+						},
+					},
+					Services: map[string]*config.TCPService{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							LoadBalancer: &config.TCPLoadBalancerService{
+								Servers: []config.TCPServer{
+									{
+										Address: "10.0.0.1:80",
+									},
+									{
+										Address: "10.0.0.2:80",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			provided: &config.Configuration{
+				HTTP: &config.HTTPConfiguration{
+					Routers: map[string]*config.Router{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							EntryPoints: []string{"ingress-5000"},
+							Service:     "6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839",
+							Rule:        "Host(`test.foo.traefik.mesh`) || Host(`10.1.0.1`)",
+						},
+					},
+					Services: map[string]*config.Service{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							LoadBalancer: &config.LoadBalancerService{
+								PassHostHeader: true,
+								Servers: []config.Server{
+									{
+										URL:    "http://10.0.0.1:80",
+										Scheme: "",
+										Port:   "",
+									},
+									{
+										URL:    "http://10.0.0.2:80",
+										Scheme: "",
+										Port:   "",
+									},
+								},
+							},
+						},
+					},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers: map[string]*config.TCPRouter{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							EntryPoints: []string{"ingress-5000"},
+							Service:     "6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839",
+							Rule:        "HostSNI(`*`)",
+						},
+					},
+					Services: map[string]*config.TCPService{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							LoadBalancer: &config.TCPLoadBalancerService{
+								Servers: []config.TCPServer{
+									{
+										Address: "10.0.0.1:80",
+									},
+									{
+										Address: "10.0.0.2:80",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			event: message.Message{
+				Object: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "foo",
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "10.1.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:     "test",
+								Port:     80,
+								Protocol: "TCP",
+							},
+						},
+					},
+				},
+				Action: message.TypeDeleted,
+			},
+		},
+		{
+			desc:     "simple configuration delete TCP service event",
+			mockFile: "build_configuration_simple.yaml",
+			expected: &config.Configuration{
+				HTTP: &config.HTTPConfiguration{
+					Routers: map[string]*config.Router{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							EntryPoints: []string{"ingress-5000"},
+							Service:     "6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839",
+							Rule:        "Host(`test.foo.traefik.mesh`) || Host(`10.1.0.1`)",
+						},
+					},
+					Services: map[string]*config.Service{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							LoadBalancer: &config.LoadBalancerService{
+								PassHostHeader: true,
+								Servers: []config.Server{
+									{
+										URL:    "http://10.0.0.1:80",
+										Scheme: "",
+										Port:   "",
+									},
+									{
+										URL:    "http://10.0.0.2:80",
+										Scheme: "",
+										Port:   "",
+									},
+								},
+							},
+						},
+					},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers:  map[string]*config.TCPRouter{},
+					Services: map[string]*config.TCPService{},
+				},
+			},
+			provided: &config.Configuration{
+				HTTP: &config.HTTPConfiguration{
+					Routers: map[string]*config.Router{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							EntryPoints: []string{"ingress-5000"},
+							Service:     "6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839",
+							Rule:        "Host(`test.foo.traefik.mesh`) || Host(`10.1.0.1`)",
+						},
+					},
+					Services: map[string]*config.Service{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							LoadBalancer: &config.LoadBalancerService{
+								PassHostHeader: true,
+								Servers: []config.Server{
+									{
+										URL:    "http://10.0.0.1:80",
+										Scheme: "",
+										Port:   "",
+									},
+									{
+										URL:    "http://10.0.0.2:80",
+										Scheme: "",
+										Port:   "",
+									},
+								},
+							},
+						},
+					},
+				},
+				TCP: &config.TCPConfiguration{
+					Routers: map[string]*config.TCPRouter{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							EntryPoints: []string{"ingress-5000"},
+							Service:     "6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839",
+							Rule:        "HostSNI(`*`)",
+						},
+					},
+					Services: map[string]*config.TCPService{
+						"6653beb49ee354ea9d22028a3816f8947fe6b2f8362e42eb258e884769be2839": {
+							LoadBalancer: &config.TCPLoadBalancerService{
+								Servers: []config.TCPServer{
+									{
+										Address: "10.0.0.1:80",
+									},
+									{
+										Address: "10.0.0.2:80",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			event: message.Message{
+				Object: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "foo",
+						Annotations: map[string]string{
+							k8s.AnnotationServiceType: k8s.ServiceTypeTCP,
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "10.1.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:     "test",
+								Port:     80,
+								Protocol: "TCP",
+							},
+						},
+					},
+				},
+				Action: message.TypeDeleted,
+			},
 		},
 	}
 
@@ -143,8 +578,11 @@ func TestBuildConfiguration(t *testing.T) {
 			if test.endpointsError {
 				clientMock.EnableEndpointsError()
 			}
+			if test.serviceError {
+				clientMock.EnableServiceError()
+			}
 
-			provider := New(clientMock)
+			provider := New(clientMock, k8s.ServiceTypeHTTP)
 			provider.BuildConfiguration(test.event, test.provided)
 			assert.Equal(t, test.expected, test.provided)
 		})
@@ -205,8 +643,69 @@ func TestBuildService(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			clientMock := k8s.NewCoreV1ClientMock(test.mockFile)
-			provider := New(clientMock)
+			provider := New(clientMock, k8s.ServiceTypeHTTP)
 			actual := provider.buildService(test.endpoints)
+			assert.Equal(t, test.expected, actual)
+
+		})
+	}
+}
+
+func TestBuildTCPService(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		mockFile  string
+		endpoints *corev1.Endpoints
+		expected  *config.TCPService
+	}{
+		{
+			desc:     "two successful endpoints",
+			mockFile: "build_service_simple.yaml",
+			endpoints: &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "foo",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+							},
+							{
+								IP: "10.0.0.2",
+							},
+						},
+						Ports: []corev1.EndpointPort{
+							{
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+			expected: &config.TCPService{
+				LoadBalancer: &config.TCPLoadBalancerService{
+					Servers: []config.TCPServer{
+						{
+							Address: "10.0.0.1:80",
+						},
+						{
+							Address: "10.0.0.2:80",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			clientMock := k8s.NewCoreV1ClientMock(test.mockFile)
+			provider := New(clientMock, k8s.ServiceTypeHTTP)
+			actual := provider.buildTCPService(test.endpoints)
 			assert.Equal(t, test.expected, actual)
 
 		})


### PR DESCRIPTION
This PR enables TCP routing, and allows for a configurable default via flags.

The unconfigured default is HTTP.

Fixes #88 