### PR TITLE
Add non-helm quickstart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ deploy:
       condition: $STABLE = true
   - provider: script
     skip_cleanup: true
-    script: make helm-package
+    script: make helm-package helm-manifest
     on:
       tags: true
       condition: $STABLE = true

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,11 @@ helm-package: helm-lint pages
 	mv *.tgz index.md $(CURDIR)/pages/charts/
 	helm repo index $(CURDIR)/pages/charts/
 
+helm-manifest: helm-package
+	mkdir -p $(CURDIR)/pages/manifests
+	helm template $(CURDIR)/pages/charts/maesh-$(TAG_NAME).tgz --name=maesh --namespace=maesh > $(CURDIR)/pages/manifests/maesh-$(TAG_NAME).yaml
+	cp $(CURDIR)/pages/manifests/maesh-$(TAG_NAME).yaml $(CURDIR)/pages/manifests/maesh.yaml
+
 .PHONY: local-check local-build local-test check build test publish-images \
 		vendor kubectl test-integration local-test-integration pages
 .PHONY: helm helm-lint helm-package

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -1,7 +1,18 @@
 # Quickstart
 
 Maesh can be installed in your cluster without affecting any running services.
-It will safely install itself via the helm chart, and will be ready for use immediately after.
+
+## Kubectl
+
+Mesh can installed using a single kubectl command line using the default configuration: 
+
+```shell
+kubectl create -f https://containous.github.io/maesh/manifests/maesh.yaml
+```
+
+## Helm
+
+Maesh will safely install itself via the helm chart, and will be ready for use immediately after.
 
 It can be installed by running:
 


### PR DESCRIPTION
While helm, of which I am very fan, is a great and flexible for deploying kubernetes applications, it also creates a barrier. This PR creates a yaml manifest that can be installed with a single commandline without prerequisites. I hope this will maesh more accessible for users, as discussed in #121.