### PR TITLE
Deploy configuration to mesh pods even if config hasn't changed

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -142,7 +142,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 				return err
 			}
 
-			if message == "force" || !reflect.DeepEqual(c.lastConfiguration.Get(), conf) {
+			if message == k8s.ConfigMessageChanForce || !reflect.DeepEqual(c.lastConfiguration.Get(), conf) {
 				c.lastConfiguration.Set(conf)
 
 				if deployErr := c.deployConfiguration(conf); deployErr != nil {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -32,7 +32,6 @@ import (
 type Controller struct {
 	clients           *k8s.ClientWrapper
 	kubernetesFactory informers.SharedInformerFactory
-	meshFactory       informers.SharedInformerFactory
 	smiAccessFactory  smiAccessExternalversions.SharedInformerFactory
 	smiSpecsFactory   smiSpecsExternalversions.SharedInformerFactory
 	smiSplitFactory   smiSplitExternalversions.SharedInformerFactory

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -37,8 +37,7 @@ type Controller struct {
 	smiSpecsFactory   smiSpecsExternalversions.SharedInformerFactory
 	smiSplitFactory   smiSplitExternalversions.SharedInformerFactory
 	handler           *Handler
-	meshHandler       *Handler
-	configRefreshChan chan bool
+	configRefreshChan chan string
 	provider          base.Provider
 	ignored           k8s.IgnoreWrapper
 	smiEnabled        bool
@@ -52,18 +51,13 @@ type Controller struct {
 // and return an initialized mesh controller object.
 func NewMeshController(clients *k8s.ClientWrapper, smiEnabled bool, defaultMode string, meshNamespace string, ignoreNamespaces []string) *Controller {
 	ignored := k8s.NewIgnored(meshNamespace, ignoreNamespaces)
-
 	// configRefreshChan is used to trigger configuration refreshes and deploys.
-	configRefreshChan := make(chan bool)
-
+	configRefreshChan := make(chan string)
 	handler := NewHandler(ignored, configRefreshChan)
-	// Create a new mesh handler to handle mesh events (pods)
-	meshHandler := NewHandler(ignored.WithoutMesh(), configRefreshChan)
 
 	c := &Controller{
 		clients:           clients,
 		handler:           handler,
-		meshHandler:       meshHandler,
 		configRefreshChan: configRefreshChan,
 		ignored:           ignored,
 		smiEnabled:        smiEnabled,
@@ -82,22 +76,12 @@ func NewMeshController(clients *k8s.ClientWrapper, smiEnabled bool, defaultMode 
 func (c *Controller) Init() error {
 	// Register handler funcs to controller funcs.
 	c.handler.RegisterMeshHandlers(c.createMeshService, c.updateMeshService, c.deleteMeshService)
-	c.meshHandler.RegisterMeshHandlers(c.createMeshService, c.updateMeshService, c.deleteMeshService)
 
 	// Create a new SharedInformerFactory, and register the event handler to informers.
 	c.kubernetesFactory = informers.NewSharedInformerFactoryWithOptions(c.clients.KubeClient, k8s.ResyncPeriod)
 	c.kubernetesFactory.Core().V1().Services().Informer().AddEventHandler(c.handler)
 	c.kubernetesFactory.Core().V1().Endpoints().Informer().AddEventHandler(c.handler)
-
-	// Create a new SharedInformerFactory, and register the event handler to informers.
-	c.meshFactory = informers.NewSharedInformerFactoryWithOptions(c.clients.KubeClient,
-		k8s.ResyncPeriod,
-		informers.WithNamespace(c.meshNamespace),
-		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.LabelSelector = "component==maesh-mesh"
-		}),
-	)
-	c.meshFactory.Core().V1().Pods().Informer().AddEventHandler(c.meshHandler)
+	c.kubernetesFactory.Core().V1().Pods().Informer().AddEventHandler(c.handler)
 
 	c.tcpStateTable = &k8s.State{Table: make(map[int]*k8s.ServiceWithPort)}
 
@@ -151,14 +135,14 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 		case <-stopCh:
 			log.Info("Shutting down workers")
 			return nil
-		case <-c.configRefreshChan:
+		case message := <-c.configRefreshChan:
 			// Reload the configuration
 			conf, err := c.provider.BuildConfig()
 			if err != nil {
 				return err
 			}
 
-			if !reflect.DeepEqual(c.lastConfiguration.Get(), conf) {
+			if message == "force" || !reflect.DeepEqual(c.lastConfiguration.Get(), conf) {
 				c.lastConfiguration.Set(conf)
 
 				if deployErr := c.deployConfiguration(conf); deployErr != nil {
@@ -175,14 +159,6 @@ func (c *Controller) startInformers(stopCh <-chan struct{}) {
 	c.kubernetesFactory.Start(stopCh)
 
 	for t, ok := range c.kubernetesFactory.WaitForCacheSync(stopCh) {
-		if !ok {
-			log.Errorf("timed out waiting for controller caches to sync: %s", t.String())
-		}
-	}
-
-	c.meshFactory.Start(stopCh)
-
-	for t, ok := range c.meshFactory.WaitForCacheSync(stopCh) {
 		if !ok {
 			log.Errorf("timed out waiting for controller caches to sync: %s", t.String())
 		}

--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -95,7 +95,7 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 		}
 
 		log.Debugf("MeshControllerHandler ObjectUpdated with type: *corev1.Pod: %s/%s", obj.Namespace, obj.Name)
-		// Since this is a mesh pod update, trigger a force deploy.'
+		// Since this is a mesh pod update, trigger a force deploy.
 		h.configRefreshChan <- k8s.ConfigMessageChanForce
 
 		return

--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -9,14 +9,14 @@ import (
 // Handler is an implementation of a ResourceEventHandler.
 type Handler struct {
 	ignored               k8s.IgnoreWrapper
-	configRefreshChan     chan bool
+	configRefreshChan     chan string
 	createMeshServiceFunc func(service *corev1.Service) error
 	updateMeshServiceFunc func(oldUserService *corev1.Service, newUserService *corev1.Service) (*corev1.Service, error)
 	deleteMeshServiceFunc func(serviceName, serviceNamespace string) error
 }
 
 // NewHandler creates a handler.
-func NewHandler(ignored k8s.IgnoreWrapper, configRefreshChan chan bool) *Handler {
+func NewHandler(ignored k8s.IgnoreWrapper, configRefreshChan chan string) *Handler {
 	h := &Handler{
 		ignored:           ignored,
 		configRefreshChan: configRefreshChan,
@@ -63,8 +63,8 @@ func (h *Handler) OnAdd(obj interface{}) {
 		}
 	}
 
-	// Trigger a configuration refresh.
-	h.configRefreshChan <- true
+	// Trigger a configuration rebuild.
+	h.configRefreshChan <- k8s.ConfigMessageChanRebuild
 }
 
 // OnUpdate executed when an object is updated.
@@ -90,14 +90,18 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 		log.Debugf("MeshControllerHandler ObjectUpdated with type: *corev1.Endpoints: %s/%s", obj.Namespace, obj.Name)
 	case *corev1.Pod:
 		if !isMeshPod(obj) {
+			// We don't track updates of user pods, updates are done through endpoints.
 			return
 		}
 
 		log.Debugf("MeshControllerHandler ObjectUpdated with type: *corev1.Pod: %s/%s", obj.Namespace, obj.Name)
+		// Since this is a mesh pod update, trigger a force deploy.'
+		h.configRefreshChan <- k8s.ConfigMessageChanForce
+		return
 	}
 
-	// Trigger a configuration refresh.
-	h.configRefreshChan <- true
+	// Trigger a configuration rebuild.
+	h.configRefreshChan <- k8s.ConfigMessageChanRebuild
 }
 
 // OnDelete executed when an object is deleted.
@@ -124,6 +128,6 @@ func (h *Handler) OnDelete(obj interface{}) {
 		return
 	}
 
-	// Trigger a configuration refresh.
-	h.configRefreshChan <- true
+	// Trigger a configuration rebuild.
+	h.configRefreshChan <- k8s.ConfigMessageChanRebuild
 }

--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -97,6 +97,7 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 		log.Debugf("MeshControllerHandler ObjectUpdated with type: *corev1.Pod: %s/%s", obj.Namespace, obj.Name)
 		// Since this is a mesh pod update, trigger a force deploy.'
 		h.configRefreshChan <- k8s.ConfigMessageChanForce
+
 		return
 	}
 

--- a/internal/k8s/constants.go
+++ b/internal/k8s/constants.go
@@ -33,4 +33,9 @@ const (
 
 	// TCPStateConfigMapName TCP config map name.
 	TCPStateConfigMapName string = "tcp-state-table"
+
+	//ConfigMessageChanRebuild rebuild.
+	ConfigMessageChanRebuild string = "rebuild"
+	//ConfigMessageChanForce force.
+	ConfigMessageChanForce string = "force"
 )

--- a/internal/k8s/constants.go
+++ b/internal/k8s/constants.go
@@ -34,8 +34,8 @@ const (
 	// TCPStateConfigMapName TCP config map name.
 	TCPStateConfigMapName string = "tcp-state-table"
 
-	//ConfigMessageChanRebuild rebuild.
+	// ConfigMessageChanRebuild rebuild.
 	ConfigMessageChanRebuild string = "rebuild"
-	//ConfigMessageChanForce force.
+	// ConfigMessageChanForce force.
 	ConfigMessageChanForce string = "force"
 )


### PR DESCRIPTION
This PR:

- Consolidates Informer Factories and handlers
- Updates the config Chan to allow forced deploys

Fixes #286 