### PR TITLE
fix: linter timeout.

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,5 +1,5 @@
 [run]
-  deadline = "5m"
+  timeout = "5m"
 
 [linters-settings]
 


### PR DESCRIPTION
golangci-lint has replaced `deadline` by `timeout`


Fixes #308 