### PR TITLE
Create API on the controller

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -13,6 +13,7 @@ type MaeshConfiguration struct {
 	DefaultMode      string   `description:"Default mode for mesh services" export:"true"`
 	Namespace        string   `description:"The namespace that maesh is installed in." export:"true"`
 	IgnoreNamespaces []string `description:"The namespace that maesh should be ignoring." export:"true"`
+	APIPort          int      `description:"API port for the controller" export:"true"`
 }
 
 // NewMaeshConfiguration creates a MaeshConfiguration with default values.
@@ -24,6 +25,7 @@ func NewMaeshConfiguration() *MaeshConfiguration {
 		SMI:         false,
 		DefaultMode: "http",
 		Namespace:   "maesh",
+		APIPort:     9000,
 	}
 }
 

--- a/cmd/maesh/maesh.go
+++ b/cmd/maesh/maesh.go
@@ -72,7 +72,7 @@ func maeshCommand(iConfig *cmd.MaeshConfiguration) error {
 	// Create a new stop Channel
 	stopCh := signals.SetupSignalHandler()
 	// Create a new ctr.
-	ctr := controller.NewMeshController(clients, iConfig.SMI, iConfig.DefaultMode, iConfig.Namespace, iConfig.IgnoreNamespaces)
+	ctr := controller.NewMeshController(clients, iConfig.SMI, iConfig.DefaultMode, iConfig.Namespace, iConfig.IgnoreNamespaces, iConfig.APIPort)
 
 	// run the ctr loop to process items
 	if err = ctr.Run(stopCh); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/deislabs/smi-sdk-go v0.0.0-20190819154013-e53a9b2d8c1a
 	github.com/go-check/check v0.0.0-20180628173108-788fd7840127
 	github.com/google/uuid v1.1.1
+	github.com/gorilla/mux v1.7.3
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/vdemeester/shakers v0.1.0

--- a/helm/chart/maesh/templates/controller/controller-deployment.yaml
+++ b/helm/chart/maesh/templates/controller/controller-deployment.yaml
@@ -93,6 +93,15 @@ spec:
             limits:
               memory: {{ .Values.controller.resources.limit.mem }}
               cpu: {{ .Values.controller.resources.limit.cpu }}
+          ports:
+            - name: api
+              containerPort: 9000
+          readinessProbe:
+            httpGet:
+              path: /api/status/readiness
+              port: api
+            initialDelaySeconds: 3
+            periodSeconds: 1
       initContainers:
         - name: maesh-prepare
           image: {{ include "maesh.controllerImage" . | quote }}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -196,7 +196,7 @@ func (s *BaseSuite) startAndWaitForKubeDNS(c *check.C) {
 }
 
 func (s *BaseSuite) waitForMaeshControllerStarted(c *check.C) {
-	err := s.try.WaitReadyDeployment("maesh-controller", "maesh", 30*time.Second)
+	err := s.try.WaitReadyDeployment("maesh-controller", "maesh", 60*time.Second)
 	c.Assert(err, checker.IsNil)
 }
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -201,7 +201,7 @@ func (s *BaseSuite) waitForMaeshControllerStarted(c *check.C) {
 }
 
 func (s *BaseSuite) waitForMaeshControllerStartedWithReturn() error {
-	return s.try.WaitReadyDeployment("maesh-controller", "maesh", 30*time.Second)
+	return s.try.WaitReadyDeployment("maesh-controller", "maesh", 60*time.Second)
 }
 
 func (s *BaseSuite) waitForTiller(c *check.C) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -196,12 +196,12 @@ func (s *BaseSuite) startAndWaitForKubeDNS(c *check.C) {
 }
 
 func (s *BaseSuite) waitForMaeshControllerStarted(c *check.C) {
-	err := s.try.WaitReadyDeployment("maesh-controller", "maesh", 60*time.Second)
+	err := s.try.WaitReadyDeployment("maesh-controller", "maesh", 30*time.Second)
 	c.Assert(err, checker.IsNil)
 }
 
 func (s *BaseSuite) waitForMaeshControllerStartedWithReturn() error {
-	return s.try.WaitReadyDeployment("maesh-controller", "maesh", 60*time.Second)
+	return s.try.WaitReadyDeployment("maesh-controller", "maesh", 30*time.Second)
 }
 
 func (s *BaseSuite) waitForTiller(c *check.C) {

--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -59,7 +59,11 @@ func (a *API) Run() {
 
 // EnableReadiness enables the readiness flag in the API.
 func (a *API) EnableReadiness() {
-	a.readiness = true
+	if !a.readiness {
+		log.Debug("Controller Readiness enabled")
+
+		a.readiness = true
+	}
 }
 
 // getCurrentConfiguration returns the current configuration.

--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -1,0 +1,85 @@
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/containous/traefik/v2/pkg/safe"
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+)
+
+// API is an implementation of an api.
+type API struct {
+	router            *mux.Router
+	readiness         bool
+	lastConfiguration *safe.Safe
+	apiPort           int
+}
+
+// NewAPI creates a new api.
+func NewAPI(apiPort int, lastConfiguration *safe.Safe) *API {
+	a := &API{
+		readiness:         false,
+		lastConfiguration: lastConfiguration,
+		apiPort:           apiPort,
+	}
+
+	if err := a.Init(); err != nil {
+		log.Errorln("Could not initialize API")
+	}
+
+	return a
+}
+
+// Init handles any api initialization.
+func (a *API) Init() error {
+	log.Debugln("API.Init")
+
+	a.router = mux.NewRouter()
+
+	a.router.HandleFunc("/api/configuration/current", a.getCurrentConfiguration)
+	a.router.HandleFunc("/api/status/readiness", a.getReadiness)
+
+	return nil
+}
+
+// Start runs the API.
+func (a *API) Start() {
+	log.Debugln("API.Start")
+
+	go a.Run()
+}
+
+// Run wraps the listenAndServe method.
+func (a *API) Run() {
+	log.Error(http.ListenAndServe(fmt.Sprintf(":%d", a.apiPort), a.router))
+}
+
+// EnableReadiness enables the readiness flag in the API.
+func (a *API) EnableReadiness() {
+	a.readiness = true
+}
+
+// getCurrentConfiguration returns the current configuration.
+func (a *API) getCurrentConfiguration(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(a.lastConfiguration.Get()); err != nil {
+		log.Error(err)
+	}
+}
+
+// getReadiness returns the current readiness value, and sets the status code to 500 if not ready.
+func (a *API) getReadiness(w http.ResponseWriter, r *http.Request) {
+	if !a.readiness {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(a.readiness); err != nil {
+		log.Error(err)
+	}
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -96,6 +96,8 @@ func (c *Controller) Init() error {
 
 	c.tcpStateTable = &k8s.State{Table: make(map[int]*k8s.ServiceWithPort)}
 
+	c.api = NewAPI(c.apiPort, &c.lastConfiguration)
+
 	if c.smiEnabled {
 		c.provider = smi.New(c.clients, c.defaultMode, c.meshNamespace, c.tcpStateTable, c.ignored)
 		// Create new SharedInformerFactories, and register the event handler to informers.
@@ -113,8 +115,6 @@ func (c *Controller) Init() error {
 
 	// If SMI is not configured, use the kubernetes provider.
 	c.provider = kubernetes.New(c.clients, c.defaultMode, c.meshNamespace, c.tcpStateTable, c.ignored)
-
-	c.api = NewAPI(c.apiPort, &c.lastConfiguration)
 
 	return nil
 }


### PR DESCRIPTION
This PR:

- Creates an API handler with 2 listeners:
  - "/api/configuration/current"
  - "/api/status/readiness"
- Exposes the Last Deployed Configuration
- Allows for configurable API port (default 9000)
- Uses the API to have a readiness endpoint
- Tune readiness to be ready after successful deploy of configuration
- Configures deployment to use the new readiness endpoint
- Makes controller not ready errors clearer in the CI, rather than just failing a random test

Fixes #171 
Fixes #321 
