### PR TITLE
Deploy to pods in parallel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/vdemeester/shakers v0.1.0
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	k8s.io/api v0.0.0-20190819141258-3544db3b9e44
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/client-go v0.0.0-20190819141724-e14f31a72a77

--- a/go.sum
+++ b/go.sum
@@ -431,6 +431,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180622082034-63fc586f45fe/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -559,7 +559,7 @@ func deployToPods(pods []corev1.Pod, config *dynamic.Configuration) error {
 
 		errg.Go(func() error {
 			b := backoff.NewExponentialBackOff()
-			b.MaxElapsedTime = time.Minute
+			b.MaxElapsedTime = 15 * time.Second
 
 			op := func() error {
 				return deployToPod(pod.Name, pod.Status.PodIP, config)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cenkalti/backoff/v3"
 	"github.com/containous/maesh/internal/k8s"
 	"github.com/containous/maesh/internal/providers/base"
 	"github.com/containous/maesh/internal/providers/kubernetes"
@@ -20,6 +21,7 @@ import (
 	smiSpecsExternalversions "github.com/deislabs/smi-sdk-go/pkg/gen/client/specs/informers/externalversions"
 	smiSplitExternalversions "github.com/deislabs/smi-sdk-go/pkg/gen/client/split/informers/externalversions"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -509,18 +511,68 @@ func (c *Controller) deployConfiguration(config *dynamic.Configuration) error {
 		return fmt.Errorf("unable to find any active mesh pods to deploy config : %+v", config)
 	}
 
-	for _, pod := range podList.Items {
-		log.Debugf("Deploying to pod %s with IP %s", pod.Name, pod.Status.PodIP)
-
-		if deployErr := c.deployToPod(pod.Name, pod.Status.PodIP, config); deployErr != nil {
-			return fmt.Errorf("error deploying configuration: %v", deployErr)
-		}
+	if err := deployToPods(podList.Items, config); err != nil {
+		return fmt.Errorf("error deploying configuration: %v", err)
 	}
 
 	return nil
 }
 
-func (c *Controller) deployToPod(name, ip string, config *dynamic.Configuration) error {
+// deployConfigurationToUnreadyNodes deploys the configuration to the mesh pods.
+func (c *Controller) deployConfigurationToUnreadyNodes(config *dynamic.Configuration) error {
+	podList, err := c.clients.ListPodWithOptions(c.meshNamespace, metav1.ListOptions{
+		LabelSelector: "component==maesh-mesh",
+	})
+	if err != nil {
+		return fmt.Errorf("unable to retrieve pod list: %v", err)
+	}
+
+	if len(podList.Items) == 0 {
+		return fmt.Errorf("unable to find any active mesh pods to deploy config : %+v", config)
+	}
+
+	var unreadyPods []corev1.Pod
+
+	for _, pod := range podList.Items {
+		for _, status := range pod.Status.ContainerStatuses {
+			if !status.Ready {
+				unreadyPods = append(unreadyPods, pod)
+				break
+			}
+		}
+	}
+
+	if err := deployToPods(unreadyPods, config); err != nil {
+		return fmt.Errorf("error deploying configuration: %v", err)
+	}
+
+	return nil
+}
+
+func deployToPods(pods []corev1.Pod, config *dynamic.Configuration) error {
+	var errg errgroup.Group
+
+	for _, p := range pods {
+		pod := p
+
+		log.Debugf("Deploying to pod %s with IP %s", pod.Name, pod.Status.PodIP)
+
+		errg.Go(func() error {
+			b := backoff.NewExponentialBackOff()
+			b.MaxElapsedTime = time.Minute
+
+			op := func() error {
+				return deployToPod(pod.Name, pod.Status.PodIP, config)
+			}
+
+			return backoff.Retry(safe.OperationWithRecover(op), b)
+		})
+	}
+
+	return errg.Wait()
+}
+
+func deployToPod(name, ip string, config *dynamic.Configuration) error {
 	if name == "" || ip == "" {
 		// If there is no name or ip, then just return.
 		return fmt.Errorf("pod has no name or IP")
@@ -562,40 +614,6 @@ func (c *Controller) deployToPod(name, ip string, config *dynamic.Configuration)
 
 	c.deployLog.LogDeploy(time.Now(), name, ip, true, "")
 	log.Debugf("Successfully deployed configuration to pod (%s:%s)", name, ip)
-
-	return nil
-}
-
-// deployConfigurationToUnreadyNodes deploys the configuration to the mesh pods.
-func (c *Controller) deployConfigurationToUnreadyNodes(config *dynamic.Configuration) error {
-	podList, err := c.clients.ListPodWithOptions(c.meshNamespace, metav1.ListOptions{
-		LabelSelector: "component==maesh-mesh",
-	})
-	if err != nil {
-		return fmt.Errorf("unable to retrieve pod list: %v", err)
-	}
-
-	if len(podList.Items) == 0 {
-		return fmt.Errorf("unable to find any active mesh pods to deploy config : %+v", config)
-	}
-
-	for _, pod := range podList.Items {
-		needsDeploy := false
-
-		for _, status := range pod.Status.ContainerStatuses {
-			if !status.Ready {
-				// If there is a non-ready container, trigger needs deploy, and break.
-				needsDeploy = true
-				break
-			}
-		}
-
-		if needsDeploy {
-			if deployErr := c.deployToPod(pod.Name, pod.Status.PodIP, config); deployErr != nil {
-				log.Debugf("Error deploying configuration: %v", deployErr)
-			}
-		}
-	}
 
 	return nil
 }


### PR DESCRIPTION
### What does this PR do

This PR makes the maesh controller deploy dynamic configuration in parallel.

Fixes: #244

### Additional information

- I'm relying on `golang.org/x/sync/errgroup` which is equivalent to `sync.WaitGroup` but cleaner. Is it OK ? 
- Each deployment goroutine applies a backoff with an hardcoded max elapsed time of ~1 minute~ 15 seconds. ~Do we want to make this configurable ?~
- I unattached `deployToPod` from  the Controller as it does not depend on any members of this struct. WDYT? 
- ~Opened as a draft 'cuz I'm not quite done testing :sweat_smile:~