### PR TITLE
Added nodeselector, tolerations and affinity to deployments and daemonsets

### DIFF
--- a/helm/chart/maesh/templates/controller/controller-deployment.yaml
+++ b/helm/chart/maesh/templates/controller/controller-deployment.yaml
@@ -46,6 +46,18 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.controller.image.pullSecret }}
       {{- end }}
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
         - name: maesh-controller
           image: {{ include "maesh.controllerImage" . | quote }}

--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -30,6 +30,10 @@ spec:
         runAsNonRoot: true
         runAsUser: 999
       terminationGracePeriodSeconds: 30
+      {{- with .Values.mesh.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       {{- if .Values.tracing.enabled }}
       initContainers:
         - name: wait-for-jaeger-init

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -18,6 +18,10 @@ controller:
   logging:
     debug: true
   ignoreNamespaces:
+  # Added so we can launch on nodes with restrictions
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 mesh:
   image:
@@ -37,6 +41,8 @@ mesh:
       cpu: "100m"
   logging: INFO
   defaultMode: http
+  # Added so we can launch on nodes with restrictions
+  tolerations: []
 
 #
 # addon jaeger tracing configuration


### PR DESCRIPTION
In our environment, we lock down deployments on the node using nodeSelector and certain tolerations. I added the sections so that we can configure and control on which nodes (like an operations set of nodes).