### PR TITLE
Host main documentation on gh-pages, mixed with Helm Chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ maesh
 .vscode
 vendor
 integration/resources/compose/images
+pages/

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ maesh
 vendor
 integration/resources/compose/images
 pages/
+maesh-gh-pages*
+*.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ services:
 
 script:
   - echo "Skipping tests... (Tests are executed on SemaphoreCI)"
-  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make -C ./docs docs; fi
+  - make docs-package
 
 # install:
   # - go mod tidy
@@ -46,7 +46,6 @@ before_deploy:
       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
     fi
 
-    make docs-package
 deploy:
   - provider: script
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ before_deploy:
       export BEFORE_DEPLOY_RUN=1;
       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
     fi
+
+    make docs-package
 deploy:
   - provider: script
     skip_cleanup: true
@@ -60,16 +62,16 @@ deploy:
       condition: $STABLE = true
   - provider: script
     skip_cleanup: true
-    script: make helm-publish
+    script: make helm-package
     on:
       tags: true
       condition: $STABLE = true
-#  - provider: pages
-#    edge: false
-#    github_token: ${GITHUB_TOKEN}
-#    target_branch: docs
-#    local_dir: docs/site
-#    skip_cleanup: true
-#    on:
-#      tag: true
-#      repo: containous/maesh
+  - provider: pages
+    edge: false
+    github_token: ${GITHUB_TOKEN}
+    target_branch: gh-pages
+    local_dir: pages
+    skip_cleanup: true
+    on:
+      repo: containous/maesh
+      all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,23 +29,17 @@ script:
   - echo "Skipping tests... (Tests are executed on SemaphoreCI)"
   - make docs-package
 
-# install:
-  # - go mod tidy
-  # - git diff --exit-code go.mod
-  # - git diff --exit-code go.sum
-  # - go mod download
+install:
+  - go mod tidy
+  - git diff --exit-code go.mod
+  - git diff --exit-code go.sum
+  - go mod download
 
 before_deploy:
   # Install linters
-  - >
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION}
-    golangci-lint --version
-
-    if ! [ "$BEFORE_DEPLOY_RUN" ]; then
-      export BEFORE_DEPLOY_RUN=1;
-      echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-    fi
-
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION}
+  - golangci-lint --version
+  # - if ! [ "$BEFORE_DEPLOY_RUN" ]; then export BEFORE_DEPLOY_RUN=1; echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin; fi
 deploy:
   - provider: script
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ deploy:
     target_branch: gh-pages
     local_dir: pages
     skip_cleanup: true
+    keep_history: true
     on:
       repo: dduportal/maesh
       all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,5 +73,5 @@ deploy:
     local_dir: pages
     skip_cleanup: true
     on:
-      repo: containous/maesh
+      repo: dduportal/maesh
       all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_deploy:
   # Install linters
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION}
   - golangci-lint --version
-  # - if ! [ "$BEFORE_DEPLOY_RUN" ]; then export BEFORE_DEPLOY_RUN=1; echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin; fi
+  - if ! [ "$BEFORE_DEPLOY_RUN" ]; then export BEFORE_DEPLOY_RUN=1; echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin; fi
 deploy:
   - provider: script
     skip_cleanup: true
@@ -47,12 +47,12 @@ deploy:
     on:
       tags: true
       condition: $STABLE = true
-  # - provider: script
-  #   skip_cleanup: true
-  #   script: make build push-docker
-  #   on:
-  #     tags: true
-  #     condition: $STABLE = true
+  - provider: script
+    skip_cleanup: true
+    script: make build push-docker
+    on:
+      tags: true
+      condition: $STABLE = true
   - provider: script
     skip_cleanup: true
     script: make helm-package
@@ -67,5 +67,5 @@ deploy:
     skip_cleanup: true
     keep_history: true
     on:
-      repo: dduportal/maesh
+      repo: containous/maesh
       all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ script:
   - echo "Skipping tests... (Tests are executed on SemaphoreCI)"
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make -C ./docs docs; fi
 
-install:
-  - go mod tidy
-  - git diff --exit-code go.mod
-  - git diff --exit-code go.sum
-  - go mod download
+# install:
+  # - go mod tidy
+  # - git diff --exit-code go.mod
+  # - git diff --exit-code go.sum
+  # - go mod download
 
 before_deploy:
   # Install linters
@@ -54,12 +54,12 @@ deploy:
     on:
       tags: true
       condition: $STABLE = true
-  - provider: script
-    skip_cleanup: true
-    script: make build push-docker
-    on:
-      tags: true
-      condition: $STABLE = true
+  # - provider: script
+  #   skip_cleanup: true
+  #   script: make build push-docker
+  #   on:
+  #     tags: true
+  #     condition: $STABLE = true
   - provider: script
     skip_cleanup: true
     script: make helm-package

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,15 @@ helm-lint: helm
 
 pages:
 	mkdir -p $(CURDIR)/pages
+	rm -rf $(TMPDIR)/.pages \
+		&& git worktree add --checkout $(TMPDIR)/.pages gh-pages \
+		&& cd $(TMPDIR)/.pages \
+		&& git pull
+	cp -r $(TMPDIR)/.pages/charts $(CURDIR)/pages/
+
+docs-package: pages
+	make -C $(CURDIR)/docs
+	cp -r $(CURDIR)/docs/site/* $(CURDIR)/pages/
 
 helm-package: helm-lint pages
 	helm package --app-version $(TAG_NAME) $(CURDIR)/helm/chart/maesh
@@ -117,10 +126,6 @@ helm-package: helm-lint pages
 	mv *.tgz index.md $(CURDIR)/pages/charts/
 	helm repo index $(CURDIR)/pages/charts/
 
-docs-package: pages
-	make -C $(CURDIR)/docs
-	cp -r $(CURDIR)/docs/site/* $(CURDIR)/pages/
-
 .PHONY: local-check local-build local-test check build test push-docker \
-		vendor kubectl test-integration local-test-integration
+		vendor kubectl test-integration local-test-integration pages
 .PHONY: helm helm-lint helm-package

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ $(DIST_DIR):
 	mkdir -p $(DIST_DIR)
 
 clean:
-	rm -rf $(CURDIR)/dist/ cover.out $(CURDIR)/pages
+	rm -rf $(CURDIR)/dist/ cover.out $(CURDIR)/pages $(CURDIR)/gh-pages.zip $(CURDIR)/maesh-gh-pages
 
 # Static linting of source files. See .golangci.toml for options
 local-check: $(DIST_DIR) helm-lint
@@ -109,12 +109,12 @@ helm-lint: helm
 
 pages:
 	mkdir -p $(CURDIR)/pages
-	rm -rf $(TMPDIR)/.pages \
-		&& git fetch --all --prune \
-		&& git worktree add --checkout $(TMPDIR)/.pages gh-pages \
-		&& cd $(TMPDIR)/.pages \
-		&& git pull
-	cp -r $(TMPDIR)/.pages/charts $(CURDIR)/pages/
+	rm -rf $(CURDIR)/gh-pages.zip $(CURDIR)/maesh-gh-pages
+	curl -sSLO https://$(PROJECT)/archive/gh-pages.zip
+	unzip $(CURDIR)/gh-pages.zip
+	# We only keep the directory "charts" so documentation may remove files
+	cp -r $(CURDIR)/maesh-gh-pages/charts $(CURDIR)/pages/
+	rm -rf $(CURDIR)/gh-pages.zip $(CURDIR)/maesh-gh-pages
 
 docs-package: pages
 	make -C $(CURDIR)/docs

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DIST_DIR_MAESH = $(DIST_DIR)/$(BINARY_NAME)
 PROJECT ?= github.com/containous/$(BINARY_NAME)
 GOLANGCI_LINTER_VERSION = v1.17.1
 
-TAG_NAME := $(shell git tag -l --contains HEAD)
+TAG_NAME ?= $(shell git tag -l --contains HEAD)
 SHA := $(shell git rev-parse --short HEAD)
 VERSION := $(if $(TAG_NAME),$(TAG_NAME),$(SHA))
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%I:%M:%S%p')

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ helm-lint: helm
 pages:
 	mkdir -p $(CURDIR)/pages
 	rm -rf $(TMPDIR)/.pages \
+		&& git fetch --all --prune \
 		&& git worktree add --checkout $(TMPDIR)/.pages gh-pages \
 		&& cd $(TMPDIR)/.pages \
 		&& git pull

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ tidy:
 
 helm:
 	@command -v helm >/dev/null 2>&1 || curl https://raw.githubusercontent.com/helm/helm/v2.14.1/scripts/get | bash
+	@helm init --client-only
 
 helm-lint: helm
 	helm lint helm/chart/maesh


### PR DESCRIPTION
This PR introduces the following changes:

- Main Documentation is generated on branches and deployed to gh-pages
  - We'll be able to use `structor` for versionned documentation in the future
  - Helm charts are mixed with documentation
- New docs and helm packaging makefile goals

Motivation is that we want to keep Netlify only for pull requests, while centralizing the "production" hosting of both `docs.mae.sh` and the helm chart on a single github page website.