### PR TITLE
Fix panic when deeting a ns

### DIFF
--- a/internal/providers/kubernetes/provider.go
+++ b/internal/providers/kubernetes/provider.go
@@ -72,7 +72,7 @@ func (p *Provider) buildTCPRouter(port int, serviceName string) *dynamic.TCPRout
 func (p *Provider) buildService(endpoints *corev1.Endpoints, scheme string) *dynamic.Service {
 	var servers []dynamic.Server
 
-	if endpoints.Subsets != nil {
+	if endpoints != nil && endpoints.Subsets != nil {
 		for _, subset := range endpoints.Subsets {
 			for _, endpointPort := range subset.Ports {
 				for _, address := range subset.Addresses {


### PR DESCRIPTION
### Description

This PR fix a panic

```console
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x120 pc=0x106563a]

goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190817020851-f2f3a405f61d/pkg/util/runtime/runtime.go:58 +0x105
panic(0x126c1a0, 0x1ecb5d0)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/containous/maesh/internal/providers/kubernetes.(*Provider).buildService(0xc000354300, 0x0, 0xc000836678, 0x3, 0xc000764600)
	/go/src/github.com/containous/maesh/internal/providers/kubernetes/provider.go:75 +0x3a
github.com/containous/maesh/internal/providers/kubernetes.(*Provider).BuildConfig(0xc000354300, 0xc0001b1b88, 0x2, 0x1)
	/go/src/github.com/containous/maesh/internal/providers/kubernetes/provider.go:150 +0xb1d
github.com/containous/maesh/internal/controller.(*Controller).Run(0xc0003b0000, 0xc00052a780, 0x0, 0x0)
	/go/src/github.com/containous/maesh/internal/controller/controller.go:156 +0x34c
main.maeshCommand(0xc000255e30, 0x40bda6, 0xc000266360)
	/go/src/github.com/containous/maesh/cmd/maesh/maesh.go:78 +0x3f9
main.main.func1(0xc00003a060, 0x4, 0x4, 0x4, 0xc000255ea0)
	/go/src/github.com/containous/maesh/cmd/maesh/maesh.go:28 +0x2a
github.com/containous/traefik/v2/pkg/cli.run(0xc000255ea0, 0xc00003a060, 0x4, 0x4, 0x7, 0xc000266300)
	/go/pkg/mod/github.com/containous/traefik/v2@v2.0.2/pkg/cli/commands.go:117 +0x171
github.com/containous/traefik/v2/pkg/cli.execute(0xc000255ea0, 0xc00003a050, 0x5, 0x5, 0xc000255f01, 0x1e74920, 0xc00005c750)
	/go/pkg/mod/github.com/containous/traefik/v2@v2.0.2/pkg/cli/commands.go:56 +0x5a2
github.com/containous/traefik/v2/pkg/cli.Execute(...)
	/go/pkg/mod/github.com/containous/traefik/v2@v2.0.2/pkg/cli/commands.go:40
main.main()
	/go/src/github.com/containous/maesh/cmd/maesh/maesh.go:43 +0x3e1
```