### PR TITLE
Update documentation tooling

### DIFF
--- a/docs/check.Dockerfile
+++ b/docs/check.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9 as alpine
+FROM alpine:3.10
 
 # The "build-dependencies" virtual package provides build tools for html-proofer installation.
 # It compile ruby-nokogiri, because alpine native version is always out of date

--- a/docs/check.Dockerfile
+++ b/docs/check.Dockerfile
@@ -18,7 +18,7 @@ RUN apk --no-cache --no-progress add \
     git \
     nodejs \
     npm \
-  && npm install markdownlint@0.12.0 markdownlint-cli@0.13.0 --global
+  && npm install markdownlint@0.16.0 markdownlint-cli@0.18.0 --global
 
 # Finally the shell tools we need for later
 # tini helps to terminate properly all the parallelized tasks when sending CTRL-C

--- a/docs/check.Dockerfile
+++ b/docs/check.Dockerfile
@@ -10,14 +10,8 @@ RUN apk --no-cache --no-progress add \
     ruby-etc \
     ruby-ffi \
     ruby-json \
-  && apk add --no-cache --virtual build-dependencies \
-    build-base \
-    libcurl \
-    libxml2-dev \
-    libxslt-dev \
-    ruby-dev \
-  && gem install --no-document html-proofer -v 3.10.2 \
-  && apk del build-dependencies
+    ruby-nokogiri
+RUN NOKOGIRI_USE_SYSTEM_LIBRARIES=true gem install --no-document html-proofer -v 3.12.0
 
 # After Ruby, some NodeJS YAY!
 RUN apk --no-cache --no-progress add \

--- a/docs/docs.Dockerfile
+++ b/docs/docs.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs==1.0.4
-pymdown-extensions==6.0
+pymdown-extensions==6.1
 mkdocs-bootswatch==1.0
-mkdocs-material==4.4.0
+mkdocs-material==4.4.2
 markdown-include==0.5.1


### PR DESCRIPTION
This PR introduces the following changes on the documentation tooling:

- Bump base image of Docker images for documentation  to Alpine `3.10`
- Bump `html-proofer` to latest stable `3.12.0`
- Faster documentation verification and linting: using native `nokogiri` in the alpine containers instead of building it, thanks to the Alpine Linux 3.10 bump.
- Bump `markdownlint` (and `markdownlint-cli`) versions to get latest changes from <https://github.com/markdownlint/markdownlint/blob/master/CHANGELOG.md#v040-2016-08-22>
- Bump `mkdocs` dependencies to their latest minor versions


Motivations:

- Faster documentation builds
- Chore on the dependencies