### PR TITLE
Add TCPStateTable Configmap to helm

### DIFF
--- a/helm/chart/maesh/templates/controller/controller-configmap.yaml
+++ b/helm/chart/maesh/templates/controller/controller-configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1 
+kind: ConfigMap 
+metadata:
+  name: tcp-state-table
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name | quote}}
+    chart: {{ include "maesh.chartLabel" . | quote}}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+data:
+  key: value

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -182,10 +182,6 @@ func (w *ClientWrapper) InitCluster(namespace string) error {
 		return err
 	}
 
-	log.Debugln("Creating TCP State Table...")
-	if err := w.createTCPStateTable(namespace); err != nil {
-		return err
-	}
 	log.Infoln("Cluster Preparation Complete...")
 
 	return nil
@@ -210,24 +206,6 @@ func (w *ClientWrapper) patchCoreDNS(deploymentName string, deploymentNamespace 
 		}
 	}
 
-	return nil
-}
-
-func (w *ClientWrapper) createTCPStateTable(namespace string) error {
-	_, exists, err := w.GetConfigMap(namespace, TCPStateConfigmapName)
-	if err != nil {
-		return err
-	}
-
-	if !exists {
-		_, err := w.CreateConfigMap(&corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      TCPStateConfigmapName,
-				Namespace: namespace,
-			},
-		})
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
This PR:

- Removes the creation of the state table from the `prepare` command
- Adds the configmap to helm for management

Fixes #183 