### PR TITLE
Bundle SMI CRD's with helm install

### DIFF
--- a/helm/chart/maesh/templates/controller/controller-deployment.yaml
+++ b/helm/chart/maesh/templates/controller/controller-deployment.yaml
@@ -70,7 +70,7 @@ spec:
             {{- if .Values.mesh }}
             - "--defaultMode={{ .Values.mesh.defaultMode }}"
             {{- end }}
-            {{- if .Values.smi }}
+            {{- if .Values.smi.enable }}
             - "--smi"
             {{- end }}
             - "--namespace=$(POD_NAMESPACE)"

--- a/helm/chart/maesh/templates/smi/smi-access.yaml
+++ b/helm/chart/maesh/templates/smi/smi-access.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.smi.deploy }}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: traffictargets.access.smi-spec.io
+spec:
+  group: access.smi-spec.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: TrafficTarget
+    shortNames:
+      - tt
+    plural: traffictargets
+    singular: traffictarget
+{{- end }}

--- a/helm/chart/maesh/templates/smi/smi-access.yaml
+++ b/helm/chart/maesh/templates/smi/smi-access.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.smi.deploy }}
+{{- if .Values.smi.deploycrds }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/helm/chart/maesh/templates/smi/smi-spec.yaml
+++ b/helm/chart/maesh/templates/smi/smi-spec.yaml
@@ -4,8 +4,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: httproutegroups.specs.smi-spec.io
-#  annotations:
-#    "helm.sh/hook": crd-install
 spec:
   group: specs.smi-spec.io
   version: v1alpha1

--- a/helm/chart/maesh/templates/smi/smi-spec.yaml
+++ b/helm/chart/maesh/templates/smi/smi-spec.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.smi.deploy }}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: httproutegroups.specs.smi-spec.io
+#  annotations:
+#    "helm.sh/hook": crd-install
+spec:
+  group: specs.smi-spec.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: HTTPRouteGroup
+    shortNames:
+      - htr
+    plural: httproutegroups
+    singular: httproutegroup
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tcproutes.specs.smi-spec.io
+spec:
+  group: specs.smi-spec.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: TCPRoute
+    shortNames:
+      - tr
+    plural: tcproutes
+    singular: tcproute
+{{- end }}

--- a/helm/chart/maesh/templates/smi/smi-spec.yaml
+++ b/helm/chart/maesh/templates/smi/smi-spec.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.smi.deploy }}
+{{- if .Values.smi.deploycrds }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/helm/chart/maesh/templates/smi/smi-trafficsplits.yaml
+++ b/helm/chart/maesh/templates/smi/smi-trafficsplits.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.smi.deploy }}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: trafficsplits.split.smi-spec.io
+spec:
+  group: split.smi-spec.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: TrafficSplit
+    shortNames:
+      - ts
+    plural: trafficsplits
+    singular: trafficsplit
+  additionalPrinterColumns:
+    - name: Service
+      type: string
+      description: The apex service of this split.
+      JSONPath: .spec.service
+{{- end }}

--- a/helm/chart/maesh/templates/smi/smi-trafficsplits.yaml
+++ b/helm/chart/maesh/templates/smi/smi-trafficsplits.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.smi.deploy }}
+{{- if .Values.smi.deploycrds }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -68,7 +68,9 @@ metrics:
   prometheus:
     enabled: true
 
-smi: false
+smi:
+  deploy: true
+  enable: false
 
 limits:
   http: 10

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -69,7 +69,7 @@ metrics:
     enabled: true
 
 smi:
-  deploy: true
+  deploycrds: true
   enable: false
 
 limits:

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -269,7 +269,7 @@ func (s *BaseSuite) installHelmMaesh(_ *check.C, smi bool, kubeDNS bool) error {
 	argSlice := []string{"install", "../helm/chart/maesh", "--values", "resources/values.yaml", "--name", "powpow", "--namespace", "maesh"}
 
 	if smi {
-		argSlice = append(argSlice, "--set", "smi=true")
+		argSlice = append(argSlice, "--set", "smi.enable=true")
 	}
 
 	if kubeDNS {

--- a/integration/resources/values.yaml
+++ b/integration/resources/values.yaml
@@ -56,7 +56,10 @@ metrics:
   prometheus:
     enabled: false
 
-smi: false
+smi:
+  deploy: false
+  enable: false
+
 kubedns: false
 
 limits:

--- a/integration/resources/values.yaml
+++ b/integration/resources/values.yaml
@@ -57,7 +57,7 @@ metrics:
     enabled: false
 
 smi:
-  deploy: false
+  deploycrds: false
   enable: false
 
 kubedns: false


### PR DESCRIPTION
Fixes #217 

That PR adds the option to install the SMI CRD's together with the normal installation of maesh.