### PR TITLE
Add Cluster Node Status and Configuration endpoints

### DIFF
--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -3,11 +3,14 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
+	"github.com/containous/maesh/internal/k8s"
 	"github.com/containous/traefik/v2/pkg/safe"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // API is an implementation of an api.
@@ -17,15 +20,25 @@ type API struct {
 	lastConfiguration *safe.Safe
 	apiPort           int
 	deployLog         *DeployLog
+	clients           *k8s.ClientWrapper
+	meshNamespace     string
+}
+
+type podInfo struct {
+	Name  string
+	IP    string
+	Ready bool
 }
 
 // NewAPI creates a new api.
-func NewAPI(apiPort int, lastConfiguration *safe.Safe, deployLog *DeployLog) *API {
+func NewAPI(apiPort int, lastConfiguration *safe.Safe, deployLog *DeployLog, clients *k8s.ClientWrapper, meshNamespace string) *API {
 	a := &API{
 		readiness:         false,
 		lastConfiguration: lastConfiguration,
 		apiPort:           apiPort,
 		deployLog:         deployLog,
+		clients:           clients,
+		meshNamespace:     meshNamespace,
 	}
 
 	if err := a.Init(); err != nil {
@@ -42,6 +55,8 @@ func (a *API) Init() error {
 	a.router = mux.NewRouter()
 
 	a.router.HandleFunc("/api/configuration/current", a.getCurrentConfiguration)
+	a.router.HandleFunc("/api/status/nodes", a.getMeshNodes)
+	a.router.HandleFunc("/api/status/node/{node}/configuration", a.getMeshNodeConfiguration)
 	a.router.HandleFunc("/api/status/readiness", a.getReadiness)
 	a.router.HandleFunc("/api/log/deploylog", a.getDeployLog)
 
@@ -96,6 +111,91 @@ func (a *API) getDeployLog(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	if _, err := w.Write(a.deployLog.GetLog()); err != nil {
+		log.Error(err)
+	}
+}
+
+// getMeshNodes returns a list of mesh nodes visible from the controller, and some basic readiness info.
+func (a *API) getMeshNodes(w http.ResponseWriter, r *http.Request) {
+	podInfoList := []podInfo{}
+
+	podList, err := a.clients.ListPodWithOptions(a.meshNamespace, metav1.ListOptions{
+		LabelSelector: "component==maesh-mesh",
+	})
+	if err != nil {
+		writeErrorResponse(w, fmt.Sprintf("unable to retrieve pod list: %v", err))
+		return
+	}
+
+	for _, pod := range podList.Items {
+		readiness := true
+
+		for _, status := range pod.Status.ContainerStatuses {
+			if !status.Ready {
+				// If there is a non-ready container, pod is not ready.
+				readiness = false
+				break
+			}
+		}
+
+		p := podInfo{
+			Name:  pod.Name,
+			IP:    pod.Status.PodIP,
+			Ready: readiness,
+		}
+		podInfoList = append(podInfoList, p)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(podInfoList); err != nil {
+		log.Error(err)
+	}
+}
+
+// getMeshNodeConfiguration returns the configuration for a named pod.
+func (a *API) getMeshNodeConfiguration(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	pod, exists, err := a.clients.GetPod(a.meshNamespace, vars["node"])
+	if err != nil {
+		writeErrorResponse(w, fmt.Sprintf("unable to retrieve pod: %v", err))
+		return
+	}
+
+	if !exists {
+		writeErrorResponse(w, fmt.Sprintf("unable to find pod: %s", vars["node"]))
+		return
+	}
+
+	resp, err := http.Get(fmt.Sprintf("http://%s:8080/api/rawdata", pod.Status.PodIP))
+	if err != nil {
+		writeErrorResponse(w, fmt.Sprintf("unable to get configuration from pod: %v", err))
+		return
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		writeErrorResponse(w, fmt.Sprintf("unable to get configuration response body from pod: %v", err))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if _, err := w.Write(body); err != nil {
+		log.Error(err)
+	}
+}
+
+func writeErrorResponse(w http.ResponseWriter, errorMessage string) {
+	w.WriteHeader(http.StatusInternalServerError)
+	log.Error(errorMessage)
+
+	w.Header().Set("Content-Type", "text/plain; charset=us-ascii")
+
+	if _, err := w.Write([]byte(errorMessage)); err != nil {
 		log.Error(err)
 	}
 }

--- a/internal/controller/api_test.go
+++ b/internal/controller/api_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestEnableReadiness(t *testing.T) {
 	config := safe.Safe{}
-	api := NewAPI(9000, &config, nil)
+	api := NewAPI(9000, &config, nil, nil, "foo")
 
 	assert.Equal(t, false, api.readiness)
 
@@ -46,7 +46,7 @@ func TestGetReadiness(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			config := safe.Safe{}
-			api := NewAPI(9000, &config, nil)
+			api := NewAPI(9000, &config, nil, nil, "foo")
 			api.readiness = test.readiness
 
 			res := httptest.NewRecorder()
@@ -61,7 +61,7 @@ func TestGetReadiness(t *testing.T) {
 
 func TestGetCurrentConfiguration(t *testing.T) {
 	config := safe.Safe{}
-	api := NewAPI(9000, &config, nil)
+	api := NewAPI(9000, &config, nil, nil, "foo")
 
 	config.Set("foo")
 
@@ -76,7 +76,7 @@ func TestGetCurrentConfiguration(t *testing.T) {
 func TestGetDeployLog(t *testing.T) {
 	config := safe.Safe{}
 	log := NewDeployLog()
-	api := NewAPI(9000, &config, log)
+	api := NewAPI(9000, &config, log, nil, "foo")
 
 	currentTime := time.Now()
 	log.LogDeploy(currentTime, "foo", "bar", true, "blabla")
@@ -91,6 +91,6 @@ func TestGetDeployLog(t *testing.T) {
 	req := testhelpers.MustNewRequest(http.MethodGet, "/api/configuration/current", nil)
 
 	api.getDeployLog(res, req)
-	actual := res.Body.String()
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, expected, res.Body.String())
+	assert.Equal(t, http.StatusOK, res.Code)
 }

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -98,7 +98,7 @@ func (c *Controller) Init() error {
 	c.tcpStateTable = &k8s.State{Table: make(map[int]*k8s.ServiceWithPort)}
 
 	c.deployLog = NewDeployLog()
-	c.api = NewAPI(c.apiPort, &c.lastConfiguration, c.deployLog)
+	c.api = NewAPI(c.apiPort, &c.lastConfiguration, c.deployLog, c.clients, c.meshNamespace)
 
 	if c.smiEnabled {
 		c.provider = smi.New(c.clients, c.defaultMode, c.meshNamespace, c.tcpStateTable, c.ignored)


### PR DESCRIPTION
This PR:

- Adds `/api/status/nodes` endpoint to list nodes, IPs and readiness status
- Adds `/api/status/node/xxx/configuration` endpoint to query the configuration from the pod name in the query

Example:

```
# curl 10.1.0.146:9000/api/status/nodes
[{"Name":"maesh-mesh-dddzh","IP":"10.1.0.141","Ready":true}]
```

```
 # curl 10.1.0.146:9000/api/status/node/maesh-mesh-dddzh/configuration
{"routers":{"b-default-80-1630c62929f8593e@rest":{"entryPoints":["http-5000"],"service":"b-default-80-1630c62929f8593e","rule":"Host(`b.default.maesh`) || Host(`10.110.234.23`)","status":"enabled","using":["http-5000"]},"compose-ap-docker-443-1a055e3db30bd9d5@rest":{"entryPoints":["http-5000"],"service":"compose-ap-docker-443-1a055e3db30bd9d5","rule":"Host(`compose-api.docker.maesh`) || Host(`10.96.62.229`)","status":"enabled","using":["http-5000"]},"d-default-80-2329da148b27c5c4@rest":{"entryPoints":["http-5000"],"service":"d-default-80-2329da148b27c5c4","rule":"Host(`d.default.maesh`) || Host(`10.106.213.110`)","status":"enabled","using":["http-5000"]},"e-default-80-99e3770fb2c461c9@rest":{"entryPoints":["http-5000"],"service":"e-default-80-99e3770fb2c461c9","rule":"Host(`e.default.maesh`) || Host(`10.96.84.128`)","status":"enabled","using":["http-5000"]},"readiness@rest":{"entryPoints":["readiness"],"service":"readiness","rule":"Path(`/ping`)","status":"enabled","using":["readiness"]}},"services":{"b-default-80-1630c62929f8593e@rest":{"loadBalancer":{"servers":[{"url":"http://10.1.0.139:80"}],"passHostHeader":true},"status":"enabled","usedBy":["b-default-80-1630c62929f8593e@rest"],"serverStatus":{"http://10.1.0.139:80":"UP"}},"compose-ap-docker-443-1a055e3db30bd9d5@rest":{"loadBalancer":{"servers":[{"url":"http://192.168.65.3:9443"}],"passHostHeader":true},"status":"enabled","usedBy":["compose-ap-docker-443-1a055e3db30bd9d5@rest"],"serverStatus":{"http://192.168.65.3:9443":"UP"}},"d-default-80-2329da148b27c5c4@rest":{"loadBalancer":{"servers":[{"url":"http://10.1.0.137:80"}],"passHostHeader":true},"status":"enabled","usedBy":["d-default-80-2329da148b27c5c4@rest"],"serverStatus":{"http://10.1.0.137:80":"UP"}},"e-default-80-99e3770fb2c461c9@rest":{"loadBalancer":{"servers":[{"url":"http://10.1.0.131:80"}],"passHostHeader":true},"status":"enabled","usedBy":["e-default-80-99e3770fb2c461c9@rest"],"serverStatus":{"http://10.1.0.131:80":"UP"}},"readiness@rest":{"loadBalancer":{"servers":[{"url":"http://127.0.0.1:8080"}],"passHostHeader":true},"status":"enabled","usedBy":["readiness@rest"],"serverStatus":{"http://127.0.0.1:8080":"UP"}}},"tcpRouters":{"tcp-default-80-5ac3efe372e6030a@rest":{"entryPoints":["tcp-10000"],"service":"tcp-default-80-5ac3efe372e6030a","rule":"HostSNI(`*`)","status":"enabled","using":["tcp-10000"]}},"tcpServices":{"tcp-default-80-5ac3efe372e6030a@rest":{"loadBalancer":{"terminationDelay":100,"servers":[{"address":"10.1.0.130:80"}]},"status":"enabled","usedBy":["tcp-default-80-5ac3efe372e6030a@rest"]}}}
```

Fixes #332 