### PR TITLE
Create IP Whitelisting for SMI Access

### DIFF
--- a/internal/k8s/client_mock.go
+++ b/internal/k8s/client_mock.go
@@ -48,7 +48,6 @@ type CoreV1ClientMock struct {
 	services     []*corev1.Service
 	servicesList *corev1.ServiceList
 	pods         []*corev1.Pod
-	podsList     *corev1.PodList
 	endpoints    []*corev1.Endpoints
 	namespaces   []*corev1.Namespace
 	configMaps   []*corev1.ConfigMap
@@ -268,7 +267,16 @@ func (c *CoreV1ClientMock) ListPodWithOptions(namespace string, options metav1.L
 		return nil, c.apiPodError
 	}
 
-	return c.podsList, nil
+	items := []corev1.Pod{}
+
+	for _, pod := range c.pods {
+		items = append(items, *pod)
+	}
+
+	result := &corev1.PodList{
+		Items: items,
+	}
+	return result, nil
 }
 
 func (c *CoreV1ClientMock) GetNamespace(name string) (*corev1.Namespace, bool, error) {

--- a/internal/k8s/constants.go
+++ b/internal/k8s/constants.go
@@ -11,4 +11,5 @@ const (
 	AnnotationServiceType        = baseAnnotation + "i3o-traffic-type"
 	ServiceTypeHTTP       string = "http"
 	ServiceTypeTCP        string = "tcp"
+	BlockAllMiddlewareKey string = "smi-block-all-middleware"
 )

--- a/internal/providers/smi/fixtures/mock.yaml
+++ b/internal/providers/smi/fixtures/mock.yaml
@@ -161,6 +161,8 @@ spec:
   containers:
     - name: example
       image: busybox
+status:
+  podIP: "10.4.3.2"
 
 ---
 apiVersion: v1


### PR DESCRIPTION
This PR provides the framework for SMI access control via IP Whitelisting.

This PR:
- Creates an IP whitelist with no matching IP (block-all whitelist).
- Creates whitelists to use when matching pods are found.

The unit tests aren't great due to filtering requirements of the clientMock. Right now it just lists all pods as valid, instead of filter.

Will need to be further implemented for #137 