### PR TITLE
Improve Router and Service Naming

### DIFF
--- a/internal/providers/kubernetes/provider.go
+++ b/internal/providers/kubernetes/provider.go
@@ -214,6 +214,5 @@ func buildKey(name, namespace string, port int32) string {
 	dst := make([]byte, hex.EncodedLen(len(sum)))
 	hex.Encode(dst, sum[:])
 	fullHash := string(dst)
-	trimmedHash := fullHash[:15]
-	return fmt.Sprintf("%s-%s-%d-%s", name, namespace, port, trimmedHash)
+	return fmt.Sprintf("%.10s-%.10s-%d-%.16s", name, namespace, port, fullHash)
 }

--- a/internal/providers/kubernetes/provider_test.go
+++ b/internal/providers/kubernetes/provider_test.go
@@ -97,14 +97,14 @@ func TestBuildConfiguration(t *testing.T) {
 			expected: &dynamic.Configuration{
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"test-foo-80-6653beb49ee354e": {
+						"test-foo-80-6653beb49ee354ea": {
 							EntryPoints: []string{"http-5000"},
-							Service:     "test-foo-80-6653beb49ee354e",
+							Service:     "test-foo-80-6653beb49ee354ea",
 							Rule:        "Host(`test.foo.maesh`) || Host(`10.1.0.1`)",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"test-foo-80-6653beb49ee354e": {
+						"test-foo-80-6653beb49ee354ea": {
 							LoadBalancer: &dynamic.LoadBalancerService{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -168,14 +168,14 @@ func TestBuildConfiguration(t *testing.T) {
 				},
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"test-foo-80-6653beb49ee354e": {
-							EntryPoints: []string{"tcp-5000"},
-							Service:     "test-foo-80-6653beb49ee354e",
+						"test-foo-80-6653beb49ee354ea": {
+							EntryPoints: []string{"tcp-10000"},
+							Service:     "test-foo-80-6653beb49ee354ea",
 							Rule:        "HostSNI(`*`)",
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"test-foo-80-6653beb49ee354e": {
+						"test-foo-80-6653beb49ee354ea": {
 							LoadBalancer: &dynamic.TCPLoadBalancerService{
 								Servers: []dynamic.TCPServer{
 									{
@@ -369,14 +369,14 @@ func TestBuildConfiguration(t *testing.T) {
 				},
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"test-foo-80-6653beb49ee354e": {
-							EntryPoints: []string{"ingress-5000"},
-							Service:     "test-foo-80-6653beb49ee354e",
+						"test-foo-80-6653beb49ee354ea": {
+							EntryPoints: []string{"tcp-10000"},
+							Service:     "test-foo-80-6653beb49ee354ea",
 							Rule:        "HostSNI(`*`)",
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"test-foo-80-6653beb49ee354e": {
+						"test-foo-80-6653beb49ee354ea": {
 							LoadBalancer: &dynamic.TCPLoadBalancerService{
 								Servers: []dynamic.TCPServer{
 									{
@@ -394,14 +394,14 @@ func TestBuildConfiguration(t *testing.T) {
 			provided: &dynamic.Configuration{
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"test-foo-80-6653beb49ee354e": {
-							EntryPoints: []string{"ingress-5000"},
-							Service:     "test-foo-80-6653beb49ee354e",
+						"test-foo-80-6653beb49ee354ea": {
+							EntryPoints: []string{"http-5000"},
+							Service:     "test-foo-80-6653beb49ee354ea",
 							Rule:        "Host(`test.foo.maesh`) || Host(`10.1.0.1`)",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"test-foo-80-6653beb49ee354e": {
+						"test-foo-80-6653beb49ee354ea": {
 							LoadBalancer: &dynamic.LoadBalancerService{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -422,14 +422,14 @@ func TestBuildConfiguration(t *testing.T) {
 				},
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"test-foo-80-6653beb49ee354e": {
-							EntryPoints: []string{"ingress-5000"},
-							Service:     "test-foo-80-6653beb49ee354e",
+						"test-foo-80-6653beb49ee354ea": {
+							EntryPoints: []string{"tcp-10000"},
+							Service:     "test-foo-80-6653beb49ee354ea",
 							Rule:        "HostSNI(`*`)",
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"test-foo-80-6653beb49ee354e": {
+						"test-foo-80-6653beb49ee354ea": {
 							LoadBalancer: &dynamic.TCPLoadBalancerService{
 								Servers: []dynamic.TCPServer{
 									{
@@ -470,14 +470,14 @@ func TestBuildConfiguration(t *testing.T) {
 			expected: &dynamic.Configuration{
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"test-foo-80-6653beb49ee354e": {
-							EntryPoints: []string{"ingress-5000"},
-							Service:     "test-foo-80-6653beb49ee354e",
+						"test-foo-80-6653beb49ee354ea": {
+							EntryPoints: []string{"http-5000"},
+							Service:     "test-foo-80-6653beb49ee354ea",
 							Rule:        "Host(`test.foo.maesh`) || Host(`10.1.0.1`)",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"test-foo-80-6653beb49ee354e": {
+						"test-foo-80-6653beb49ee354ea": {
 							LoadBalancer: &dynamic.LoadBalancerService{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -504,14 +504,14 @@ func TestBuildConfiguration(t *testing.T) {
 			provided: &dynamic.Configuration{
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"test-foo-80-6653beb49ee354e": {
-							EntryPoints: []string{"ingress-5000"},
-							Service:     "test-foo-80-6653beb49ee354e",
+						"test-foo-80-6653beb49ee354ea": {
+							EntryPoints: []string{"http-5000"},
+							Service:     "test-foo-80-6653beb49ee354ea",
 							Rule:        "Host(`test.foo.maesh`) || Host(`10.1.0.1`)",
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"test-foo-80-6653beb49ee354e": {
+						"test-foo-80-6653beb49ee354ea": {
 							LoadBalancer: &dynamic.LoadBalancerService{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -532,14 +532,14 @@ func TestBuildConfiguration(t *testing.T) {
 				},
 				TCP: &dynamic.TCPConfiguration{
 					Routers: map[string]*dynamic.TCPRouter{
-						"test-foo-80-6653beb49ee354e": {
-							EntryPoints: []string{"ingress-5000"},
-							Service:     "test-foo-80-6653beb49ee354e",
+						"test-foo-80-6653beb49ee354ea": {
+							EntryPoints: []string{"tcp-10000"},
+							Service:     "test-foo-80-6653beb49ee354ea",
 							Rule:        "HostSNI(`*`)",
 						},
 					},
 					Services: map[string]*dynamic.TCPService{
-						"test-foo-80-6653beb49ee354e": {
+						"test-foo-80-6653beb49ee354ea": {
 							LoadBalancer: &dynamic.TCPLoadBalancerService{
 								Servers: []dynamic.TCPServer{
 									{

--- a/internal/providers/smi/provider.go
+++ b/internal/providers/smi/provider.go
@@ -440,8 +440,7 @@ func buildKey(serviceName, namespace string, port int32, ttName, ttNamespace str
 	dst := make([]byte, hex.EncodedLen(len(sum)))
 	hex.Encode(dst, sum[:])
 	fullHash := string(dst)
-	trimmedHash := fullHash[:15]
-	return fmt.Sprintf("%s-%s-%d-%s-%s-%s", serviceName, namespace, port, ttName, ttNamespace, trimmedHash)
+	return fmt.Sprintf("%.10s-%.10s-%d-%.10s-%.10s-%.16s", serviceName, namespace, port, ttName, ttNamespace, fullHash)
 }
 
 func createWhitelistMiddleware(sourceIPs []string) *dynamic.Middleware {

--- a/internal/providers/smi/provider_test.go
+++ b/internal/providers/smi/provider_test.go
@@ -1260,15 +1260,15 @@ func TestBuildConfiguration(t *testing.T) {
 			expected: &dynamic.Configuration{
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"demo-service-default-80-api-service-metrics-default-5bb66e727779b5b": {
+						"demo-servi-default-80-api-servic-default-5bb66e727779b5ba": {
 							EntryPoints: []string{"ingress-5000"},
 							Rule:        "((PathPrefix(`/metrics`) && Method(`GET`) && (Host(`demo-service.default.maesh`) || Host(`10.1.0.1`))))",
-							Service:     "demo-service-default-80-api-service-metrics-default-5bb66e727779b5b",
-							Middlewares: []string{"api-service-metrics-default-demo-service-default-80-api-service-metrics-default-5bb66e727779b5b-whitelist"},
+							Service:     "demo-servi-default-80-api-servic-default-5bb66e727779b5ba",
+							Middlewares: []string{"api-service-metrics-default-demo-servi-default-80-api-servic-default-5bb66e727779b5ba-whitelist"},
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"demo-service-default-80-api-service-metrics-default-5bb66e727779b5b": {
+						"demo-servi-default-80-api-servic-default-5bb66e727779b5ba": {
 							LoadBalancer: &dynamic.LoadBalancerService{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -1280,7 +1280,7 @@ func TestBuildConfiguration(t *testing.T) {
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
-						"api-service-metrics-default-demo-service-default-80-api-service-metrics-default-5bb66e727779b5b-whitelist": {
+						"api-service-metrics-default-demo-servi-default-80-api-servic-default-5bb66e727779b5ba-whitelist": {
 							IPWhiteList: &dynamic.IPWhiteList{
 								SourceRange: []string{"10.4.3.2"},
 							},
@@ -1328,15 +1328,15 @@ func TestBuildConfiguration(t *testing.T) {
 			expected: &dynamic.Configuration{
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"demo-test-default-80-api-service-metrics-default-7f2af3b9b8c3257": {
+						"demo-test-default-80-api-servic-default-7f2af3b9b8c32573": {
 							EntryPoints: []string{"ingress-5000"},
 							Rule:        "((PathPrefix(`/metrics`) && Method(`GET`) && (Host(`demo-test.default.maesh`) || Host(`10.1.0.1`))))",
-							Service:     "demo-test-default-80-api-service-metrics-default-7f2af3b9b8c3257",
-							Middlewares: []string{"api-service-metrics-default-demo-test-default-80-api-service-metrics-default-7f2af3b9b8c3257-whitelist"},
+							Service:     "demo-test-default-80-api-servic-default-7f2af3b9b8c32573",
+							Middlewares: []string{"api-service-metrics-default-demo-test-default-80-api-servic-default-7f2af3b9b8c32573-whitelist"},
 						},
 					},
 					Services: map[string]*dynamic.Service{
-						"demo-test-default-80-api-service-metrics-default-7f2af3b9b8c3257": {
+						"demo-test-default-80-api-servic-default-7f2af3b9b8c32573": {
 							LoadBalancer: &dynamic.LoadBalancerService{
 								PassHostHeader: true,
 								Servers: []dynamic.Server{
@@ -1348,7 +1348,7 @@ func TestBuildConfiguration(t *testing.T) {
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
-						"api-service-metrics-default-demo-test-default-80-api-service-metrics-default-7f2af3b9b8c3257-whitelist": {
+						"api-service-metrics-default-demo-test-default-80-api-servic-default-7f2af3b9b8c32573-whitelist": {
 							IPWhiteList: &dynamic.IPWhiteList{
 								SourceRange: []string{"10.4.3.2"},
 							},


### PR DESCRIPTION
This PR reworks the generation of key names.

It keeps 15 characters of the SHA, but now uses human-readable names.

We may run into length issues, where we want to truncate to 10 digits or whatever. This would ensure that the strings don't run into length issues (particularly for the SMI provider).

Feedback Appreciated on this one!

Fixes #163 