### PR TITLE
Create a cap for the max number of deploy log entries

### DIFF
--- a/internal/controller/api.go
+++ b/internal/controller/api.go
@@ -108,9 +108,17 @@ func (a *API) getReadiness(w http.ResponseWriter, r *http.Request) {
 
 // getDeployLog returns the current deploylog.
 func (a *API) getDeployLog(w http.ResponseWriter, r *http.Request) {
+	entries := a.deployLog.GetLog()
+
+	data, err := json.Marshal(entries)
+	if err != nil {
+		writeErrorResponse(w, fmt.Sprintf("unable to marshal deploy log entries: %v", err), http.StatusInternalServerError)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 
-	if _, err := w.Write(a.deployLog.GetLog()); err != nil {
+	if _, err := w.Write(data); err != nil {
 		log.Error(err)
 	}
 }

--- a/internal/controller/api_test.go
+++ b/internal/controller/api_test.go
@@ -75,7 +75,7 @@ func TestGetCurrentConfiguration(t *testing.T) {
 
 func TestGetDeployLog(t *testing.T) {
 	config := safe.Safe{}
-	log := NewDeployLog()
+	log := NewDeployLog(1000)
 	api := NewAPI(9000, &config, log, nil, "foo")
 
 	currentTime := time.Now()

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -99,7 +99,7 @@ func (c *Controller) Init() error {
 
 	c.tcpStateTable = &k8s.State{Table: make(map[int]*k8s.ServiceWithPort)}
 
-	c.deployLog = NewDeployLog()
+	c.deployLog = NewDeployLog(1000)
 	c.api = NewAPI(c.apiPort, &c.lastConfiguration, c.deployLog, c.clients, c.meshNamespace)
 
 	if c.smiEnabled {

--- a/internal/controller/log.go
+++ b/internal/controller/log.go
@@ -63,8 +63,3 @@ func (d *DeployLog) LogDeploy(timeStamp time.Time, podName string, podIP string,
 func (d *DeployLog) GetLog() []Entry {
 	return d.entries
 }
-
-// Len returns the number of records in the entries slice.
-func (d *DeployLog) Len() int {
-	return len(d.entries)
-}

--- a/internal/controller/log.go
+++ b/internal/controller/log.go
@@ -1,13 +1,13 @@
 package controller
 
 import (
-	"encoding/json"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 )
 
-type logEntry struct {
+// Entry holds the details of a deployment.
+type Entry struct {
 	TimeStamp        time.Time
 	PodName          string
 	PodIP            string
@@ -17,7 +17,7 @@ type logEntry struct {
 
 // DeployLog holds a slice of log entries.
 type DeployLog struct {
-	entries    []logEntry
+	entries    []Entry
 	maxEntries int
 }
 
@@ -43,7 +43,7 @@ func (d *DeployLog) Init() error {
 
 // LogDeploy adds a record to the entries list.
 func (d *DeployLog) LogDeploy(timeStamp time.Time, podName string, podIP string, deploySuccessful bool, reason string) {
-	newEntry := logEntry{
+	newEntry := Entry{
 		TimeStamp:        timeStamp,
 		PodName:          podName,
 		PodIP:            podIP,
@@ -51,25 +51,20 @@ func (d *DeployLog) LogDeploy(timeStamp time.Time, podName string, podIP string,
 		Reason:           reason,
 	}
 
-	if len(d.entries) >= d.maxEntries {
+	for len(d.entries) > d.maxEntries {
 		// Pull elements off the front of the slice to make sure that the newly appended record is under the max record value.
-		d.entries = d.entries[(len(d.entries)-d.maxEntries)+1:]
+		d.entries = d.entries[1:]
 	}
 
 	d.entries = append(d.entries, newEntry)
 }
 
 // GetLog returns a json representation of the entries list.
-func (d *DeployLog) GetLog() []byte {
-	data, err := json.Marshal(d.entries)
-	if err != nil {
-		log.Error("Could not marshal deploylog entries")
-	}
-
-	return data
+func (d *DeployLog) GetLog() []Entry {
+	return d.entries
 }
 
-// GetLogLength returns the number of records in the entries slice.
-func (d *DeployLog) GetLogLength() int {
+// Len returns the number of records in the entries slice.
+func (d *DeployLog) Len() int {
 	return len(d.entries)
 }

--- a/internal/controller/log.go
+++ b/internal/controller/log.go
@@ -51,8 +51,8 @@ func (d *DeployLog) LogDeploy(timeStamp time.Time, podName string, podIP string,
 		Reason:           reason,
 	}
 
-	for len(d.entries) > d.maxEntries {
-		// Pull elements off the front of the slice to make sure that the newly appended record is under the max record value.
+	for len(d.entries) >= d.maxEntries {
+		// Pull elements off the front of the slice to make sure that the newly appended record is one under the max record value.
 		d.entries = d.entries[1:]
 	}
 

--- a/internal/controller/log_test.go
+++ b/internal/controller/log_test.go
@@ -41,10 +41,8 @@ func TestLogRotationAndGetLogLength(t *testing.T) {
 	}
 
 	assert.Equal(t, 10, len(log.entries))
-	assert.Equal(t, 10, log.Len())
 
 	log.LogDeploy(time.Now(), "foo", "bar", true, "blabla")
 
 	assert.Equal(t, 10, len(log.entries))
-	assert.Equal(t, 10, log.Len())
 }

--- a/internal/controller/log_test.go
+++ b/internal/controller/log_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -24,7 +25,10 @@ func TestGetLog(t *testing.T) {
 
 	currentTimeString := string(data)
 
-	actual := string(log.GetLog())
+	data, err = json.Marshal(log.GetLog())
+	assert.NoError(t, err)
+
+	actual := string(data)
 	expected := fmt.Sprintf("[{\"TimeStamp\":%s,\"PodName\":\"foo\",\"PodIP\":\"bar\",\"DeploySuccessful\":true,\"Reason\":\"blabla\"}]", currentTimeString)
 	assert.Equal(t, expected, actual)
 }
@@ -37,10 +41,10 @@ func TestLogRotationAndGetLogLength(t *testing.T) {
 	}
 
 	assert.Equal(t, 10, len(log.entries))
-	assert.Equal(t, 10, log.GetLogLength())
+	assert.Equal(t, 10, log.Len())
 
 	log.LogDeploy(time.Now(), "foo", "bar", true, "blabla")
 
 	assert.Equal(t, 10, len(log.entries))
-	assert.Equal(t, 10, log.GetLogLength())
+	assert.Equal(t, 10, log.Len())
 }

--- a/internal/controller/log_test.go
+++ b/internal/controller/log_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestLogDeploy(t *testing.T) {
-	log := NewDeployLog()
+	log := NewDeployLog(1000)
 	log.LogDeploy(time.Now(), "foo", "bar", true, "blabla")
-	assert.Equal(t, 1, len(log.Entries))
+	assert.Equal(t, 1, len(log.entries))
 }
 
 func TestGetLog(t *testing.T) {
-	log := NewDeployLog()
+	log := NewDeployLog(1000)
 	currentTime := time.Now()
 	log.LogDeploy(currentTime, "foo", "bar", true, "blabla")
 
@@ -27,4 +27,18 @@ func TestGetLog(t *testing.T) {
 	actual := string(log.GetLog())
 	expected := fmt.Sprintf("[{\"TimeStamp\":%s,\"PodName\":\"foo\",\"PodIP\":\"bar\",\"DeploySuccessful\":true,\"Reason\":\"blabla\"}]", currentTimeString)
 	assert.Equal(t, expected, actual)
+}
+
+func TestLogRotationAndGetLogLength(t *testing.T) {
+	log := NewDeployLog(10)
+	for i := 0; i < 10; i++ {
+		log.LogDeploy(time.Now(), "foo", "bar", true, "blabla")
+	}
+	assert.Equal(t, 10, len(log.entries))
+	assert.Equal(t, 10, log.GetLogLength())
+
+	log.LogDeploy(time.Now(), "foo", "bar", true, "blabla")
+
+	assert.Equal(t, 10, len(log.entries))
+	assert.Equal(t, 10, log.GetLogLength())
 }

--- a/internal/controller/log_test.go
+++ b/internal/controller/log_test.go
@@ -31,9 +31,11 @@ func TestGetLog(t *testing.T) {
 
 func TestLogRotationAndGetLogLength(t *testing.T) {
 	log := NewDeployLog(10)
+
 	for i := 0; i < 10; i++ {
 		log.LogDeploy(time.Now(), "foo", "bar", true, "blabla")
 	}
+
 	assert.Equal(t, 10, len(log.entries))
 	assert.Equal(t, 10, log.GetLogLength())
 


### PR DESCRIPTION
This PR:

- Creates a log rotation scheme where old records are removed
- Adds tests to ensure the rotation works

Fixes #334 