### PR TITLE
Add support for kubedns

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -33,5 +33,5 @@ Using the Maesh endpoints is all that is required.
 To run this app, you require the following:
 
 - Kubernetes 1.11+
-- CoreDNS installed as [Cluster DNS Provider](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/) (versions 1.3+ supported)
+- CoreDNS/KubeDNS installed as [Cluster DNS Provider](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/) (versions 1.3+ supported)
 - Helm v2 with a [working tiller service account](https://helm.sh/docs/using_helm/#installing-tiller)

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -31,6 +31,17 @@ To deploy the helm chart, run:
 helm install helm/chart/maesh --namespace maesh --set controller.image.pullPolicy=IfNotPresent --set controller.image.tag=latest
 ```
 
+## KubeDNS support
+
+Maesh can support KubeDNS
+
+```bash
+helm install --name=maesh --namespace=maesh maesh/maesh --set kubedns=true
+```
+
+With this parameter Maesh will install a CoreDNS as a daemonset.
+KubeDNS will be patched with [stubDomains](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#example-stub-domain)
+
 ## Installation namespace
 
 Maesh does not _need_ to be installed into the maesh namespace, 

--- a/helm/chart/maesh/templates/hooks/coredns.yaml
+++ b/helm/chart/maesh/templates/hooks/coredns.yaml
@@ -1,0 +1,242 @@
+{{- if .Values.kubedns }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ include "maesh.chartLabel" . | quote }}
+    release: {{ .Release.Name | quote}}
+    heritage: {{ .Release.Service | quote}}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    chart: {{ include "maesh.chartLabel" . | quote }}
+    release: {{ .Release.Name | quote}}
+    heritage: {{ .Release.Service | quote}}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+  name: coredns
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - services
+      - pods
+      - namespaces
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    chart: {{ include "maesh.chartLabel" . | quote }}
+    release: {{ .Release.Name | quote}}
+    heritage: {{ .Release.Service | quote}}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: coredns
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coredns
+subjects:
+  - kind: ServiceAccount
+    name: coredns
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ include "maesh.chartLabel" . | quote }}
+    release: {{ .Release.Name | quote}}
+    heritage: {{ .Release.Service | quote}}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "4"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+          pods insecure
+          upstream
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        forward . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+
+    maesh:53 {
+        errors
+        rewrite continue {
+            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh maesh-{1}-{2}.maesh.svc.cluster.local
+            answer name maesh-([a-zA-Z0-9-_]*)-([a-zA-Z0-9-_]*)\.maesh\.svc\.cluster\.local {1}.{2}.maesh
+        }
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+            pods insecure
+            upstream
+        	fallthrough in-addr.arpa ip6.arpa
+        }
+        forward . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: coredns
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: coredns
+    kubernetes.io/name: "CoreDNS"
+    chart: {{ include "maesh.chartLabel" . | quote }}
+    release: {{ .Release.Name | quote}}
+    heritage: {{ .Release.Service | quote}}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "4"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: coredns
+  template:
+    metadata:
+      labels:
+        k8s-app: coredns
+    spec:
+      serviceAccountName: coredns
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      containers:
+        - name: coredns
+          image: coredns/coredns:1.6.3
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              memory: 170Mi
+            requests:
+              cpu: 100m
+              memory: 70Mi
+          args: [ "-conf", "/etc/coredns/Corefile" ]
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/coredns
+              readOnly: true
+          ports:
+            - containerPort: 53
+              name: dns
+              protocol: UDP
+            - containerPort: 53
+              name: dns-tcp
+              protocol: TCP
+            - containerPort: 9153
+              name: metrics
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - NET_BIND_SERVICE
+              drop:
+                - all
+            readOnlyRootFilesystem: true
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+      dnsPolicy: Default
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+              - key: Corefile
+                path: Corefile
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: coredns
+    kubernetes.io/name: "CoreDNS"
+    kubernetes.io/cluster-service: "true"
+    chart: {{ include "maesh.chartLabel" . | quote }}
+    release: {{ .Release.Name | quote}}
+    heritage: {{ .Release.Service | quote}}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "4"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    prometheus.io/port: "9153"
+    prometheus.io/scrape: "true"
+spec:
+  selector:
+    k8s-app: coredns
+  type: ClusterIP
+  ports:
+    - name: dns
+      port: 53
+      protocol: UDP
+    - name: dns-tcp
+      port: 53
+      protocol: TCP
+    - name: metrics
+      port: 9153
+      protocol: TCP
+{{- end }}

--- a/helm/chart/maesh/templates/hooks/coredns.yaml
+++ b/helm/chart/maesh/templates/hooks/coredns.yaml
@@ -122,7 +122,7 @@ data:
 
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: coredns
   namespace: {{ .Release.Namespace }}
@@ -137,6 +137,7 @@ metadata:
     "helm.sh/hook-weight": "4"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -150,6 +151,18 @@ spec:
         k8s-app: coredns
     spec:
       serviceAccountName: coredns
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: k8s-app
+                      operator: In
+                      values:
+                        - corednss
+                topologyKey: "kubernetes.io/hostname"
       tolerations:
         - key: "CriticalAddonsOnly"
           operator: "Exists"

--- a/helm/chart/maesh/templates/hooks/prepare-hook.yaml
+++ b/helm/chart/maesh/templates/hooks/prepare-hook.yaml
@@ -13,6 +13,7 @@ metadata:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -45,12 +46,19 @@ rules:
       - update
       - create
   - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+  - apiGroups:
       - apps
     resources:
       - deployments
     verbs:
       - get
       - update
+      - create
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -111,6 +119,9 @@ spec:
           imagePullPolicy: {{ .Values.controller.image.pullPolicy | default "IfNotPresent"}}
           args:
             - "prepare"
+            {{- if .Values.controller.logging.debug }}
+            - "--debug"
+            {{- end }}
           securityContext:
             capabilities:
               drop:

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -23,6 +23,8 @@ controller:
   tolerations: []
   affinity: {}
 
+kubedns: false
+
 mesh:
   image:
     name: traefik:v2.0.0

--- a/integration/coredns_test.go
+++ b/integration/coredns_test.go
@@ -61,7 +61,7 @@ func (s *CoreDNSSuite) TestCoreDNSVersion(c *check.C) {
 
 		c.Log(test.desc)
 		s.setCoreDNSVersion(c, test.version)
-		err := s.installHelmMaesh(c, false)
+		err := s.installHelmMaesh(c, false, false)
 		if test.expectedError {
 			c.Assert(err, checker.NotNil)
 		} else {

--- a/integration/kubedns_test.go
+++ b/integration/kubedns_test.go
@@ -1,0 +1,44 @@
+package integration
+
+import (
+	"os"
+
+	"github.com/go-check/check"
+	checker "github.com/vdemeester/shakers"
+)
+
+// KubeDNSSuite
+type KubeDNSSuite struct{ BaseSuite }
+
+func (s *KubeDNSSuite) SetUpSuite(c *check.C) {
+	s.startk3s(c)
+	c.Assert(os.Setenv("KUBECONFIG", s.kubeConfigPath), checker.IsNil)
+	s.startAndWaitForKubeDNS(c)
+	s.startWhoami(c)
+	s.installTinyToolsMaesh(c)
+	s.installTiller(c)
+}
+
+func (s *KubeDNSSuite) TearDownSuite(c *check.C) {
+	s.stopK3s()
+}
+
+func (s *KubeDNSSuite) TestKubeDNS(c *check.C) {
+	pod := s.getToolsPodMaesh(c)
+	c.Assert(pod, checker.NotNil)
+
+	argSlice := []string{
+		"exec", "-it", pod.Name, "-n", pod.Namespace, "-c", pod.Spec.Containers[0].Name, "--", "curl", "whoami.whoami.svc.cluster.local", "--max-time", "5",
+	}
+
+	err := s.installHelmMaesh(c, false, true)
+	c.Assert(err, checker.IsNil)
+	s.waitForMaeshControllerStarted(c)
+	s.waitKubectlExecCommand(c, argSlice, "whoami")
+
+	argSlice = []string{
+		"exec", "-it", pod.Name, "-n", pod.Namespace, "-c", pod.Spec.Containers[0].Name, "--", "curl", "whoami.whoami.maesh", "--max-time", "5",
+	}
+	s.waitKubectlExecCommand(c, argSlice, "whoami")
+	s.unInstallHelmMaesh(c)
+}

--- a/integration/kubernetes_test.go
+++ b/integration/kubernetes_test.go
@@ -16,7 +16,7 @@ func (s *KubernetesSuite) SetUpSuite(c *check.C) {
 	s.startAndWaitForCoreDNS(c)
 	s.installTiller(c)
 
-	err := s.installHelmMaesh(c, false)
+	err := s.installHelmMaesh(c, false, false)
 	c.Assert(err, checker.IsNil)
 	s.waitForMaeshControllerStarted(c)
 	s.startWhoami(c)

--- a/integration/resources/kubedns/kubedns.yaml
+++ b/integration/resources/kubedns/kubedns.yaml
@@ -1,0 +1,206 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "KubeDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  clusterIP: 10.43.0.10
+  ports:
+    - name: dns
+      port: 53
+      protocol: UDP
+    - name: dns-tcp
+      port: 53
+      protocol: TCP
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  # replicas: not specified here:
+  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+  # 2. Default is 1.
+  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  strategy:
+    rollingUpdate:
+      maxSurge: 10%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      volumes:
+        - name: kube-dns-config
+          configMap:
+            name: kube-dns
+            optional: true
+      containers:
+        - name: kubedns
+          image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
+          resources:
+            # TODO: Set memory limits when we've profiled the container for large
+            # clusters, then set request = limit to keep this container in
+            # guaranteed class. Currently, this container falls into the
+            # "burstable" category so the kubelet doesn't backoff from restarting it.
+            limits:
+              memory: 170Mi
+            requests:
+              cpu: 100m
+              memory: 70Mi
+          livenessProbe:
+            httpGet:
+              path: /healthcheck/kubedns
+              port: 10054
+              scheme: HTTP
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 8081
+              scheme: HTTP
+            # we poll on pod startup for the Kubernetes master service and
+            # only setup the /readiness HTTP server once that's available.
+            initialDelaySeconds: 3
+            timeoutSeconds: 5
+          args:
+            - --domain=cluster.local.
+            - --dns-port=10053
+            - --config-dir=/kube-dns-config
+            - --v=2
+          env:
+            - name: PROMETHEUS_PORT
+              value: "10055"
+          ports:
+            - containerPort: 10053
+              name: dns-local
+              protocol: UDP
+            - containerPort: 10053
+              name: dns-tcp-local
+              protocol: TCP
+            - containerPort: 10055
+              name: metrics
+              protocol: TCP
+          volumeMounts:
+            - name: kube-dns-config
+              mountPath: /kube-dns-config
+        - name: dnsmasq
+          image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7
+          livenessProbe:
+            httpGet:
+              path: /healthcheck/dnsmasq
+              port: 10054
+              scheme: HTTP
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+          args:
+            - -v=2
+            - -logtostderr
+            - -configDir=/etc/k8s/dns/dnsmasq-nanny
+            - -restartDnsmasq=true
+            - --
+            - -k
+            - --cache-size=1000
+            - --no-negcache
+            - --log-facility=-
+            - --server=/cluster.local/127.0.0.1#10053
+            - --server=/in-addr.arpa/127.0.0.1#10053
+            - --server=/ip6.arpa/127.0.0.1#10053
+          ports:
+            - containerPort: 53
+              name: dns
+              protocol: UDP
+            - containerPort: 53
+              name: dns-tcp
+              protocol: TCP
+          # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
+          resources:
+            requests:
+              cpu: 150m
+              memory: 20Mi
+          volumeMounts:
+            - name: kube-dns-config
+              mountPath: /etc/k8s/dns/dnsmasq-nanny
+        - name: sidecar
+          image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 10054
+              scheme: HTTP
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+          args:
+            - --v=2
+            - --logtostderr
+            - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,SRV
+            - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,SRV
+          ports:
+            - containerPort: 10054
+              name: metrics
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+      dnsPolicy: Default  # Don't use cluster DNS.
+      serviceAccountName: kube-dns

--- a/integration/resources/values.yaml
+++ b/integration/resources/values.yaml
@@ -57,6 +57,7 @@ metrics:
     enabled: false
 
 smi: false
+kubedns: false
 
 limits:
   http: 10

--- a/integration/smi_test.go
+++ b/integration/smi_test.go
@@ -59,7 +59,7 @@ func (s *SMISuite) TestSMIAccessControl(c *check.C) {
 
 	time.Sleep(10 * time.Second)
 
-	err := s.installHelmMaesh(c, true)
+	err := s.installHelmMaesh(c, true, false)
 	c.Assert(err, checker.IsNil)
 	s.waitForMaeshControllerStarted(c)
 
@@ -217,7 +217,7 @@ func (s *SMISuite) TestSMITrafficSplit(c *check.C) {
 
 	time.Sleep(10 * time.Second)
 
-	err := s.installHelmMaesh(c, true)
+	err := s.installHelmMaesh(c, true, false)
 	c.Assert(err, checker.IsNil)
 	s.waitForMaeshControllerStarted(c)
 

--- a/internal/k8s/client_mock.go
+++ b/internal/k8s/client_mock.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+
 	"path/filepath"
 	"regexp"
 	"strings"


### PR DESCRIPTION
### Description

This PR adds support for kubedns.

If KubeDNS is detected in the kubernetes cluster and coredns is not installed. Maesh will install CoreDNS as a DaemonSet and will patch KubeDNS to add a stubDomains that forward all dns request with prefix `.maesh` to the coreDNS instances.

