### PR TITLE
Update traefik to version 2.0-beta1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/sprig v2.20.0+incompatible // indirect
 	github.com/cenkalti/backoff v2.1.1+incompatible
 	github.com/containous/mux v0.0.0-20181024131434-c33f32e26898 // indirect
-	github.com/containous/traefik v2.0.0-alpha8.0.20190715150404-6fdd48509ebf+incompatible
+	github.com/containous/traefik v2.0.0-beta1+incompatible
 	github.com/deislabs/smi-sdk-go v0.0.0-20190621175932-114e91dce170
 	github.com/go-acme/lego v2.6.0+incompatible // indirect
 	github.com/go-check/check v0.0.0-20180628173108-788fd7840127

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containous/mux v0.0.0-20181024131434-c33f32e26898 h1:1srn9voikJGofblBhWy3WuZWqo14Ou7NaswNG/I2yWc=
 github.com/containous/mux v0.0.0-20181024131434-c33f32e26898/go.mod h1:z8WW7n06n8/1xF9Jl9WmuDeZuHAhfL+bwarNjsciwwg=
-github.com/containous/traefik v2.0.0-alpha8.0.20190715150404-6fdd48509ebf+incompatible h1:Zh61nQoso1i0HjraU1oLxN/jD7H/3ri4xdhvuLeZ3r4=
-github.com/containous/traefik v2.0.0-alpha8.0.20190715150404-6fdd48509ebf+incompatible/go.mod h1:epDRqge3JzKOhlSWzOpNYEEKXmM6yfN5tPzDGKk3ljo=
+github.com/containous/traefik v2.0.0-beta1+incompatible h1:9hTAt6OzVNITnp/Ib5GWIYbuua4cooVcNHcWUX7Jx88=
+github.com/containous/traefik v2.0.0-beta1+incompatible/go.mod h1:epDRqge3JzKOhlSWzOpNYEEKXmM6yfN5tPzDGKk3ljo=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
### Description

This PR updates traefik to version v2.0.0-beta1