### PR TITLE
add spec.selector field to Helm chart dependencies

### DIFF
--- a/helm/chart/maesh/charts/metrics/templates/grafana.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/grafana.yaml
@@ -12,6 +12,10 @@ metadata:
     component: grafana
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+      component: core
   template:
     metadata:
       labels:

--- a/helm/chart/maesh/charts/metrics/templates/prometheus.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/prometheus.yaml
@@ -78,6 +78,10 @@ metadata:
     component: prometheus
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+      component: core
   template:
     metadata:
       name: prometheus-main

--- a/helm/chart/maesh/charts/tracing/templates/jaeger-deployment.yaml
+++ b/helm/chart/maesh/charts/tracing/templates/jaeger-deployment.yaml
@@ -24,6 +24,11 @@ metadata:
     app.kubernetes.io/component: all-in-one
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: jaeger
+      app.kubernetes.io/name: jaeger
+      app.kubernetes.io/component: all-in-one
   strategy:
     type: Recreate
   template:


### PR DESCRIPTION
The K8s API version `apps/v1` made the `spec.selector` field required for deployments. This PR adds values for the missing selectors.

Fixes #305 