### PR TITLE
Update Semaphore + Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG MAKE_TARGET=local-build
 RUN make ${MAKE_TARGET}
 
 ## IMAGE
-FROM alpine:3.9
+FROM alpine:3.10
 
 RUN addgroup -g 1000 -S app && \
     adduser -u 1000 -S app -G app

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BINARY_NAME = i3o
 DIST_DIR = $(CURDIR)/dist
 DIST_DIR_I3O = $(DIST_DIR)/$(BINARY_NAME)
 PROJECT ?= github.com/containous/$(BINARY_NAME)
-GOLANGCI_LINTER_VERSION = v1.16.0
+GOLANGCI_LINTER_VERSION = v1.17.1
 
 TAG_NAME := $(shell git tag -l --contains HEAD)
 SHA := $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
This PR updates build reqs, and keeps the linter in version check with Traefik CE. (and updated).