### PR TITLE
add codecov integration

### DIFF
--- a/.semaphoreci/job1.sh
+++ b/.semaphoreci/job1.sh
@@ -2,3 +2,4 @@
 set -e
 
 make
+make codecov

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ $(DIST_DIR):
 	mkdir -p $(DIST_DIR)
 
 clean:
-	rm -rf $(CURDIR)/dist/ cover.out $(CURDIR)/pages $(CURDIR)/gh-pages.zip $(CURDIR)/maesh-gh-pages
+	rm -rf $(CURDIR)/dist/ coverage.txt $(CURDIR)/pages $(CURDIR)/gh-pages.zip $(CURDIR)/maesh-gh-pages
 
 # Static linting of source files. See .golangci.toml for options
 local-check: $(DIST_DIR) helm-lint
@@ -40,7 +40,7 @@ local-build: $(DIST_DIR)
 	$(CURDIR)/cmd/$(BINARY_NAME)/*.go
 
 local-test: clean
-	go test -v -cover ./...
+	go test -v -coverprofile=coverage.txt -covermode=atomic ./...
 
 # Integration test
 local-test-integration: $(DIST_DIR) kubectl helm build
@@ -130,6 +130,9 @@ helm-package: helm-lint pages
 	mv *.tgz index.md $(CURDIR)/pages/charts/
 	helm repo index $(CURDIR)/pages/charts/
 
+codecov: local-test
+	curl -s https://codecov.io/bash | bash -s
+
 .PHONY: local-check local-build local-test check build test publish-images \
-		vendor kubectl test-integration local-test-integration pages
+		vendor kubectl test-integration local-test-integration pages codecov
 .PHONY: helm helm-lint helm-package

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ helm-package: helm-lint pages
 	helm repo index $(CURDIR)/pages/charts/
 
 codecov: local-test
-	curl -s https://codecov.io/bash | bash -s
+	curl -s https://codecov.io/bash | bash -s -- -K -F unittests
 
 .PHONY: local-check local-build local-test check build test publish-images \
 		vendor kubectl test-integration local-test-integration pages codecov


### PR DESCRIPTION
This PR integrates codecov into the CI process to track test coverage changes.

To make this work one of the maintainers needs to:
1. Create a codecov token
https://docs.codecov.io/docs/quick-start#section-getting-started

2. Make the token accessible in the Semaphore CI pipeline
https://docs.semaphoreci.com/article/66-environment-variables-and-secrets#managing-sensitive-data-with-secrets

If you need any support with this process I'm glad to help out.

You may want to change some of codecov's [configuration](https://docs.codecov.io/docs/codecov-yaml). As this is highly dependent on the project's needs I went with the defaults for now.

Fixes #281 