### PR TITLE
Refactor ignorewrapper

### DIFF
--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -48,7 +48,7 @@ func (h *Handler) OnAdd(obj interface{}) {
 	// assert the type to an object to pull out relevant data
 	switch obj := obj.(type) {
 	case *corev1.Service:
-		if h.ignored.Ignored(obj.Name, obj.Namespace) {
+		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace) {
 			return
 		}
 
@@ -69,10 +69,10 @@ func (h *Handler) OnAdd(obj interface{}) {
 
 // OnUpdate executed when an object is updated.
 func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
-	// assert the type to an object to pull out relevant data
+	// Assert the type to an object to pull out relevant data.
 	switch obj := newObj.(type) {
 	case *corev1.Service:
-		if h.ignored.Ignored(obj.Name, obj.Namespace) {
+		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace) {
 			return
 		}
 
@@ -83,7 +83,8 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 
 		log.Debugf("MeshControllerHandler ObjectUpdated with type: *corev1.Service: %s/%s", obj.Namespace, obj.Name)
 	case *corev1.Endpoints:
-		if h.ignored.Ignored(obj.Name, obj.Namespace) {
+		// We can use the same ignore for services and endpoints.
+		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace) {
 			return
 		}
 
@@ -107,10 +108,10 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 
 // OnDelete executed when an object is deleted.
 func (h *Handler) OnDelete(obj interface{}) {
-	// assert the type to an object to pull out relevant data
+	// Assert the type to an object to pull out relevant data.
 	switch obj := obj.(type) {
 	case *corev1.Service:
-		if h.ignored.Ignored(obj.Name, obj.Namespace) {
+		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace) {
 			return
 		}
 
@@ -120,7 +121,8 @@ func (h *Handler) OnDelete(obj interface{}) {
 			log.Errorf("Could not delete mesh service: %v", err)
 		}
 	case *corev1.Endpoints:
-		if h.ignored.Ignored(obj.Name, obj.Namespace) {
+		// We can use the same ignore for services and endpoints.
+		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace) {
 			return
 		}
 

--- a/internal/k8s/namespace.go
+++ b/internal/k8s/namespace.go
@@ -1,9 +1,5 @@
 package k8s
 
-import (
-	"strings"
-)
-
 // Namespaces holds namespace name.
 type Namespaces []string
 
@@ -16,15 +12,4 @@ func (n Namespaces) Contains(x string) bool {
 	}
 
 	return false
-}
-
-// ObjectKeyInNamespace returns true if the object key is in the namespace.
-func ObjectKeyInNamespace(key string, namespaces Namespaces) bool {
-	splitKey := strings.Split(key, "/")
-	if len(splitKey) == 1 {
-		// No namespace in the key
-		return false
-	}
-
-	return namespaces.Contains(splitKey[0])
 }

--- a/internal/providers/kubernetes/provider.go
+++ b/internal/providers/kubernetes/provider.go
@@ -136,7 +136,7 @@ func (p *Provider) BuildConfig() (*dynamic.Configuration, error) {
 	config := base.CreateBaseConfigWithReadiness()
 
 	for _, service := range services {
-		if p.ignored.Ignored(service.Name, service.Namespace) {
+		if p.ignored.IsIgnoredService(service.Name, service.Namespace) {
 			continue
 		}
 

--- a/internal/providers/kubernetes/provider_test.go
+++ b/internal/providers/kubernetes/provider_test.go
@@ -28,7 +28,10 @@ func TestBuildRouter(t *testing.T) {
 		Service:     "bar",
 	}
 
-	provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored(meshNamespace, []string{}))
+	ignored := k8s.NewIgnored()
+	ignored.SetMeshNamespace(meshNamespace)
+
+	provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
 
 	name := "test"
 	namespace := "foo"
@@ -49,7 +52,10 @@ func TestBuildTCPRouter(t *testing.T) {
 		Service:     "bar",
 	}
 
-	provider := New(nil, k8s.ServiceTypeTCP, meshNamespace, nil, k8s.NewIgnored(meshNamespace, []string{}))
+	ignored := k8s.NewIgnored()
+	ignored.SetMeshNamespace(meshNamespace)
+
+	provider := New(nil, k8s.ServiceTypeTCP, meshNamespace, nil, ignored)
 
 	port := 10000
 	associatedService := "bar"
@@ -275,7 +281,10 @@ func TestBuildConfiguration(t *testing.T) {
 				clientMock.EnableServiceError()
 			}
 
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, stateTable, k8s.NewIgnored(meshNamespace, []string{}))
+			ignored := k8s.NewIgnored()
+			ignored.SetMeshNamespace(meshNamespace)
+
+			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, stateTable, ignored)
 			config, err := provider.BuildConfig()
 			assert.Equal(t, test.expected, config)
 			if test.endpointsError || test.serviceError {
@@ -383,7 +392,10 @@ func TestBuildService(t *testing.T) {
 			t.Parallel()
 
 			clientMock := k8s.NewCoreV1ClientMock(test.mockFile)
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored(meshNamespace, []string{}))
+			ignored := k8s.NewIgnored()
+			ignored.SetMeshNamespace(meshNamespace)
+
+			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
 			actual := provider.buildService(test.endpoints, test.scheme)
 			assert.Equal(t, test.expected, actual)
 		})
@@ -454,7 +466,10 @@ func TestBuildTCPService(t *testing.T) {
 			t.Parallel()
 
 			clientMock := k8s.NewCoreV1ClientMock(test.mockFile)
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, stateTable, k8s.NewIgnored(meshNamespace, []string{}))
+			ignored := k8s.NewIgnored()
+			ignored.SetMeshNamespace(meshNamespace)
+
+			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, stateTable, ignored)
 			actual := provider.buildTCPService(test.endpoints)
 			assert.Equal(t, test.expected, actual)
 		})
@@ -500,7 +515,10 @@ func TestGetMeshPort(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, stateTable, k8s.NewIgnored(meshNamespace, []string{}))
+			ignored := k8s.NewIgnored()
+			ignored.SetMeshNamespace(meshNamespace)
+
+			provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, stateTable, ignored)
 			actual := provider.getMeshPort(test.name, test.namespace, test.port)
 			assert.Equal(t, test.expected, actual)
 		})
@@ -590,7 +608,7 @@ func TestBuildHTTPMiddlewares(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored(meshNamespace, []string{}))
+			provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored())
 			actual := provider.buildHTTPMiddlewares(test.annotations)
 			assert.Equal(t, test.expected, actual)
 		})

--- a/internal/providers/smi/provider.go
+++ b/internal/providers/smi/provider.go
@@ -80,7 +80,7 @@ func (p *Provider) BuildConfig() (*dynamic.Configuration, error) {
 	}
 
 	for _, service := range services {
-		if p.ignored.Ignored(service.Name, service.Namespace) {
+		if p.ignored.IsIgnoredService(service.Name, service.Namespace) {
 			continue
 		}
 

--- a/internal/providers/smi/provider_test.go
+++ b/internal/providers/smi/provider_test.go
@@ -17,7 +17,10 @@ import (
 const meshNamespace string = "maesh"
 
 func TestBuildRuleSnippetFromServiceAndMatch(t *testing.T) {
-	provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored(meshNamespace, []string{}))
+	ignored := k8s.NewIgnored()
+	ignored.SetMeshNamespace(meshNamespace)
+
+	provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
 
 	testCases := []struct {
 		desc     string
@@ -66,7 +69,10 @@ func TestBuildRuleSnippetFromServiceAndMatch(t *testing.T) {
 
 func TestGetTrafficTargetsWithDestinationInNamespace(t *testing.T) {
 	clientMock := k8s.NewClientMock("mock.yaml")
-	provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored(meshNamespace, []string{}))
+	ignored := k8s.NewIgnored()
+	ignored.SetMeshNamespace(meshNamespace)
+
+	provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
 
 	expected := []*accessv1alpha1.TrafficTarget{
 		{
@@ -333,7 +339,10 @@ func TestBuildHTTPRouterFromTrafficTarget(t *testing.T) {
 			if test.httpError {
 				clientMock.EnableHTTPRouteGroupError()
 			}
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored(meshNamespace, []string{}))
+			ignored := k8s.NewIgnored()
+			ignored.SetMeshNamespace(meshNamespace)
+
+			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
 			middleware := "block-all"
 			actual := provider.buildHTTPRouterFromTrafficTarget(test.serviceName, test.serviceNamespace, test.serviceIP, test.trafficTarget, test.port, test.key, middleware)
 			assert.Equal(t, test.expected, actual)
@@ -474,7 +483,10 @@ func TestBuildTCPRouterFromTrafficTarget(t *testing.T) {
 			if test.tcpError {
 				clientMock.EnableTCPRouteError()
 			}
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored(meshNamespace, []string{}))
+			ignored := k8s.NewIgnored()
+			ignored.SetMeshNamespace(meshNamespace)
+
+			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
 			actual := provider.buildTCPRouterFromTrafficTarget(test.trafficTarget, test.port, test.key)
 			assert.Equal(t, test.expected, actual)
 		})
@@ -482,7 +494,10 @@ func TestBuildTCPRouterFromTrafficTarget(t *testing.T) {
 }
 
 func TestGetServiceMode(t *testing.T) {
-	provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored(meshNamespace, []string{}))
+	ignored := k8s.NewIgnored()
+	ignored.SetMeshNamespace(meshNamespace)
+
+	provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
 
 	testCases := []struct {
 		desc     string
@@ -863,7 +878,10 @@ func TestGetApplicableTrafficTargets(t *testing.T) {
 				clientMock.EnablePodError()
 			}
 
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored(meshNamespace, []string{}))
+			ignored := k8s.NewIgnored()
+			ignored.SetMeshNamespace(meshNamespace)
+
+			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
 
 			actual := provider.getApplicableTrafficTargets(test.endpoints, test.trafficTargets)
 			assert.Equal(t, test.expected, actual)
@@ -1202,7 +1220,10 @@ func TestBuildHTTPServiceFromTrafficTarget(t *testing.T) {
 				clientMock.EnablePodError()
 			}
 
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored(meshNamespace, []string{}))
+			ignored := k8s.NewIgnored()
+			ignored.SetMeshNamespace(meshNamespace)
+
+			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
 
 			actual := provider.buildHTTPServiceFromTrafficTarget(test.endpoints, test.trafficTarget, k8s.SchemeHTTP)
 			assert.Equal(t, test.expected, actual)
@@ -1211,7 +1232,10 @@ func TestBuildHTTPServiceFromTrafficTarget(t *testing.T) {
 }
 
 func TestGroupTrafficTargetsByDestination(t *testing.T) {
-	provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored(meshNamespace, []string{}))
+	ignored := k8s.NewIgnored()
+	ignored.SetMeshNamespace(meshNamespace)
+
+	provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
 
 	trafficTargets := []*accessv1alpha1.TrafficTarget{
 		{
@@ -1449,7 +1473,10 @@ func TestBuildConfiguration(t *testing.T) {
 				clientMock.EnableServiceError()
 			}
 
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored(meshNamespace, []string{}))
+			ignored := k8s.NewIgnored()
+			ignored.SetMeshNamespace(meshNamespace)
+
+			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
 			config, err := provider.BuildConfig()
 			assert.Equal(t, test.expected, config)
 			if test.endpointsError || test.serviceError {


### PR DESCRIPTION
This PR:

- Refactors `ignoreWrapper` to be more dynamic
- Prepares code for non-maesh namespaces

Fixes #289 