### PR TITLE
using lastindex to find coredns version

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -194,7 +194,6 @@ func (w *ClientWrapper) CoreDNSMatch() (bool, error) {
 
 		sp := strings.Split(c.Image, ":")
 		version = sp[len(sp)-1]
-
 	}
 
 	if !isCoreDNSVersionSupported(version) {

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -192,10 +192,9 @@ func (w *ClientWrapper) CoreDNSMatch() (bool, error) {
 			continue
 		}
 
-		split := strings.Split(c.Image, ":")
-		if len(split) == 2 {
-			version = split[1]
-		}
+		sp := strings.Split(c.Image, ":")
+		version = sp[len(sp)-1]
+
 	}
 
 	if !isCoreDNSVersionSupported(version) {


### PR DESCRIPTION
applicable when there are multiple colons in image/tag string, for example:

```image-registry.canonical.com:5000/cdk/coredns/coredns-amd64:1.5.1```

error from maesh-prepare init container:

```2019/11/08 13:51:28 command prepare error: error during cluster check: unsupported CoreDNS version "", (supported versions are: 1.3,1.4,1.5,1.6)```