### PR TITLE
Remove unused example variable

### DIFF
--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -31,8 +31,6 @@ mesh:
     # (Optional)
     # pullPolicy: IfNotPresent
     # (Optional)
-    # tag: v0.0.1
-    # (Optional)
     # pullSecret: xxx
   resources:
     limit:


### PR DESCRIPTION
Tag is not used in `mesh-daemonset.yaml`.