### PR TITLE
Create a deploy log and wire to API

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdko
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/sarama v1.23.1/go.mod h1:XLH1GYJnLVE0XCr6KdJGVJRTwY30moWNJ4sERjXX6fs=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/abronan/valkeyrie v0.0.0-20190802193736-ed4c4a229894/go.mod h1:sQZ/48uDt1GRBDNsLboJGPD2w/HxEOhqf3JiikfHj1I=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.0/go.mod h1:zpDJeKyp9ScW4NNrbdr+Eyxvry3ilGPewKoXw3XGN1k=
@@ -126,6 +127,7 @@ github.com/go-cmd/cmd v1.0.5/go.mod h1:y8q8qlK5wQibcw63djSl/ntiHUHXHGdCkPk0j4QeW
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-ini/ini v1.44.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=

--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -95,5 +95,7 @@ func (a *API) getReadiness(w http.ResponseWriter, r *http.Request) {
 func (a *API) getDeployLog(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	w.Write(a.deployLog.GetLog())
+	if _, err := w.Write(a.deployLog.GetLog()); err != nil {
+		log.Error(err)
+	}
 }

--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -16,14 +16,16 @@ type API struct {
 	readiness         bool
 	lastConfiguration *safe.Safe
 	apiPort           int
+	deployLog         *DeployLog
 }
 
 // NewAPI creates a new api.
-func NewAPI(apiPort int, lastConfiguration *safe.Safe) *API {
+func NewAPI(apiPort int, lastConfiguration *safe.Safe, deployLog *DeployLog) *API {
 	a := &API{
 		readiness:         false,
 		lastConfiguration: lastConfiguration,
 		apiPort:           apiPort,
+		deployLog:         deployLog,
 	}
 
 	if err := a.Init(); err != nil {

--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -43,6 +43,7 @@ func (a *API) Init() error {
 
 	a.router.HandleFunc("/api/configuration/current", a.getCurrentConfiguration)
 	a.router.HandleFunc("/api/status/readiness", a.getReadiness)
+	a.router.HandleFunc("/api/log/deploylog", a.getDeployLog)
 
 	return nil
 }
@@ -88,4 +89,11 @@ func (a *API) getReadiness(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(a.readiness); err != nil {
 		log.Error(err)
 	}
+}
+
+// getDeployLog returns the current deploylog.
+func (a *API) getDeployLog(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	w.Write(a.deployLog.GetLog())
 }

--- a/internal/controller/api_test.go
+++ b/internal/controller/api_test.go
@@ -24,7 +24,6 @@ func TestEnableReadiness(t *testing.T) {
 }
 
 func TestGetReadiness(t *testing.T) {
-
 	testCases := []struct {
 		desc               string
 		readiness          bool
@@ -84,6 +83,7 @@ func TestGetDeployLog(t *testing.T) {
 
 	data, err := currentTime.MarshalJSON()
 	assert.NoError(t, err)
+
 	currentTimeString := string(data)
 	expected := fmt.Sprintf("[{\"TimeStamp\":%s,\"PodName\":\"foo\",\"PodIP\":\"bar\",\"DeploySuccessful\":true,\"Reason\":\"blabla\"}]", currentTimeString)
 

--- a/internal/controller/api_test.go
+++ b/internal/controller/api_test.go
@@ -1,0 +1,73 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/containous/traefik/v2/pkg/safe"
+	"github.com/containous/traefik/v2/pkg/testhelpers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnableReadiness(t *testing.T) {
+	config := safe.Safe{}
+	api := NewAPI(9000, &config, nil)
+
+	assert.Equal(t, false, api.readiness)
+
+	api.EnableReadiness()
+
+	assert.Equal(t, true, api.readiness)
+}
+
+func TestGetReadiness(t *testing.T) {
+
+	testCases := []struct {
+		desc               string
+		readiness          bool
+		expectedStatusCode int
+	}{
+		{
+			desc:               "ready",
+			readiness:          true,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			desc:               "not ready",
+			readiness:          false,
+			expectedStatusCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			config := safe.Safe{}
+			api := NewAPI(9000, &config, nil)
+			api.readiness = test.readiness
+
+			res := httptest.NewRecorder()
+			req := testhelpers.MustNewRequest(http.MethodGet, "/api/status/readiness", nil)
+
+			api.getReadiness(res, req)
+
+			assert.Equal(t, test.expectedStatusCode, res.Code)
+		})
+	}
+}
+
+func TestGetCurrentConfiguration(t *testing.T) {
+	config := safe.Safe{}
+	api := NewAPI(9000, &config, nil)
+
+	config.Set("foo")
+
+	res := httptest.NewRecorder()
+	req := testhelpers.MustNewRequest(http.MethodGet, "/api/configuration/current", nil)
+
+	api.getCurrentConfiguration(res, req)
+
+	assert.Equal(t, "\"foo\"\n", res.Body.String())
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -545,18 +545,22 @@ func (c *Controller) deployToPod(name, ip string, config *dynamic.Configuration)
 		defer resp.Body.Close()
 
 		if _, bodyErr := ioutil.ReadAll(resp.Body); bodyErr != nil {
+			c.deployLog.LogDeploy(time.Now(), name, ip, false, fmt.Sprintf("unable to read response body: %v", bodyErr))
 			return fmt.Errorf("unable to read response body: %v", bodyErr)
 		}
 
 		if resp.StatusCode != http.StatusOK {
+			c.deployLog.LogDeploy(time.Now(), name, ip, false, fmt.Sprintf("received non-ok response code: %d", resp.StatusCode))
 			return fmt.Errorf("received non-ok response code: %d", resp.StatusCode)
 		}
 	}
 
 	if err != nil {
+		c.deployLog.LogDeploy(time.Now(), name, ip, false, fmt.Sprintf("unable to deploy configuration: %v", err))
 		return fmt.Errorf("unable to deploy configuration: %v", err)
 	}
 
+	c.deployLog.LogDeploy(time.Now(), name, ip, true, "")
 	log.Debugf("Successfully deployed configuration to pod (%s:%s)", name, ip)
 
 	return nil

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -46,6 +46,7 @@ type Controller struct {
 	lastConfiguration safe.Safe
 	api               *API
 	apiPort           int
+	deployLog         *DeployLog
 }
 
 // NewMeshController is used to build the informers and other required components of the mesh controller,
@@ -96,7 +97,8 @@ func (c *Controller) Init() error {
 
 	c.tcpStateTable = &k8s.State{Table: make(map[int]*k8s.ServiceWithPort)}
 
-	c.api = NewAPI(c.apiPort, &c.lastConfiguration)
+	c.deployLog = NewDeployLog()
+	c.api = NewAPI(c.apiPort, &c.lastConfiguration, c.deployLog)
 
 	if c.smiEnabled {
 		c.provider = smi.New(c.clients, c.defaultMode, c.meshNamespace, c.tcpStateTable, c.ignored)

--- a/internal/controller/log.go
+++ b/internal/controller/log.go
@@ -50,11 +50,11 @@ func (d *DeployLog) LogDeploy(timeStamp time.Time, podName string, podIP string,
 }
 
 // GetLog returns a json representation of the entries list.
-func (d *DeployLog) GetLog() string {
+func (d *DeployLog) GetLog() []byte {
 	data, err := json.Marshal(d.Entries)
 	if err != nil {
 		log.Error("Could not marshal deploylog entries")
 	}
 
-	return string(data)
+	return data
 }

--- a/internal/controller/log.go
+++ b/internal/controller/log.go
@@ -1,0 +1,58 @@
+package controller
+
+import (
+	"encoding/json"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type logEntry struct {
+	TimeStamp        time.Time
+	PodName          string
+	DeploySuccessful bool
+	Reason           string
+}
+
+type DeployLog struct {
+	Entries []logEntry
+}
+
+func NewDeployLog() *DeployLog {
+	d := &DeployLog{}
+
+	if err := d.Init(); err != nil {
+		log.Error("Could not initialize DeployLog")
+	}
+
+	return d
+}
+
+// Init handles any DeployLog initialization.
+func (d *DeployLog) Init() error {
+	log.Debug("DeployLog.Init")
+
+	return nil
+}
+
+// LogDeploy adds a record to the entries list.
+func (d *DeployLog) LogDeploy(timeStamp time.Time, podName string, deploySuccessful bool, reason string) {
+	newEntry := logEntry{
+		TimeStamp:        timeStamp,
+		PodName:          podName,
+		DeploySuccessful: deploySuccessful,
+		Reason:           reason,
+	}
+
+	d.Entries = append(d.Entries, newEntry)
+}
+
+// GetLog returns a json representation of the entries list.
+func (d *DeployLog) GetLog() string {
+	data, err := json.Marshal(d.Entries)
+	if err != nil {
+		log.Error("Could not marshal deploylog entries")
+	}
+
+	return string(data)
+}

--- a/internal/controller/log.go
+++ b/internal/controller/log.go
@@ -10,6 +10,7 @@ import (
 type logEntry struct {
 	TimeStamp        time.Time
 	PodName          string
+	PodIP            string
 	DeploySuccessful bool
 	Reason           string
 }
@@ -36,10 +37,11 @@ func (d *DeployLog) Init() error {
 }
 
 // LogDeploy adds a record to the entries list.
-func (d *DeployLog) LogDeploy(timeStamp time.Time, podName string, deploySuccessful bool, reason string) {
+func (d *DeployLog) LogDeploy(timeStamp time.Time, podName string, podIP string, deploySuccessful bool, reason string) {
 	newEntry := logEntry{
 		TimeStamp:        timeStamp,
 		PodName:          podName,
+		PodIP:            podIP,
 		DeploySuccessful: deploySuccessful,
 		Reason:           reason,
 	}

--- a/internal/controller/log.go
+++ b/internal/controller/log.go
@@ -15,10 +15,12 @@ type logEntry struct {
 	Reason           string
 }
 
+// DeployLog holds a slice of log entries.
 type DeployLog struct {
 	Entries []logEntry
 }
 
+// NewDeployLog returns an initialized DeployLog.
 func NewDeployLog() *DeployLog {
 	d := &DeployLog{}
 

--- a/internal/controller/log_test.go
+++ b/internal/controller/log_test.go
@@ -10,20 +10,20 @@ import (
 
 func TestLogDeploy(t *testing.T) {
 	log := NewDeployLog()
-	log.LogDeploy(time.Now(), "foo", true, "")
+	log.LogDeploy(time.Now(), "foo", "bar", true, "blabla")
 	assert.Equal(t, 1, len(log.Entries))
 }
 
 func TestGetLog(t *testing.T) {
 	log := NewDeployLog()
 	currentTime := time.Now()
-	log.LogDeploy(currentTime, "foo", true, "")
+	log.LogDeploy(currentTime, "foo", "bar", true, "blabla")
 
 	data, err := currentTime.MarshalJSON()
 	assert.NoError(t, err)
 
 	currentTimeString := string(data)
 	actual := log.GetLog()
-	expected := fmt.Sprintf("[{\"TimeStamp\":%s,\"PodName\":\"foo\",\"DeploySuccessful\":true,\"Reason\":\"\"}]", currentTimeString)
+	expected := fmt.Sprintf("[{\"TimeStamp\":%s,\"PodName\":\"foo\",\"PodIP\":\"bar\",\"DeploySuccessful\":true,\"Reason\":\"blabla\"}]", currentTimeString)
 	assert.Equal(t, expected, actual)
 }

--- a/internal/controller/log_test.go
+++ b/internal/controller/log_test.go
@@ -1,0 +1,29 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogDeploy(t *testing.T) {
+	log := NewDeployLog()
+	log.LogDeploy(time.Now(), "foo", true, "")
+	assert.Equal(t, 1, len(log.Entries))
+}
+
+func TestGetLog(t *testing.T) {
+	log := NewDeployLog()
+	currentTime := time.Now()
+	log.LogDeploy(currentTime, "foo", true, "")
+
+	data, err := currentTime.MarshalJSON()
+	assert.NoError(t, err)
+
+	currentTimeString := string(data)
+	actual := log.GetLog()
+	expected := fmt.Sprintf("[{\"TimeStamp\":%s,\"PodName\":\"foo\",\"DeploySuccessful\":true,\"Reason\":\"\"}]", currentTimeString)
+	assert.Equal(t, expected, actual)
+}

--- a/internal/controller/log_test.go
+++ b/internal/controller/log_test.go
@@ -21,6 +21,7 @@ func TestGetLog(t *testing.T) {
 
 	data, err := currentTime.MarshalJSON()
 	assert.NoError(t, err)
+
 	currentTimeString := string(data)
 
 	actual := string(log.GetLog())

--- a/internal/controller/log_test.go
+++ b/internal/controller/log_test.go
@@ -21,9 +21,9 @@ func TestGetLog(t *testing.T) {
 
 	data, err := currentTime.MarshalJSON()
 	assert.NoError(t, err)
-
 	currentTimeString := string(data)
-	actual := log.GetLog()
+
+	actual := string(log.GetLog())
 	expected := fmt.Sprintf("[{\"TimeStamp\":%s,\"PodName\":\"foo\",\"PodIP\":\"bar\",\"DeploySuccessful\":true,\"Reason\":\"blabla\"}]", currentTimeString)
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
This PR:
- Creates a deployLog
- Logs successful and failed deployments to mesh pods
- Creates an API endpoint to list the log

Fixes #331 