### PR TITLE
Run in single namespace

### DIFF
--- a/helm/chart/maesh/templates/controller/controller-deployment.yaml
+++ b/helm/chart/maesh/templates/controller/controller-deployment.yaml
@@ -113,6 +113,12 @@ spec:
             {{- end }}
             - "--clusterdomain"
             - {{ default "cluster.local" .Values.clusterDomain | quote }}
+            - "--namespace=$(POD_NAMESPACE)"
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           securityContext:
             capabilities:
               drop:

--- a/helm/chart/maesh/templates/mesh/mesh-service.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: maesh-mesh-api
   namespace: {{ .Release.Namespace }}
   labels:
-    app: mesh-api
+    app: maesh
 spec:
   type: ClusterIP
   ports:

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -103,7 +103,7 @@ func (c *Controller) Init() error {
 	c.api = NewAPI(c.apiPort, &c.lastConfiguration, c.deployLog, c.clients, c.meshNamespace)
 
 	if c.smiEnabled {
-		c.provider = smi.New(c.clients, c.defaultMode, c.meshNamespace, c.tcpStateTable, c.ignored)
+		c.provider = smi.New(c.clients, c.defaultMode, c.tcpStateTable, c.ignored)
 		// Create new SharedInformerFactories, and register the event handler to informers.
 		c.smiAccessFactory = smiAccessExternalversions.NewSharedInformerFactoryWithOptions(c.clients.SmiAccessClient, k8s.ResyncPeriod)
 		c.smiAccessFactory.Access().V1alpha1().TrafficTargets().Informer().AddEventHandler(c.handler)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -239,8 +239,6 @@ func (c *Controller) createMeshServices() error {
 		return fmt.Errorf("unable to get maesh services: %v", err)
 	}
 
-	// Use a map here to have lookups in log(N), so were O(n*log(n)) and not O(n^2) on this algorithm.
-	// N being the amount of services in the cluster, this can be important.
 	maeshSvcsByName := reduceServicesByName(maeshSvcs)
 
 	for _, service := range potentialSvcs {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -311,8 +311,7 @@ func (c *Controller) createMeshService(service *corev1.Service) error {
 				Name:      meshServiceName,
 				Namespace: c.meshNamespace,
 				Labels: map[string]string{
-					"app":       "maesh",
-					"component": "maesh-svc",
+					"app": "maesh",
 				},
 			},
 			Spec: corev1.ServiceSpec{

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -232,12 +232,12 @@ func (c *Controller) createMeshServices() error {
 
 	sel, err := c.ignored.LabelSelector()
 	if err != nil {
-		return fmt.Errorf("unable to build label selectors: %v", err)
+		return fmt.Errorf("unable to build label selectors: %w", err)
 	}
 
 	potentialSvcs, err := svcs.List(sel)
 	if err != nil {
-		return fmt.Errorf("unable to get services: %v", err)
+		return fmt.Errorf("unable to get services: %w", err)
 	}
 
 	for _, service := range potentialSvcs {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -302,6 +302,9 @@ func (c *Controller) createMeshService(service *corev1.Service) error {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      meshServiceName,
 				Namespace: c.meshNamespace,
+				Labels: map[string]string{
+					"app": "maesh",
+				},
 			},
 			Spec: corev1.ServiceSpec{
 				Ports: ports,

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -118,7 +118,7 @@ func (c *Controller) Init() error {
 	}
 
 	// If SMI is not configured, use the kubernetes provider.
-	c.provider = kubernetes.New(c.clients, c.defaultMode, c.meshNamespace, c.tcpStateTable, c.ignored)
+	c.provider = kubernetes.New(c.clients, c.defaultMode, c.tcpStateTable, c.ignored)
 
 	return nil
 }

--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -48,7 +48,7 @@ func (h *Handler) OnAdd(obj interface{}) {
 	// assert the type to an object to pull out relevant data
 	switch obj := obj.(type) {
 	case *corev1.Service:
-		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace) {
+		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace, obj.GetLabels()["app"]) {
 			return
 		}
 
@@ -72,7 +72,7 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 	// Assert the type to an object to pull out relevant data.
 	switch obj := newObj.(type) {
 	case *corev1.Service:
-		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace) {
+		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace, obj.GetLabels()["app"]) {
 			return
 		}
 
@@ -84,7 +84,7 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 		log.Debugf("MeshControllerHandler ObjectUpdated with type: *corev1.Service: %s/%s", obj.Namespace, obj.Name)
 	case *corev1.Endpoints:
 		// We can use the same ignore for services and endpoints.
-		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace) {
+		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace, obj.GetLabels()["app"]) {
 			return
 		}
 
@@ -111,7 +111,7 @@ func (h *Handler) OnDelete(obj interface{}) {
 	// Assert the type to an object to pull out relevant data.
 	switch obj := obj.(type) {
 	case *corev1.Service:
-		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace) {
+		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace, obj.GetLabels()["app"]) {
 			return
 		}
 
@@ -122,7 +122,7 @@ func (h *Handler) OnDelete(obj interface{}) {
 		}
 	case *corev1.Endpoints:
 		// We can use the same ignore for services and endpoints.
-		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace) {
+		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace, obj.GetLabels()["app"]) {
 			return
 		}
 

--- a/internal/controller/handler.go
+++ b/internal/controller/handler.go
@@ -48,7 +48,7 @@ func (h *Handler) OnAdd(obj interface{}) {
 	// assert the type to an object to pull out relevant data
 	switch obj := obj.(type) {
 	case *corev1.Service:
-		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace, obj.GetLabels()["app"]) {
+		if h.ignored.IsIgnored(obj.ObjectMeta) {
 			return
 		}
 
@@ -72,7 +72,7 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 	// Assert the type to an object to pull out relevant data.
 	switch obj := newObj.(type) {
 	case *corev1.Service:
-		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace, obj.GetLabels()["app"]) {
+		if h.ignored.IsIgnored(obj.ObjectMeta) {
 			return
 		}
 
@@ -84,7 +84,7 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 		log.Debugf("MeshControllerHandler ObjectUpdated with type: *corev1.Service: %s/%s", obj.Namespace, obj.Name)
 	case *corev1.Endpoints:
 		// We can use the same ignore for services and endpoints.
-		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace, obj.GetLabels()["app"]) {
+		if h.ignored.IsIgnored(obj.ObjectMeta) {
 			return
 		}
 
@@ -111,7 +111,7 @@ func (h *Handler) OnDelete(obj interface{}) {
 	// Assert the type to an object to pull out relevant data.
 	switch obj := obj.(type) {
 	case *corev1.Service:
-		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace, obj.GetLabels()["app"]) {
+		if h.ignored.IsIgnored(obj.ObjectMeta) {
 			return
 		}
 
@@ -122,7 +122,7 @@ func (h *Handler) OnDelete(obj interface{}) {
 		}
 	case *corev1.Endpoints:
 		// We can use the same ignore for services and endpoints.
-		if h.ignored.IsIgnoredService(obj.Name, obj.Namespace, obj.GetLabels()["app"]) {
+		if h.ignored.IsIgnored(obj.ObjectMeta) {
 			return
 		}
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -585,9 +585,16 @@ func (w *ClientWrapper) GetService(namespace, name string) (*corev1.Service, boo
 
 // GetServices retrieves the services from the specified namespace.
 func (w *ClientWrapper) GetServices(namespace string) ([]*corev1.Service, error) {
+	return w.GetServicesWithSelectors(namespace, "", "")
+}
+
+// GetServicesWithSelectors retrieves the services from the specified namespace and given selectors.
+func (w *ClientWrapper) GetServicesWithSelectors(namespace string, labelSelectors, fieldSelector string) ([]*corev1.Service, error) {
 	var result []*corev1.Service
 
-	list, err := w.KubeClient.CoreV1().Services(namespace).List(metav1.ListOptions{})
+	list, err := w.KubeClient.CoreV1().Services(namespace).List(
+		metav1.ListOptions{LabelSelector: labelSelectors, FieldSelector: fieldSelector},
+	)
 	if err != nil {
 		return result, err
 	}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -585,16 +585,9 @@ func (w *ClientWrapper) GetService(namespace, name string) (*corev1.Service, boo
 
 // GetServices retrieves the services from the specified namespace.
 func (w *ClientWrapper) GetServices(namespace string) ([]*corev1.Service, error) {
-	return w.GetServicesWithSelectors(namespace, "", "")
-}
-
-// GetServicesWithSelectors retrieves the services from the specified namespace and given selectors.
-func (w *ClientWrapper) GetServicesWithSelectors(namespace string, labelSelectors, fieldSelector string) ([]*corev1.Service, error) {
 	var result []*corev1.Service
 
-	list, err := w.KubeClient.CoreV1().Services(namespace).List(
-		metav1.ListOptions{LabelSelector: labelSelectors, FieldSelector: fieldSelector},
-	)
+	list, err := w.KubeClient.CoreV1().Services(namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return result, err
 	}

--- a/internal/k8s/ignore.go
+++ b/internal/k8s/ignore.go
@@ -41,7 +41,7 @@ func (i *IgnoreWrapper) FieldSelector() string {
 		selectors = append(selectors, "metadata.namespace!="+n)
 	}
 
-	// TODO: loosing the filter by specifng namespace and service name here, but not sure if it's needed.
+	// We are loosing the filter by specifng namespace and service name here, but not sure if it's needed.
 	for _, n := range i.Services {
 		selectors = append(selectors, "metadata.name!="+n.Name)
 	}
@@ -82,10 +82,5 @@ func (i *IgnoreWrapper) IsIgnoredService(name, namespace, app string) bool {
 
 // IsIgnoredNamespace returns if the service's events should be ignored.
 func (i *IgnoreWrapper) IsIgnoredNamespace(namespace string) bool {
-	// Is the namespace ignored?
-	if i.Namespaces.Contains(namespace) {
-		return true
-	}
-
-	return false
+	return i.Namespaces.Contains(namespace)
 }

--- a/internal/k8s/ignore.go
+++ b/internal/k8s/ignore.go
@@ -1,24 +1,21 @@
 package k8s
 
+import "strings"
+
 // IgnoreWrapper holds namespaces and services to ignore.
 type IgnoreWrapper struct {
-	Namespaces    Namespaces
-	Services      Services
-	MeshNamespace string
+	Namespaces Namespaces
+	Services   Services
+	Apps       []string
 }
 
 // NewIgnored returns a new IgnoreWrapper.
 func NewIgnored() IgnoreWrapper {
 	return IgnoreWrapper{
-		Namespaces:    Namespaces{},
-		Services:      Services{},
-		MeshNamespace: "",
+		Namespaces: Namespaces{},
+		Services:   Services{},
+		Apps:       []string{},
 	}
-}
-
-// SetMeshNamespace sets the meshNamespace.
-func (i *IgnoreWrapper) SetMeshNamespace(namespace string) {
-	i.MeshNamespace = namespace
 }
 
 // AddIgnoredNamespace adds a namespace to the list of ignored namespaces.
@@ -31,8 +28,40 @@ func (i *IgnoreWrapper) AddIgnoredService(serviceName, serviceNamespace string) 
 	i.Services = append(i.Services, Service{Name: serviceName, Namespace: serviceNamespace})
 }
 
+// AddIgnoredApps add an app to the list of ignored apps.
+func (i *IgnoreWrapper) AddIgnoredApps(app ...string) {
+	i.Apps = append(i.Apps, app...)
+}
+
+// FieldSelector returns the field selectors query representing the ignored namespace and services.
+func (i *IgnoreWrapper) FieldSelector() string {
+	var selectors []string
+
+	for _, n := range i.Namespaces {
+		selectors = append(selectors, "metadata.namespace!="+n)
+	}
+
+	// TODO: loosing the filter by specifng namespace and service name here, but not sure if it's needed.
+	for _, n := range i.Services {
+		selectors = append(selectors, "metadata.name!="+n.Name)
+	}
+
+	return strings.Join(selectors, ",")
+}
+
+// LabelSelector returns the label selector representing the ignored apps.
+func (i *IgnoreWrapper) LabelSelector() string {
+	var selectors []string
+
+	for _, a := range i.Apps {
+		selectors = append(selectors, "app!="+a)
+	}
+
+	return strings.Join(selectors, ",")
+}
+
 // IsIgnoredService returns if the service's events should be ignored.
-func (i *IgnoreWrapper) IsIgnoredService(name, namespace string) bool {
+func (i *IgnoreWrapper) IsIgnoredService(name, namespace, app string) bool {
 	// Is the service's namespace ignored?
 	if i.Namespaces.Contains(namespace) {
 		return true
@@ -43,8 +72,8 @@ func (i *IgnoreWrapper) IsIgnoredService(name, namespace string) bool {
 		return true
 	}
 
-	// Is the service in the mesh namespace?
-	if i.MeshNamespace != "" && namespace == i.MeshNamespace {
+	// Is the app ignored ?
+	if contains(i.Apps, app) {
 		return true
 	}
 
@@ -55,11 +84,6 @@ func (i *IgnoreWrapper) IsIgnoredService(name, namespace string) bool {
 func (i *IgnoreWrapper) IsIgnoredNamespace(namespace string) bool {
 	// Is the namespace ignored?
 	if i.Namespaces.Contains(namespace) {
-		return true
-	}
-
-	// Is the namespace the mesh namespace?
-	if i.MeshNamespace != "" && namespace == i.MeshNamespace {
 		return true
 	}
 

--- a/internal/k8s/ignore.go
+++ b/internal/k8s/ignore.go
@@ -1,6 +1,10 @@
 package k8s
 
-import "strings"
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 // IgnoreWrapper holds namespaces and services to ignore.
 type IgnoreWrapper struct {
@@ -60,20 +64,20 @@ func (i *IgnoreWrapper) LabelSelector() string {
 	return strings.Join(selectors, ",")
 }
 
-// IsIgnoredService returns if the service's events should be ignored.
-func (i *IgnoreWrapper) IsIgnoredService(name, namespace, app string) bool {
-	// Is the service's namespace ignored?
-	if i.Namespaces.Contains(namespace) {
+// IsIgnored returns if the object events should be ignored.
+func (i *IgnoreWrapper) IsIgnored(obj metav1.ObjectMeta) bool {
+	// Is the object's namespace ignored?
+	if i.Namespaces.Contains(obj.GetNamespace()) {
 		return true
 	}
 
-	// Is the service explicitly ignored?
-	if i.Services.Contains(name, namespace) {
+	// Is the object explicitly ignored?
+	if i.Services.Contains(obj.GetName(), obj.GetNamespace()) {
 		return true
 	}
 
 	// Is the app ignored ?
-	if contains(i.Apps, app) {
+	if contains(i.Apps, obj.GetLabels()["app"]) {
 		return true
 	}
 

--- a/internal/k8s/ignore_test.go
+++ b/internal/k8s/ignore_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIgnoredNamespace(t *testing.T) {
@@ -92,8 +93,18 @@ func TestIgnoredService(t *testing.T) {
 			i.AddIgnoredNamespace("someNamespace")
 			i.AddIgnoredService("foo", "bar")
 			i.AddIgnoredApps("ignoredapp")
-			actual := i.IsIgnoredService(test.name, test.namespace, test.app)
+			actual := i.IsIgnored(buildMeta(test.name, test.namespace, test.app))
 			assert.Equal(t, test.expected, actual)
 		})
+	}
+}
+
+func buildMeta(name, ns, app string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: ns,
+		Labels: map[string]string{
+			"app": app,
+		},
 	}
 }

--- a/internal/k8s/ignore_test.go
+++ b/internal/k8s/ignore_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestIgnoredNamespace(t *testing.T) {
-	meshNamespace := "maesh"
 	testCases := []struct {
 		desc      string
 		namespace string
@@ -31,7 +30,7 @@ func TestIgnoredNamespace(t *testing.T) {
 		{
 			desc:      "ignored mesh namespace",
 			namespace: "maesh",
-			expected:  true,
+			expected:  false,
 		},
 	}
 
@@ -40,7 +39,6 @@ func TestIgnoredNamespace(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			i := NewIgnored()
-			i.SetMeshNamespace(meshNamespace)
 			i.AddIgnoredNamespace("someNamespace")
 			actual := i.IsIgnoredNamespace(test.namespace)
 			assert.Equal(t, test.expected, actual)
@@ -49,35 +47,39 @@ func TestIgnoredNamespace(t *testing.T) {
 }
 
 func TestIgnoredService(t *testing.T) {
-	meshNamespace := "maesh"
 	testCases := []struct {
 		desc      string
 		name      string
 		namespace string
+		app       string
 		expected  bool
 	}{
 		{
 			desc:      "empty ignored",
 			name:      "",
 			namespace: "",
+			app:       "",
 			expected:  false,
 		},
 		{
 			desc:      "ignored service due to namespace",
 			name:      "foo",
 			namespace: "someNamespace",
+			app:       "notignored",
 			expected:  true,
 		},
 		{
 			desc:      "explicit ignored service",
 			name:      "foo",
 			namespace: "bar",
+			app:       "notignored",
 			expected:  true,
 		},
 		{
-			desc:      "ignored mesh service",
+			desc:      "ignored app",
 			name:      "omg",
-			namespace: "maesh",
+			namespace: "foo",
+			app:       "ignoredapp",
 			expected:  true,
 		},
 	}
@@ -87,10 +89,10 @@ func TestIgnoredService(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			i := NewIgnored()
-			i.SetMeshNamespace(meshNamespace)
 			i.AddIgnoredNamespace("someNamespace")
 			i.AddIgnoredService("foo", "bar")
-			actual := i.IsIgnoredService(test.name, test.namespace)
+			i.AddIgnoredApps("ignoredapp")
+			actual := i.IsIgnoredService(test.name, test.namespace, test.app)
 			assert.Equal(t, test.expected, actual)
 		})
 	}

--- a/internal/k8s/namespace.go
+++ b/internal/k8s/namespace.go
@@ -5,7 +5,11 @@ type Namespaces []string
 
 // Contains returns true if x is in the slice, false otherwise.
 func (n Namespaces) Contains(x string) bool {
-	for _, v := range n {
+	return contains(n, x)
+}
+
+func contains(s []string, x string) bool {
+	for _, v := range s {
 		if x == v {
 			return true
 		}

--- a/internal/providers/kubernetes/provider.go
+++ b/internal/providers/kubernetes/provider.go
@@ -134,7 +134,7 @@ func (p *Provider) BuildConfig() (*dynamic.Configuration, error) {
 	config := base.CreateBaseConfigWithReadiness()
 
 	for _, service := range services {
-		if p.ignored.IsIgnoredService(service.Name, service.Namespace, service.GetLabels()["app"]) {
+		if p.ignored.IsIgnored(service.ObjectMeta) {
 			continue
 		}
 

--- a/internal/providers/kubernetes/provider.go
+++ b/internal/providers/kubernetes/provider.go
@@ -136,7 +136,7 @@ func (p *Provider) BuildConfig() (*dynamic.Configuration, error) {
 	config := base.CreateBaseConfigWithReadiness()
 
 	for _, service := range services {
-		if p.ignored.IsIgnoredService(service.Name, service.Namespace) {
+		if p.ignored.IsIgnoredService(service.Name, service.Namespace, service.GetLabels()["app"]) {
 			continue
 		}
 

--- a/internal/providers/kubernetes/provider.go
+++ b/internal/providers/kubernetes/provider.go
@@ -19,7 +19,6 @@ import (
 type Provider struct {
 	client        k8s.CoreV1Client
 	defaultMode   string
-	meshNamespace string
 	tcpStateTable *k8s.State
 	ignored       k8s.IgnoreWrapper
 }
@@ -30,11 +29,10 @@ func (p *Provider) Init() {
 }
 
 // New creates a new provider.
-func New(client k8s.CoreV1Client, defaultMode string, meshNamespace string, tcpStateTable *k8s.State, ignored k8s.IgnoreWrapper) *Provider {
+func New(client k8s.CoreV1Client, defaultMode string, tcpStateTable *k8s.State, ignored k8s.IgnoreWrapper) *Provider {
 	p := &Provider{
 		client:        client,
 		defaultMode:   defaultMode,
-		meshNamespace: meshNamespace,
 		tcpStateTable: tcpStateTable,
 		ignored:       ignored,
 	}
@@ -47,7 +45,7 @@ func New(client k8s.CoreV1Client, defaultMode string, meshNamespace string, tcpS
 func (p *Provider) buildRouter(name, namespace, ip string, port int, serviceName string, addMiddlewares bool) *dynamic.Router {
 	if addMiddlewares {
 		return &dynamic.Router{
-			Rule:        fmt.Sprintf("Host(`%s.%s.%s`) || Host(`%s`)", name, namespace, p.meshNamespace, ip),
+			Rule:        fmt.Sprintf("Host(`%s.%s.maesh`) || Host(`%s`)", name, namespace, ip),
 			EntryPoints: []string{fmt.Sprintf("http-%d", port)},
 			Middlewares: []string{serviceName},
 			Service:     serviceName,
@@ -55,7 +53,7 @@ func (p *Provider) buildRouter(name, namespace, ip string, port int, serviceName
 	}
 
 	return &dynamic.Router{
-		Rule:        fmt.Sprintf("Host(`%s.%s.%s`) || Host(`%s`)", name, namespace, p.meshNamespace, ip),
+		Rule:        fmt.Sprintf("Host(`%s.%s.maesh`) || Host(`%s`)", name, namespace, ip),
 		EntryPoints: []string{fmt.Sprintf("http-%d", port)},
 		Service:     serviceName,
 	}

--- a/internal/providers/kubernetes/provider_test.go
+++ b/internal/providers/kubernetes/provider_test.go
@@ -12,8 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const meshNamespace string = "maesh"
-
 func TestBuildRouter(t *testing.T) {
 	expectedWithMiddlewares := &dynamic.Router{
 		Rule:        "Host(`test.foo.maesh`) || Host(`10.0.0.1`)",
@@ -29,9 +27,7 @@ func TestBuildRouter(t *testing.T) {
 	}
 
 	ignored := k8s.NewIgnored()
-	ignored.SetMeshNamespace(meshNamespace)
-
-	provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
+	provider := New(nil, k8s.ServiceTypeHTTP, nil, ignored)
 
 	name := "test"
 	namespace := "foo"
@@ -53,9 +49,8 @@ func TestBuildTCPRouter(t *testing.T) {
 	}
 
 	ignored := k8s.NewIgnored()
-	ignored.SetMeshNamespace(meshNamespace)
 
-	provider := New(nil, k8s.ServiceTypeTCP, meshNamespace, nil, ignored)
+	provider := New(nil, k8s.ServiceTypeTCP, nil, ignored)
 
 	port := 10000
 	associatedService := "bar"
@@ -282,9 +277,8 @@ func TestBuildConfiguration(t *testing.T) {
 			}
 
 			ignored := k8s.NewIgnored()
-			ignored.SetMeshNamespace(meshNamespace)
 
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, stateTable, ignored)
+			provider := New(clientMock, k8s.ServiceTypeHTTP, stateTable, ignored)
 			config, err := provider.BuildConfig()
 			assert.Equal(t, test.expected, config)
 			if test.endpointsError || test.serviceError {
@@ -393,9 +387,8 @@ func TestBuildService(t *testing.T) {
 
 			clientMock := k8s.NewCoreV1ClientMock(test.mockFile)
 			ignored := k8s.NewIgnored()
-			ignored.SetMeshNamespace(meshNamespace)
 
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
+			provider := New(clientMock, k8s.ServiceTypeHTTP, nil, ignored)
 			actual := provider.buildService(test.endpoints, test.scheme)
 			assert.Equal(t, test.expected, actual)
 		})
@@ -467,9 +460,8 @@ func TestBuildTCPService(t *testing.T) {
 
 			clientMock := k8s.NewCoreV1ClientMock(test.mockFile)
 			ignored := k8s.NewIgnored()
-			ignored.SetMeshNamespace(meshNamespace)
 
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, stateTable, ignored)
+			provider := New(clientMock, k8s.ServiceTypeHTTP, stateTable, ignored)
 			actual := provider.buildTCPService(test.endpoints)
 			assert.Equal(t, test.expected, actual)
 		})
@@ -516,9 +508,8 @@ func TestGetMeshPort(t *testing.T) {
 			t.Parallel()
 
 			ignored := k8s.NewIgnored()
-			ignored.SetMeshNamespace(meshNamespace)
 
-			provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, stateTable, ignored)
+			provider := New(nil, k8s.ServiceTypeHTTP, stateTable, ignored)
 			actual := provider.getMeshPort(test.name, test.namespace, test.port)
 			assert.Equal(t, test.expected, actual)
 		})
@@ -608,7 +599,7 @@ func TestBuildHTTPMiddlewares(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, k8s.NewIgnored())
+			provider := New(nil, k8s.ServiceTypeHTTP, nil, k8s.NewIgnored())
 			actual := provider.buildHTTPMiddlewares(test.annotations)
 			assert.Equal(t, test.expected, actual)
 		})

--- a/internal/providers/smi/provider.go
+++ b/internal/providers/smi/provider.go
@@ -85,17 +85,17 @@ func (p *Provider) BuildConfig() (*dynamic.Configuration, error) {
 		serviceMode := p.getServiceMode(service.Annotations[k8s.AnnotationServiceType])
 		// Get all traffic targets in the service's namespace.
 		trafficTargetsInNamespace := p.getTrafficTargetsWithDestinationInNamespace(service.Namespace, trafficTargets)
-		log.Debugf("Found traffictargets for service %s/%s: %+v\n", service.Namespace, service.Name, trafficTargets)
+		log.Debugf("Found traffictargets for service %s/%s: %+v", service.Namespace, service.Name, trafficTargets)
 		// Find all traffic targets that are applicable to the service in question.
 		applicableTrafficTargets := p.getApplicableTrafficTargets(base.GetEndpointsFromList(service.Name, service.Namespace, endpoints), trafficTargetsInNamespace)
-		log.Debugf("Found applicable traffictargets for service %s/%s: %+v\n", service.Namespace, service.Name, applicableTrafficTargets)
+		log.Debugf("Found applicable traffictargets for service %s/%s: %+v", service.Namespace, service.Name, applicableTrafficTargets)
 		// Group the traffic targets by destination, so that they can be built separately.
 		groupedByDestinationTrafficTargets := p.groupTrafficTargetsByDestination(applicableTrafficTargets)
-		log.Debugf("Found grouped traffictargets for service %s/%s: %+v\n", service.Namespace, service.Name, groupedByDestinationTrafficTargets)
+		log.Debugf("Found grouped traffictargets for service %s/%s: %+v", service.Namespace, service.Name, groupedByDestinationTrafficTargets)
 
 		// Get all traffic split in the service's namespace.
 		trafficSplitsInNamespace := p.getTrafficSplitsWithDestinationInNamespace(service.Namespace, trafficSplits)
-		log.Debugf("Found trafficsplits for service %s/%s: %+v\n", service.Namespace, service.Name, trafficSplitsInNamespace)
+		log.Debugf("Found trafficsplits for service %s/%s: %+v", service.Namespace, service.Name, trafficSplitsInNamespace)
 
 		for _, groupedTrafficTargets := range groupedByDestinationTrafficTargets {
 			for _, groupedTrafficTarget := range groupedTrafficTargets {

--- a/internal/providers/smi/provider.go
+++ b/internal/providers/smi/provider.go
@@ -23,7 +23,6 @@ import (
 type Provider struct {
 	client        k8s.Client
 	defaultMode   string
-	meshNamespace string
 	tcpStateTable *k8s.State
 	ignored       k8s.IgnoreWrapper
 }
@@ -39,11 +38,10 @@ type destinationKey struct {
 func (p *Provider) Init() {}
 
 // New creates a new provider.
-func New(client k8s.Client, defaultMode string, meshNamespace string, tcpStateTable *k8s.State, ignored k8s.IgnoreWrapper) *Provider {
+func New(client k8s.Client, defaultMode string, tcpStateTable *k8s.State, ignored k8s.IgnoreWrapper) *Provider {
 	p := &Provider{
 		client:        client,
 		defaultMode:   defaultMode,
-		meshNamespace: meshNamespace,
 		tcpStateTable: tcpStateTable,
 		ignored:       ignored,
 	}
@@ -376,7 +374,7 @@ func (p *Provider) buildRuleSnippetFromServiceAndMatch(name, namespace, ip strin
 		result = append(result, fmt.Sprintf("Method(`%s`)", methods))
 	}
 
-	result = append(result, fmt.Sprintf("(Host(`%s.%s.%s`) || Host(`%s`))", name, namespace, p.meshNamespace, ip))
+	result = append(result, fmt.Sprintf("(Host(`%s.%s.maesh`) || Host(`%s`))", name, namespace, ip))
 
 	return strings.Join(result, " && ")
 }

--- a/internal/providers/smi/provider.go
+++ b/internal/providers/smi/provider.go
@@ -80,7 +80,7 @@ func (p *Provider) BuildConfig() (*dynamic.Configuration, error) {
 	}
 
 	for _, service := range services {
-		if p.ignored.IsIgnoredService(service.Name, service.Namespace) {
+		if p.ignored.IsIgnoredService(service.Name, service.Namespace, service.GetLabels()["app"]) {
 			continue
 		}
 

--- a/internal/providers/smi/provider.go
+++ b/internal/providers/smi/provider.go
@@ -78,7 +78,7 @@ func (p *Provider) BuildConfig() (*dynamic.Configuration, error) {
 	}
 
 	for _, service := range services {
-		if p.ignored.IsIgnoredService(service.Name, service.Namespace, service.GetLabels()["app"]) {
+		if p.ignored.IsIgnored(service.ObjectMeta) {
 			continue
 		}
 

--- a/internal/providers/smi/provider_test.go
+++ b/internal/providers/smi/provider_test.go
@@ -14,13 +14,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const meshNamespace string = "maesh"
-
 func TestBuildRuleSnippetFromServiceAndMatch(t *testing.T) {
 	ignored := k8s.NewIgnored()
-	ignored.SetMeshNamespace(meshNamespace)
-
-	provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
+	provider := New(nil, k8s.ServiceTypeHTTP, nil, ignored)
 
 	testCases := []struct {
 		desc     string
@@ -70,9 +66,8 @@ func TestBuildRuleSnippetFromServiceAndMatch(t *testing.T) {
 func TestGetTrafficTargetsWithDestinationInNamespace(t *testing.T) {
 	clientMock := k8s.NewClientMock("mock.yaml")
 	ignored := k8s.NewIgnored()
-	ignored.SetMeshNamespace(meshNamespace)
 
-	provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
+	provider := New(clientMock, k8s.ServiceTypeHTTP, nil, ignored)
 
 	expected := []*accessv1alpha1.TrafficTarget{
 		{
@@ -340,9 +335,8 @@ func TestBuildHTTPRouterFromTrafficTarget(t *testing.T) {
 				clientMock.EnableHTTPRouteGroupError()
 			}
 			ignored := k8s.NewIgnored()
-			ignored.SetMeshNamespace(meshNamespace)
 
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
+			provider := New(clientMock, k8s.ServiceTypeHTTP, nil, ignored)
 			middleware := "block-all"
 			actual := provider.buildHTTPRouterFromTrafficTarget(test.serviceName, test.serviceNamespace, test.serviceIP, test.trafficTarget, test.port, test.key, middleware)
 			assert.Equal(t, test.expected, actual)
@@ -484,9 +478,8 @@ func TestBuildTCPRouterFromTrafficTarget(t *testing.T) {
 				clientMock.EnableTCPRouteError()
 			}
 			ignored := k8s.NewIgnored()
-			ignored.SetMeshNamespace(meshNamespace)
 
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
+			provider := New(clientMock, k8s.ServiceTypeHTTP, nil, ignored)
 			actual := provider.buildTCPRouterFromTrafficTarget(test.trafficTarget, test.port, test.key)
 			assert.Equal(t, test.expected, actual)
 		})
@@ -495,9 +488,8 @@ func TestBuildTCPRouterFromTrafficTarget(t *testing.T) {
 
 func TestGetServiceMode(t *testing.T) {
 	ignored := k8s.NewIgnored()
-	ignored.SetMeshNamespace(meshNamespace)
 
-	provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
+	provider := New(nil, k8s.ServiceTypeHTTP, nil, ignored)
 
 	testCases := []struct {
 		desc     string
@@ -879,9 +871,8 @@ func TestGetApplicableTrafficTargets(t *testing.T) {
 			}
 
 			ignored := k8s.NewIgnored()
-			ignored.SetMeshNamespace(meshNamespace)
 
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
+			provider := New(clientMock, k8s.ServiceTypeHTTP, nil, ignored)
 
 			actual := provider.getApplicableTrafficTargets(test.endpoints, test.trafficTargets)
 			assert.Equal(t, test.expected, actual)
@@ -1221,9 +1212,8 @@ func TestBuildHTTPServiceFromTrafficTarget(t *testing.T) {
 			}
 
 			ignored := k8s.NewIgnored()
-			ignored.SetMeshNamespace(meshNamespace)
 
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
+			provider := New(clientMock, k8s.ServiceTypeHTTP, nil, ignored)
 
 			actual := provider.buildHTTPServiceFromTrafficTarget(test.endpoints, test.trafficTarget, k8s.SchemeHTTP)
 			assert.Equal(t, test.expected, actual)
@@ -1233,9 +1223,8 @@ func TestBuildHTTPServiceFromTrafficTarget(t *testing.T) {
 
 func TestGroupTrafficTargetsByDestination(t *testing.T) {
 	ignored := k8s.NewIgnored()
-	ignored.SetMeshNamespace(meshNamespace)
 
-	provider := New(nil, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
+	provider := New(nil, k8s.ServiceTypeHTTP, nil, ignored)
 
 	trafficTargets := []*accessv1alpha1.TrafficTarget{
 		{
@@ -1474,9 +1463,8 @@ func TestBuildConfiguration(t *testing.T) {
 			}
 
 			ignored := k8s.NewIgnored()
-			ignored.SetMeshNamespace(meshNamespace)
 
-			provider := New(clientMock, k8s.ServiceTypeHTTP, meshNamespace, nil, ignored)
+			provider := New(clientMock, k8s.ServiceTypeHTTP, nil, ignored)
 			config, err := provider.BuildConfig()
 			assert.Equal(t, test.expected, config)
 			if test.endpointsError || test.serviceError {


### PR DESCRIPTION
## What does this PR do

This PR makes Maesh able to run in a single namespace.

Fixes: #253 

## How to test this

Install maesh in the same namespace of your applications, and enjoy your shiny service mesh  as usual :tada:

## How does it work

Now, all generated mesh services are labeled with `app=maesh` too.
Then the controller is now able to a list of apps, right now `maesh` and `jaeger` are hardcoded, and we might want to change that. But it makes maesh ignore the maesh services. 
For the initial `createMaeshService` I used  [fields selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/#supported-operators) instead of filtering everything in memory.

I also made the filtering more time efficient using a map instead of iterating over the services, as we can have a lot of services this can be important. 

## Additional information

I kind of hacked my way to get it working, that is definitely not a final implementation.
Also It doesn't support CNI just yet. 

Draft for the moment as CI is super broken and it is not finished.