### PR TITLE
Remove deprecated extensions/v1beta1 API group

### DIFF
--- a/helm/chart/maesh/charts/metrics/templates/grafana.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/grafana.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana-core

--- a/helm/chart/maesh/charts/metrics/templates/prometheus.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/prometheus.yaml
@@ -65,7 +65,7 @@ data:
               names:
                 - {{ .Release.Namespace }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-core

--- a/helm/chart/maesh/charts/tracing/templates/jaeger-deployment.yaml
+++ b/helm/chart/maesh/charts/tracing/templates/jaeger-deployment.yaml
@@ -13,7 +13,7 @@
 #
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jaeger

--- a/integration/resources/coredns/coredns.yaml
+++ b/integration/resources/coredns/coredns.yaml
@@ -73,7 +73,7 @@ data:
     }
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coredns

--- a/integration/resources/tools/deployment.yaml
+++ b/integration/resources/tools/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tiny-tools

--- a/integration/resources/whoami/whoami.yaml
+++ b/integration/resources/whoami/whoami.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: whoami
   namespace: whoami


### PR DESCRIPTION
This PR:

Removes the deprecated extensions/v1beta1 API group.

From: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

This allows installation in k8s 1.16.

Fixes #277 