### PR TITLE
Upgrade golangci-lint and fix helm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /go/src/github.com/containous/maesh
 RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
 
 # Download golangci-lint binary to bin folder in $GOPATH
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.20.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.21.0
 
 ENV GO111MODULE on
 COPY go.mod go.sum ./

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ tidy:
 	go mod tidy
 
 helm:
-	@command -v helm >/dev/null 2>&1 || curl https://raw.githubusercontent.com/helm/helm/v2.14.1/scripts/get | bash
+	@command -v helm >/dev/null 2>&1 || curl -L https://git.io/get_helm.sh | bash -s -- -v v2.14.3
 	@helm init --client-only
 
 helm-lint: helm

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -46,7 +46,7 @@ func Test(t *testing.T) {
 	images = append(images, image{"coredns/coredns:1.4.0", true})
 	images = append(images, image{"coredns/coredns:1.5.2", true})
 	images = append(images, image{"coredns/coredns:1.6.3", true})
-	images = append(images, image{"gcr.io/kubernetes-helm/tiller:v2.14.1", true})
+	images = append(images, image{"gcr.io/kubernetes-helm/tiller:v2.14.3", true})
 	images = append(images, image{"giantswarm/tiny-tools:3.9", true})
 	images = append(images, image{"gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7", true})
 	images = append(images, image{"gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7", true})

--- a/integration/resources/whoami/whoami.yaml
+++ b/integration/resources/whoami/whoami.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: whoami
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: whoami
   template:
     metadata:
       labels:


### PR DESCRIPTION
### Description

This Pr upgrades golangci-lint version to v1.21.0 and fix helm version to v2.14.3

Fixes #300 