### PR TITLE
Improve grafana and prometheus liveness and readiness probes

### DIFF
--- a/helm/chart/maesh/charts/metrics/Chart.yaml
+++ b/helm/chart/maesh/charts/metrics/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A metrics Helm chart for Kubernetes
 name: metrics
-version: 0.0.5
+version: 0.0.6
 appVersion: 0.0.1
 tillerVersion: ">=2.7.2"

--- a/helm/chart/maesh/charts/metrics/templates/grafana.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/grafana.yaml
@@ -40,10 +40,12 @@ spec:
             memory: 100Mi
         readinessProbe:
           httpGet:
-            path: /login
+            path: /api/health
             port: web
+          initialDelaySeconds: 5
         livenessProbe:
-          tcpSocket:
+          httpGet:
+            path: /api/health
             port: web
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/helm/chart/maesh/charts/metrics/templates/prometheus.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/prometheus.yaml
@@ -104,11 +104,12 @@ spec:
           containerPort: 9090
         readinessProbe:
           httpGet:
-            path: "/"
+            path: "/-/ready"
             port: webui
           initialDelaySeconds: 5
         livenessProbe:
-          tcpSocket:
+          httpGet:
+            path: "/-/healthy"
             port: webui
           initialDelaySeconds: 5
         resources:

--- a/helm/chart/maesh/charts/tracing/Chart.yaml
+++ b/helm/chart/maesh/charts/tracing/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Jaeger tracing Helm chart for Kubernetes
 name: tracing
-version: 0.0.2
+version: 0.0.3
 appVersion: 0.0.1
 tillerVersion: ">=2.7.2"

--- a/helm/chart/maesh/requirements.yaml
+++ b/helm/chart/maesh/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: tracing
-    version: 0.0.2
+    version: 0.0.3
     condition: tracing.deploy
   - name: metrics
-    version: 0.0.5
+    version: 0.0.6
     condition: metrics.deploy


### PR DESCRIPTION
Performing liveness/readiness probes on endpoints other than
health/ready can cause unexpected results, and depending on
the Kubernetes version further problems depending on the size of
the response.

In particular, starting from Kubernetes 1.16 the limit of these
responses have been restricted to 10KB [1]. Thus, on Kubernetes 1.16
and beyond, Grafana was never marked as ready with the default maesh
deployment.

[1] https://github.com/kubernetes/kubernetes/pull/76518