### PR TITLE
fix: maesh daemonset is not scraped by prometheus

### DIFF
--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -20,6 +20,9 @@ spec:
         app: {{ .Release.Name | quote }}
         component: maesh-mesh
         release: {{ .Release.Name | quote }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
     spec:
       serviceAccountName: maesh-mesh
       automountServiceAccountToken: false


### PR DESCRIPTION
The maesh daemonset is not being scraped by prometheus because of missing annotations. This PR adds the annotation to add the metrics to the prometheus instance.