### PR TITLE
Move to stateless Kubernetes Provider

### DIFF
--- a/integration/smi_test.go
+++ b/integration/smi_test.go
@@ -426,7 +426,7 @@ func (s *SMISuite) createResources(c *check.C, dirPath string) {
 }
 
 func (s *SMISuite) deleteResources(c *check.C, dirPath string, force bool) {
-	// Create the required objects from the smi directory
+	// Delete the required objects from the smi directory
 	args := []string{"delete", "-f", path.Join(s.dir, dirPath)}
 	if force {
 		args = append(args, "--force", "--grace-period=0")

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -379,8 +379,7 @@ func (c *Controller) createMeshServices() error {
 			}
 		}
 		log.Infof("Creating associated mesh service: %s", meshServiceName)
-		err := c.createMeshService(service)
-		if err != nil {
+		if err := c.createMeshService(service); err != nil {
 			return fmt.Errorf("unable to get create mesh service: %v", err)
 		}
 	}
@@ -417,6 +416,7 @@ func (c *Controller) createMeshService(service *corev1.Service) error {
 
 			if targetPort.IntVal == 0 {
 				log.Errorf("Could not get TCP Port for service: %s with service port: %v", service.Name, sp)
+				continue
 			}
 
 			meshPort := corev1.ServicePort{

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -200,22 +200,15 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 
 // runWorker executes the loop to process new items added to the queue
 func (c *Controller) runWorker() {
-	log.Debug("MeshController.runWorker: starting")
-
 	// invoke processNextMessage to fetch and consume the next
 	// message put in the queue
 	for c.processNextMessage() {
-		log.Debugf("MeshController.runWorker: processing next item")
 	}
-
-	log.Debugf("MeshController.runWorker: completed")
 }
 
 // processNextConfiguration retrieves each queued item and takes the
 // necessary handler action.
 func (c *Controller) processNextMessage() bool {
-	log.Debugf("MeshController Waiting for next item to process...")
-
 	// fetch the next item (blocking) from the queue to process or
 	// if a shutdown is requested then return out of this to stop
 	// processing
@@ -268,7 +261,6 @@ func (c *Controller) processCreatedMessage(event message.Message) {
 		}
 
 	case *corev1.Endpoints:
-		log.Debugf("MeshController ObjectCreated with type: *corev1.Endpoints: %s/%s, skipping...", obj.Namespace, obj.Name)
 		return
 
 	case *corev1.Pod:
@@ -358,7 +350,6 @@ func (c *Controller) processDeletedMessage(event message.Message) {
 		log.Debugf("MeshController ObjectDeleted with type: *corev1.Endpoints: %s/%s", obj.Namespace, obj.Name)
 
 	case *corev1.Pod:
-		log.Debugf("MeshController ObjectDeleted with type: *corev1.Pod: %s/%s, skipping...", obj.Namespace, obj.Name)
 		return
 	}
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -247,7 +247,11 @@ func (c *Controller) buildConfigurationFromProviders(event message.Message) {
 		c.smiProvider.BuildConfiguration(event, c.traefikConfig)
 		return
 	}
-	c.kubernetesProvider.BuildConfiguration(event, c.traefikConfig)
+	config, err := c.kubernetesProvider.BuildConfig()
+	if err != nil {
+		log.Errorf("unable to build configuration: %v", err)
+	}
+	c.traefikConfig = config
 }
 
 func (c *Controller) processCreatedMessage(event message.Message) {

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -65,6 +65,7 @@ type CoreV1Client interface {
 	DeleteService(namespace, name string) error
 
 	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
+	GetEndpointses(namespace string) ([]*corev1.Endpoints, error)
 
 	GetPod(namespace, name string) (*corev1.Pod, bool, error)
 	ListPodWithOptions(namespace string, options metav1.ListOptions) (*corev1.PodList, error)
@@ -583,6 +584,19 @@ func (w *ClientWrapper) GetEndpoints(namespace, name string) (*corev1.Endpoints,
 	endpoints, err := w.KubeClient.CoreV1().Endpoints(namespace).Get(name, metav1.GetOptions{})
 	exists, err := translateNotFoundError(err)
 	return endpoints, exists, err
+}
+
+// GetEndpointses retrieves the endpoints from all namespaces.
+func (w *ClientWrapper) GetEndpointses(namespace string) ([]*corev1.Endpoints, error) {
+	var result []*corev1.Endpoints
+	list, err := w.KubeClient.CoreV1().Endpoints(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return result, err
+	}
+	for _, endpoints := range list.Items {
+		result = append(result, &endpoints)
+	}
+	return result, nil
 }
 
 // GetPod retrieves the pod from the specified namespace.

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -587,7 +587,7 @@ func (w *ClientWrapper) GetEndpoints(namespace, name string) (*corev1.Endpoints,
 	return endpoints, exists, err
 }
 
-// GetEndpointses retrieves the endpoints from all namespaces.
+// GetEndpointses retrieves the endpoints from the specified namespace.
 func (w *ClientWrapper) GetEndpointses(namespace string) ([]*corev1.Endpoints, error) {
 	var result []*corev1.Endpoints
 	list, err := w.KubeClient.CoreV1().Endpoints(namespace).List(metav1.ListOptions{})

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -549,7 +549,8 @@ func (w *ClientWrapper) GetServices(namespace string) ([]*corev1.Service, error)
 		return result, err
 	}
 	for _, service := range list.Items {
-		result = append(result, &service)
+		item := service
+		result = append(result, &item)
 	}
 	return result, nil
 }
@@ -594,7 +595,8 @@ func (w *ClientWrapper) GetEndpointses(namespace string) ([]*corev1.Endpoints, e
 		return result, err
 	}
 	for _, endpoints := range list.Items {
-		result = append(result, &endpoints)
+		item := endpoints
+		result = append(result, &item)
 	}
 	return result, nil
 }
@@ -626,7 +628,8 @@ func (w *ClientWrapper) GetNamespaces() ([]*corev1.Namespace, error) {
 		return result, err
 	}
 	for _, namespace := range list.Items {
-		result = append(result, &namespace)
+		item := namespace
+		result = append(result, &item)
 	}
 	return result, nil
 }

--- a/internal/k8s/client_mock.go
+++ b/internal/k8s/client_mock.go
@@ -265,6 +265,15 @@ func (c *CoreV1ClientMock) GetEndpoints(namespace, name string) (*corev1.Endpoin
 	return nil, false, c.apiEndpointsError
 }
 
+// GetEndpointses returns mocked date for endpoints.
+func (c *CoreV1ClientMock) GetEndpointses(namespace string) ([]*corev1.Endpoints, error) {
+	if c.apiEndpointsError != nil {
+		return nil, c.apiEndpointsError
+	}
+
+	return c.endpoints, nil
+}
+
 // GetPod returns mocked data for pod.
 func (c *CoreV1ClientMock) GetPod(namespace, name string) (*corev1.Pod, bool, error) {
 	if c.apiPodError != nil {

--- a/internal/providers/kubernetes/fixtures/build_configuration_simple_http_middlewares.yaml
+++ b/internal/providers/kubernetes/fixtures/build_configuration_simple_http_middlewares.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+  namespace: foo
+  annotations:
+    maesh.containo.us/retry-attempts: "2"
+spec:
+  clusterIP: 10.1.0.1
+  selector:
+    app: test
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: test
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.0.0.1
+  ports:
+  - port: 80
+- addresses:
+  - ip: 10.0.0.2
+  ports:
+  - port: 80
+

--- a/internal/providers/kubernetes/fixtures/build_configuration_simple_tcp.yaml
+++ b/internal/providers/kubernetes/fixtures/build_configuration_simple_tcp.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+  namespace: foo
+  annotations:
+    maesh.containo.us/traffic-type: tcp
+spec:
+  clusterIP: 10.1.0.1
+  selector:
+    app: test
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: test
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.0.0.1
+  ports:
+  - port: 80
+- addresses:
+  - ip: 10.0.0.2
+  ports:
+  - port: 80
+


### PR DESCRIPTION
This PR:

- modifies the Kubernetes provider to be stateless.
- reduces the number of kubernetes api calls by selecting objects first, then looping through them in-memory
- moves base config building to the provider, from the controller.

Partially solves #242. 