### PR TITLE
Add examples to doc

### DIFF
--- a/docs/content/examples.md
+++ b/docs/content/examples.md
@@ -1,0 +1,236 @@
+# Examples
+
+Here are some examples on how to easily deploy Maesh on your cluster.
+
+??? Note "Prerequisites"
+    Before following those examples, make sure your cluster follows [the prerequisites for deploying Maesh](quickstart.md#prerequisites)
+
+## Simple Example
+
+Deploy those two yaml files on your Kubernetes cluster in order to add a simple backend example, available through HTTP and TCP.
+
+```yaml tab="namespace.yaml"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: whoami
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: whoami-server
+  namespace: whoami
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: whoami-client
+  namespace: whoami
+```
+
+```yaml tab="deployment.yaml"
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: whoami
+  namespace: whoami
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: whoami
+    spec:
+      serviceAccount: whoami-server
+      containers:
+      - name: whoami
+        image: containous/whoami:v1.4.0
+        imagePullPolicy: IfNotPresent
+
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: whoami-tcp
+  namespace: whoami
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: whoami-tcp
+    spec:
+      serviceAccount: whoami-server
+      containers:
+      - name: whoami-tcp
+        image: containous/whoamitcp:latest
+        imagePullPolicy: IfNotPresent
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+  namespace: whoami
+  labels:
+    app: whoami
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    name: whoami
+  selector:
+    app: whoami
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami-tcp
+  namespace: whoami
+  labels:
+    app: whoami-tcp
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: whoami-tcp
+  selector:
+    app: whoami-tcp
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: whoami-client
+  namespace: whoami
+spec:
+  serviceAccountName: whoami-client
+  containers:
+    - name: whoami-client
+      image: giantswarm/tiny-tools:3.9
+      command:
+      - "sleep"
+      - "3600"
+```
+
+You should now see the following when running `kubectl get pods -n whoami`:
+
+```text
+NAME                             READY   STATUS    RESTARTS   AGE
+pod/whoami-client                1/1     Running   0          11s
+pod/whoami-f4cbd7f9c-lddgq       1/1     Running   0          12s
+pod/whoami-f4cbd7f9c-zk4rb       1/1     Running   0          12s
+pod/whoami-tcp-7679bc465-ldlt2   1/1     Running   0          12s
+pod/whoami-tcp-7679bc465-wf87n   1/1     Running   0          12s
+
+NAME                 TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+service/whoami       ClusterIP   100.68.109.244   <none>        80/TCP     13s
+service/whoami-tcp   ClusterIP   100.68.73.211    <none>        8080/TCP   13s
+
+NAME                         DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/whoami       2         2         2            2           13s
+deployment.apps/whoami-tcp   2         2         2            2           13s
+
+NAME                                   DESIRED   CURRENT   READY   AGE
+replicaset.apps/whoami-f4cbd7f9c       2         2         2       13s
+replicaset.apps/whoami-tcp-7679bc465   2         2         2       13s
+```
+
+You should now be able to make direct requests on your `whoami` service through HTTP.
+
+```bash tab="Command"
+kubectl -n whoami exec whoami-client -- curl -s whoami.whoami.svc.cluster.local
+```
+
+```text tab="Expected Output"
+Hostname: whoami-84bdf87956-gvbm8
+IP: 127.0.0.1
+IP: 5.6.7.8
+RemoteAddr: 1.2.3.4:12345
+GET / HTTP/1.1
+Host: whoami.whoami.svc.cluster.local
+User-Agent: curl/7.64.0
+Accept: */*
+```
+
+And through TCP, by executing the following `netcat` command and sending some data.
+
+```bash tab="Command"
+kubectl -n whoami exec -ti whoami-client -- nc whoami-tcp.whoami.svc.cluster.local 8080
+my data
+```
+
+```text tab="Expected Output"
+Received: my data
+```
+
+You can now install Maesh [by following this documentation](install.md) on your cluster.
+
+Since Maesh is not intrusive, it has to be explicitly given access to services before it can be used. You can ensure that the HTTP endpoint of your service does not pass through Maesh since no `X-Forwarded-For` header should be added.
+
+Now, in order to configure Maesh for your `whoami` service, you just need to update the `whoami` service specs, in order to add the appropriate annotations.
+
+The HTTP service needs to have `maesh.containo.us/traffic-type: "http"` and the TCP service, `maesh.containo.us/traffic-type: "tcp"`.
+
+```yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+  namespace: whoami
+  labels:
+    app: whoami
+  annotations:
+    maesh.containo.us/traffic-type: "http"
+    maesh.containo.us/retry-attempts: "2"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    name: whoami
+  selector:
+    app: whoami
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami-tcp
+  namespace: whoami
+  labels:
+    app: whoami-tcp
+  annotations:
+    maesh.containo.us/traffic-type: "tcp"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      name: whoami-tcp
+  selector:
+    app: whoami-tcp
+
+```
+
+You should now be able to access your HTTP and TCP services through the Maesh endpoint:
+
+```bash tab="Command"
+kubectl -n whoami exec whoami-client -- curl -s whoami.whoami.maesh
+```
+
+```text tab="Expected Output"
+Hostname: whoami-84bdf87956-gvbm8
+IP: 127.0.0.1
+IP: 5.6.7.8
+RemoteAddr: 1.2.3.4:12345
+GET / HTTP/1.1
+Host: whoami.whoami.svc.cluster.local
+User-Agent: curl/7.64.0
+Accept: */*
+X-Forwarded-For: 3.4.5.6
+```

--- a/docs/content/examples.md
+++ b/docs/content/examples.md
@@ -186,6 +186,7 @@ metadata:
   namespace: whoami
   labels:
     app: whoami
+  # These annotations enable Maesh for this service:
   annotations:
     maesh.containo.us/traffic-type: "http"
     maesh.containo.us/retry-attempts: "2"
@@ -205,6 +206,7 @@ metadata:
   namespace: whoami
   labels:
     app: whoami-tcp
+  # These annotations enable Maesh for this service:
   annotations:
     maesh.containo.us/traffic-type: "tcp"
 spec:

--- a/docs/content/examples.md
+++ b/docs/content/examples.md
@@ -34,12 +34,15 @@ metadata:
 ```yaml tab="deployment.yaml"
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: whoami
   namespace: whoami
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: whoami
   template:
     metadata:
       labels:
@@ -53,12 +56,15 @@ spec:
 
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: whoami-tcp
   namespace: whoami
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: whoami-tcp
   template:
     metadata:
       labels:
@@ -118,7 +124,7 @@ spec:
       - "3600"
 ```
 
-You should now see the following when running `kubectl get pods -n whoami`:
+You should now see the following when running `kubectl get all -n whoami`:
 
 ```text
 NAME                             READY   STATUS    RESTARTS   AGE

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -53,8 +53,36 @@ helm install --name=maesh --namespace=maesh maesh/maesh --set clusterDomain=my.c
 
 ## Installation namespace
 
-Maesh does not _need_ to be installed into the maesh namespace, 
+Maesh does not _need_ to be installed into the `maesh` namespace, 
 but it does need to be installed into its _own_ namespace, separate from user namespaces.
+
+## Verify your installation
+
+You can check that Maesh has been installed properly by running the following command:
+
+```bash tab="Command"
+kubectl get all -n maesh
+```
+
+```text tab="Expected Output"
+
+NAME                                    READY   STATUS    RESTARTS   AGE
+pod/maesh-controller-676fb86b89-pj8ph   1/1     Running   0          11s
+pod/maesh-mesh-w62z5                    1/1     Running   0          11s
+pod/maesh-mesh-zjlpf                    1/1     Running   0          11s
+
+NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+service/maesh-mesh-api   ClusterIP   100.69.177.254   <none>        8080/TCP   29s
+
+NAME                        DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+daemonset.apps/maesh-mesh   2         2         0       2            0           <none>          29s
+
+NAME                               DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/maesh-controller   1         1         1            0           28s
+
+NAME                                          DESIRED   CURRENT   READY   AGE
+replicaset.apps/maesh-controller-676fb86b89   1         1         0       28s
+```
 
 ## Usage
 

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -37,3 +37,7 @@ helm installation to perform all steps it needs is to edit the
 
 Assuming `tiller` is deployed in your `kube-system` namespace, this will
 give it very open permissions.
+
+### Installation Examples
+
+See the [examples page](examples.md) to see how to easily deploy Maesh and configure your services to use it.

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -11,6 +11,12 @@ helm repo update
 helm install --name=maesh --namespace=maesh maesh/maesh
 ```
 
+## Prerequisites
+
+- Kubernetes 1.11+
+- CoreDNS installed as [Cluster DNS Provider](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/) (versions 1.3+ supported)
+- Helm v2 with a [working tiller service account](https://helm.sh/docs/using_helm/#installing-tiller)
+
 ## RBAC
 
 Depending on the tool you used to deploy your cluster you might need

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -66,3 +66,4 @@ nav:
   - 'Quickstart': 'quickstart.md'
   - 'Installation': 'install.md'
   - 'Configuration': 'configuration.md'
+  - 'Examples': 'examples.md'


### PR DESCRIPTION
## Goal of this PR

Fixes #267 
Fixes #319 
Fixes #269 

This PR adds an example page to the documentation, with YAML snippets of example services.

It also adds a link in the quickstart page to the examples page, as well as adds the prerequisites to the documentation, in the install page (they were only in the README.md before and not in the doc)

## How to test it

* `cd docs ; make serve`
* Ensure that links are working
* Ensure that notes and command blocks (and their tabs) are working
* Look out for typos etc.