### PR TITLE
Re-add ignored namespace

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -57,6 +57,7 @@ func NewMeshController(clients *k8s.ClientWrapper, smiEnabled bool, defaultMode 
 	}
 
 	ignored.AddIgnoredService("kubernetes", metav1.NamespaceDefault)
+	ignored.AddIgnoredNamespace(metav1.NamespaceSystem)
 
 	// configRefreshChan is used to trigger configuration refreshes and deploys.
 	configRefreshChan := make(chan string)


### PR DESCRIPTION
This PR:

- Re-adds the `kube-system` namespace to the ignored list

Fixes #324 