### PR TITLE
Update golangci-lint to 1.20.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /go/src/github.com/containous/maesh
 RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
 
 # Download golangci-lint binary to bin folder in $GOPATH
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.18.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.20.0
 
 ENV GO111MODULE on
 COPY go.mod go.sum ./

--- a/cmd/maesh/maesh.go
+++ b/cmd/maesh/maesh.go
@@ -51,6 +51,7 @@ func main() {
 func maeshCommand(iConfig *cmd.MaeshConfiguration) error {
 	log.SetOutput(os.Stdout)
 	log.SetLevel(log.InfoLevel)
+
 	if iConfig.Debug {
 		log.SetLevel(log.DebugLevel)
 	}
@@ -77,5 +78,6 @@ func maeshCommand(iConfig *cmd.MaeshConfiguration) error {
 	if err = ctr.Run(stopCh); err != nil {
 		log.Fatalf("Error running ctr: %v", err)
 	}
+
 	return nil
 }

--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -26,6 +26,7 @@ func NewCmd(pConfig *cmd.PrepareConfig, loaders []cli.ResourceLoader) *cli.Comma
 func patchCommand(pConfig *cmd.PrepareConfig) error {
 	log.SetOutput(os.Stdout)
 	log.SetLevel(log.InfoLevel)
+
 	if pConfig.Debug {
 		log.SetLevel(log.DebugLevel)
 	}

--- a/integration/coredns_test.go
+++ b/integration/coredns_test.go
@@ -62,6 +62,7 @@ func (s *CoreDNSSuite) TestCoreDNSVersion(c *check.C) {
 		c.Log(test.desc)
 		s.setCoreDNSVersion(c, test.version)
 		err := s.installHelmMaesh(c, false, false)
+
 		if test.expectedError {
 			err = s.waitForMaeshControllerStartedWithReturn()
 			c.Assert(err, checker.NotNil)
@@ -70,6 +71,7 @@ func (s *CoreDNSSuite) TestCoreDNSVersion(c *check.C) {
 			s.waitForMaeshControllerStarted(c)
 			s.waitKubectlExecCommand(c, argSlice, "whoami")
 		}
+
 		s.unInstallHelmMaesh(c)
 	}
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -60,6 +60,7 @@ func Test(t *testing.T) {
 
 			output, err := cmd.CombinedOutput()
 			fmt.Println(string(output))
+
 			if err != nil {
 				fmt.Printf("unable to pull docker image: %v", err)
 			}
@@ -104,6 +105,7 @@ func (s *BaseSuite) startk3s(c *check.C) {
 
 	// Load images into k3s
 	c.Log("Importing docker images in to k3s...")
+
 	err = s.loadK3sImages()
 	c.Assert(err, checker.IsNil)
 
@@ -120,6 +122,7 @@ func (s *BaseSuite) startk3s(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	s.try = try.NewTry(s.client)
+
 	c.Log("k3s start successfully.")
 }
 
@@ -130,6 +133,7 @@ func (s *BaseSuite) loadK3sImages() error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -281,7 +285,6 @@ func (s *BaseSuite) unInstallHelmMaesh(c *check.C) {
 
 func (s *BaseSuite) setCoreDNSVersion(c *check.C, version string) {
 	// Get current coreDNS deployment.
-
 	deployment, exists, err := s.client.GetDeployment(metav1.NamespaceSystem, "coredns")
 	c.Assert(err, checker.IsNil)
 	c.Assert(exists, checker.True)

--- a/integration/smi_test.go
+++ b/integration/smi_test.go
@@ -53,7 +53,6 @@ func (s *SMISuite) TestSMIAccessControl(c *check.C) {
 	// Pod B -> Service E.maesh /test returns 404
 	// Pod C -> Service E.maesh /test returns 404
 	// Pod D -> Service E.maesh /test returns 404
-
 	s.createResources(c, "resources/smi")
 	s.createResources(c, "resources/smi/access-control/")
 
@@ -202,6 +201,7 @@ func (s *SMISuite) TestSMIAccessControl(c *check.C) {
 		argSlice := []string{
 			"exec", "-it", test.source, "--", "curl", "-v", test.destination + test.path, "--max-time", "5",
 		}
+
 		c.Log(test.desc)
 		s.waitKubectlExecCommand(c, argSlice, fmt.Sprintf("HTTP/1.1 %d", test.expected))
 	}
@@ -363,9 +363,11 @@ func (s *SMISuite) TestSMITrafficSplit(c *check.C) {
 
 			time.Sleep(10 * time.Second)
 		}
+
 		argSlice := []string{
 			"exec", "-it", test.source, "--", "curl", "-v", test.destination, "--max-time", "5",
 		}
+
 		c.Log(test.desc)
 
 		err := s.try.WaitFunction(func() error {
@@ -430,6 +432,7 @@ func (s *SMISuite) deleteResources(c *check.C, dirPath string, force bool) {
 	if force {
 		args = append(args, "--force", "--grace-period=0")
 	}
+
 	cmd := exec.Command("kubectl", args...)
 	cmd.Env = os.Environ()
 	_, err := cmd.CombinedOutput()

--- a/integration/try/try.go
+++ b/integration/try/try.go
@@ -102,6 +102,7 @@ func (t *Try) WaitCommandExecute(command string, argSlice []string, expected str
 	ebo.MaxElapsedTime = applyCIMultiplier(timeout)
 
 	var output []byte
+
 	if err := backoff.Retry(safe.OperationWithRecover(func() error {
 		cmd := exec.Command(command, argSlice...)
 		cmd.Env = os.Environ()
@@ -129,6 +130,7 @@ func (t *Try) WaitCommandExecuteReturn(command string, argSlice []string, timeou
 	ebo.MaxElapsedTime = applyCIMultiplier(timeout)
 
 	var output []byte
+
 	if err := backoff.Retry(safe.OperationWithRecover(func() error {
 		cmd := exec.Command(command, argSlice...)
 		cmd.Env = os.Environ()
@@ -185,8 +187,11 @@ func (t *Try) WaitClientCreated(url string, kubeConfigPath string, timeout time.
 	ebo := backoff.NewExponentialBackOff()
 	ebo.MaxElapsedTime = applyCIMultiplier(timeout)
 
-	var clients *k8s.ClientWrapper
-	var err error
+	var (
+		clients *k8s.ClientWrapper
+		err     error
+	)
+
 	if err = backoff.Retry(safe.OperationWithRecover(func() error {
 		clients, err = k8s.NewClientWrapper(url, kubeConfigPath)
 		if err != nil {
@@ -212,6 +217,7 @@ func applyCIMultiplier(timeout time.Duration) time.Duration {
 
 	ciTimeoutMultiplier := getCITimeoutMultiplier()
 	log.Debug("Apply CI multiplier:", ciTimeoutMultiplier)
+
 	return time.Duration(float64(timeout) * ciTimeoutMultiplier)
 }
 

--- a/internal/k8s/client_mock.go
+++ b/internal/k8s/client_mock.go
@@ -30,14 +30,17 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
 	err = specsv1alpha1.AddToScheme(scheme.Scheme)
 	if err != nil {
 		panic(err)
 	}
+
 	err = splitv1alpha1.AddToScheme(scheme.Scheme)
 	if err != nil {
 		panic(err)
 	}
+
 	err = v1alpha1.AddToScheme(scheme.Scheme)
 	if err != nil {
 		panic(err)
@@ -189,6 +192,7 @@ func NewClientMock(paths ...string) *ClientMock {
 			}
 		}
 	}
+
 	return c
 }
 
@@ -209,6 +213,7 @@ func (c *CoreV1ClientMock) GetService(namespace, name string) (*corev1.Service, 
 			return service, true, nil
 		}
 	}
+
 	return nil, false, c.apiServiceError
 }
 
@@ -261,6 +266,7 @@ func (c *CoreV1ClientMock) GetEndpoints(namespace, name string) (*corev1.Endpoin
 			return endpoint, true, nil
 		}
 	}
+
 	return nil, false, c.apiEndpointsError
 }
 
@@ -284,6 +290,7 @@ func (c *CoreV1ClientMock) GetPod(namespace, name string) (*corev1.Pod, bool, er
 			return pod, true, nil
 		}
 	}
+
 	return nil, false, c.apiPodError
 }
 
@@ -302,6 +309,7 @@ func (c *CoreV1ClientMock) ListPodWithOptions(namespace string, options metav1.L
 	result := &corev1.PodList{
 		Items: items,
 	}
+
 	return result, nil
 }
 
@@ -316,6 +324,7 @@ func (c *CoreV1ClientMock) GetNamespace(name string) (*corev1.Namespace, bool, e
 			return ns, true, nil
 		}
 	}
+
 	return nil, false, c.apiNamespaceError
 }
 
@@ -324,6 +333,7 @@ func (c *CoreV1ClientMock) GetNamespaces() ([]*corev1.Namespace, error) {
 	if c.apiNamespaceError != nil {
 		return nil, c.apiNamespaceError
 	}
+
 	return c.namespaces, nil
 }
 
@@ -338,6 +348,7 @@ func (c *CoreV1ClientMock) GetConfigMap(namespace, name string) (*corev1.ConfigM
 			return configmap, true, nil
 		}
 	}
+
 	return nil, false, c.apiConfigMapError
 }
 
@@ -382,6 +393,7 @@ func (a *AppsV1ClientMock) GetDeployment(namespace, name string) (*appsv1.Deploy
 			return deployment, true, nil
 		}
 	}
+
 	return nil, false, a.apiDeploymentError
 }
 
@@ -444,6 +456,7 @@ func MustParseYaml(content []byte) []runtime.Object {
 
 	files := strings.Split(string(content), "---")
 	retVal := make([]runtime.Object, 0, len(files))
+
 	for _, file := range files {
 		if file == "\n" || file == "" {
 			continue
@@ -451,6 +464,7 @@ func MustParseYaml(content []byte) []runtime.Object {
 
 		decode := scheme.Codecs.UniversalDeserializer().Decode
 		obj, groupVersionKind, err := decode([]byte(file), nil, nil)
+
 		if err != nil {
 			panic(fmt.Sprintf("Error while decoding YAML object. Err was: %s", err))
 		}
@@ -461,5 +475,6 @@ func MustParseYaml(content []byte) []runtime.Object {
 			retVal = append(retVal, obj)
 		}
 	}
+
 	return retVal
 }

--- a/internal/k8s/namespace.go
+++ b/internal/k8s/namespace.go
@@ -14,6 +14,7 @@ func (n Namespaces) Contains(x string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/internal/k8s/service.go
+++ b/internal/k8s/service.go
@@ -28,5 +28,6 @@ func (s Services) Contains(name, namespace string) bool {
 			return true
 		}
 	}
+
 	return false
 }

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -44,6 +44,7 @@ func (d *Deploy) GetVersion() (time.Time, error) {
 			return time.Unix(0, nano), err
 		}
 	}
+
 	return time.Now(), errors.New("could not parse version from Deploy")
 }
 
@@ -65,6 +66,7 @@ func BuildNewConfigWithVersion(conf *dynamic.Configuration) Config {
 			},
 		},
 	}
+
 	return Config{
 		Config: c,
 	}
@@ -78,5 +80,6 @@ func (c *Config) GetVersion() (time.Time, error) {
 			return time.Unix(0, nano), err
 		}
 	}
+
 	return time.Now(), errors.New("could not parse version from Config")
 }

--- a/internal/providers/smi/provider_test.go
+++ b/internal/providers/smi/provider_test.go
@@ -134,6 +134,7 @@ func TestGetTrafficTargetsWithDestinationInNamespace(t *testing.T) {
 	}
 	allTrafficTargets, err := clientMock.GetTrafficTargets()
 	assert.NoError(t, err)
+
 	actual := provider.getTrafficTargetsWithDestinationInNamespace("foo", allTrafficTargets)
 	assert.Equal(t, expected, actual)
 }

--- a/internal/signals/signal.go
+++ b/internal/signals/signal.go
@@ -32,6 +32,7 @@ func SetupSignalHandler() (stopCh <-chan struct{}) {
 	stop := make(chan struct{})
 	c := make(chan os.Signal, 2)
 	signal.Notify(c, shutdownSignals...)
+
 	go func() {
 		<-c
 		close(stop)


### PR DESCRIPTION
This PR updates golangci-lint to 1.20.0

`wsl` is enabled.

Deal with it.