### PR TITLE
Use traefik:v2.0.0-beta1 instaed of experimental image

### DIFF
--- a/helm/chart/i3o/values.yaml
+++ b/helm/chart/i3o/values.yaml
@@ -7,7 +7,7 @@ image:
   # tag: v0.0.1
   # (Optional)
   # pullSecret: xxx
-  traefik: containous/traefik:experimental-v2.0
+  traefik: traefik:v2.0.0-beta1
 
 debug: true
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -49,7 +49,7 @@ func init() {
 	images = append(images, image{"coredns/coredns:1.4.0", true})
 	images = append(images, image{"gcr.io/kubernetes-helm/tiller:v2.14.1", true})
 	images = append(images, image{"giantswarm/tiny-tools:3.9", true})
-	images = append(images, image{"containous/traefik:experimental-v2.0", true})
+	images = append(images, image{"traefik:v2.0.0-beta1", true})
 
 	check.Suite(&SMISuite{})
 	check.Suite(&CurlI3oSuite{})

--- a/integration/resources/values.yaml
+++ b/integration/resources/values.yaml
@@ -7,7 +7,7 @@ image:
   tag: latest
   # (Optional)
   # pullSecret: xxx
-  traefik: containous/traefik:experimental-v2.0
+  traefik: traefik:v2.0.0-beta1
 
 debug: true
 


### PR DESCRIPTION
### Description

This PR use `traefik:v2.0.0-beta1` docker image instead of `containous/traefik:experimental-v2.0`