### PR TITLE
Document Maesh and SMI

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -111,7 +111,9 @@ matches:
 ```
 
 In this example, we define a set of HTTP routes for our `server` application.
+
 More precisely, the `server` app is composed by two routes:
+
 - The `api` route under the `/api` path, accepting all methods
 - The `metrics` routes under the `/metrics` path, accepting only a `GET` request
 
@@ -143,6 +145,34 @@ sources:
 
 In this example, we grant access to all pods running with the service account `client` under the namespace `client` to the HTTP route `api` specified by on the group `server-routes` on all pods running with the service account `server` under the namespace `server`.
 
+Any client running with the service account `client` under the `client` namespace accessing `server.server.maesh/api` is allowed to access the `/api` resource. Other will receive a 404 answer from the Maesh node.
+
 More information can be found [in the specification](https://github.com/deislabs/smi-spec/blob/master/traffic-access-control.md).
 
 #### Traffic Splitting
+
+SMI defines the `TrafficSplit` resource which allows to direct incrementally a subset of the traffic to a different services.
+
+```yaml
+apiVersion: split.smi-spec.io/v1alpha1
+kind: TrafficSplit
+metadata:
+  name: server-split
+  namespace server
+spec:
+  service: server
+  backends:
+  - service: server-v1
+    weight: 80
+  - service: server-v2
+    weight: 20
+```
+
+In this example, we define a traffic split for our server service between two version of our server, v1 and v2.
+`server.server.maesh` directs 80% of the traffic to the server-v1 pods, and  20% of the traffic to the server-v2 pods.
+
+More information can be found [in the specification](https://github.com/deislabs/smi-spec/blob/master/traffic-split.md).
+
+#### Traffic Metrics
+
+At the moment, Maesh does not implement the [Traffic Metrics specification](https://github.com/deislabs/smi-spec/blob/master/traffic-metrics.md).

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
-The configuration for maesh is broken into two parts: the static configuration, and the dynamic configuration. 
-The static configuration is configured when the maesh service mesh is installed, 
+The configuration for maesh is broken into two parts: the static configuration, and the dynamic configuration.
+The static configuration is configured when the maesh service mesh is installed,
 and is configured via the values.yaml file in the helm install.
 
 ## Static configuration

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-The configuration for maesh is broken into two parts: the static configuration, and the dynamic configuration.
+The configuration for maesh is broken down into two parts: the static configuration, and the dynamic configuration.
 The static configuration is configured when the maesh service mesh is installed,
 and is configured via the values.yaml file in the helm install.
 
@@ -115,7 +115,7 @@ In this example, we define a set of HTTP routes for our `server` application.
 More precisely, the `server` app is composed by two routes:
 
 - The `api` route under the `/api` path, accepting all methods
-- The `metrics` routes under the `/metrics` path, accepting only a `GET` request
+- The `metrics` routes under the `/metrics` path, accepting only `GET` requests
 
 Other types of route groups and detailed information are available [in the specification](https://github.com/deislabs/smi-spec/blob/master/traffic-specs.md).
 
@@ -145,13 +145,13 @@ sources:
 
 In this example, we grant access to all pods running with the service account `client` under the namespace `client` to the HTTP route `api` specified by on the group `server-routes` on all pods running with the service account `server` under the namespace `server`.
 
-Any client running with the service account `client` under the `client` namespace accessing `server.server.maesh/api` is allowed to access the `/api` resource. Other will receive a 404 answer from the Maesh node.
+Any client running with the service account `client` under the `client` namespace accessing `server.server.maesh/api` is allowed to access the `/api` resource. Others will receive 404 answers from the Maesh node.
 
-More information can be found [in the specification](https://github.com/deislabs/smi-spec/blob/master/traffic-access-control.md).
+More information can be found [in the SMI specification](https://github.com/deislabs/smi-spec/blob/master/traffic-access-control.md).
 
 #### Traffic Splitting
 
-SMI defines the `TrafficSplit` resource which allows to direct incrementally a subset of the traffic to a different services.
+SMI defines the `TrafficSplit` resource which allows to direct subsets of the traffic to different services.
 
 ```yaml
 apiVersion: split.smi-spec.io/v1alpha1
@@ -168,10 +168,10 @@ spec:
     weight: 20
 ```
 
-In this example, we define a traffic split for our server service between two version of our server, v1 and v2.
+In this example, we define a traffic split for our server service between two versions of our server, v1 and v2.
 `server.server.maesh` directs 80% of the traffic to the server-v1 pods, and 20% of the traffic to the server-v2 pods.
 
-More information can be found [in the specification](https://github.com/deislabs/smi-spec/blob/master/traffic-split.md).
+More information can be found [in the SMI specification](https://github.com/deislabs/smi-spec/blob/master/traffic-split.md).
 
 #### Traffic Metrics
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -169,7 +169,7 @@ spec:
 ```
 
 In this example, we define a traffic split for our server service between two version of our server, v1 and v2.
-`server.server.maesh` directs 80% of the traffic to the server-v1 pods, and  20% of the traffic to the server-v2 pods.
+`server.server.maesh` directs 80% of the traffic to the server-v1 pods, and 20% of the traffic to the server-v2 pods.
 
 More information can be found [in the specification](https://github.com/deislabs/smi-spec/blob/master/traffic-split.md).
 

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -47,13 +47,26 @@ KubeDNS will be patched with [stubDomains](https://kubernetes.io/docs/tasks/admi
 If you use a cluster domain other than `cluster.local` set it by using the `clusterDomain` parameter:
 
 ```bash
-
 helm install --name=maesh --namespace=maesh maesh/maesh --set clusterDomain=my.custom.domain.com
 ```
 
+## Service Mesh Interface
+
+Maesh supports the [SMI specification](https://smi-spec.io/) which defines a set of custom resources
+to provide a fine-grained control over instrumentation and access control of east-west communications.
+
+To enable SMI, install maesh in SMI mode by setting the `--smi.enable` and `--smi.deploy` options to true.
+
+```bash
+helm install --name=maesh --namespace=maesh maesh/maesh --set smi.enable=true --set smi.deploy=true`
+```
+
+- The `smi.enable` option tells Maesh to process SMI resources.
+- The `smi.deploy` option controls if the SMI CRDs are deployed with the helm chart.
+
 ## Installation namespace
 
-Maesh does not _need_ to be installed into the `maesh` namespace, 
+Maesh does not _need_ to be installed into the `maesh` namespace,
 but it does need to be installed into its _own_ namespace, separate from user namespaces.
 
 ## Platform recommendations

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -55,7 +55,7 @@ helm install --name=maesh --namespace=maesh maesh/maesh --set clusterDomain=my.c
 Maesh supports the [SMI specification](https://smi-spec.io/) which defines a set of custom resources
 to provide a fine-grained control over instrumentation, routing and access control of east-west communications.
 
-To enable SMI, install maesh in SMI mode by setting the `--smi.enable` and `--smi.deploy` options to true.
+To enable SMI, install maesh in SMI mode by setting the `smi.enable` and `smi.deploy` helm chart options to true.
 
 ```bash
 helm install --name=maesh --namespace=maesh maesh/maesh --set smi.enable=true --set smi.deploy=true`

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -53,7 +53,7 @@ helm install --name=maesh --namespace=maesh maesh/maesh --set clusterDomain=my.c
 ## Service Mesh Interface
 
 Maesh supports the [SMI specification](https://smi-spec.io/) which defines a set of custom resources
-to provide a fine-grained control over instrumentation and access control of east-west communications.
+to provide a fine-grained control over instrumentation, routing and access control of east-west communications.
 
 To enable SMI, install maesh in SMI mode by setting the `--smi.enable` and `--smi.deploy` options to true.
 

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -61,12 +61,12 @@ To enable SMI, install maesh in SMI mode by setting the `--smi.enable` and `--sm
 helm install --name=maesh --namespace=maesh maesh/maesh --set smi.enable=true --set smi.deploy=true`
 ```
 
-- The `smi.enable` option tells Maesh to process SMI resources.
-- The `smi.deploy` option controls if the SMI CRDs are deployed with the helm chart.
+- The `smi.enable` option makes Maesh process SMI resources.
+- The `smi.deploy` option makes Maesh deploy the SMI CRDs with the helm chart.
 
 ## Installation namespace
 
-Maesh does not _need_ to be installed into the `maesh` namespace,
+Maesh does not _need_ to be installed in the `maesh` namespace,
 but it does need to be installed into its _own_ namespace, separate from user namespaces.
 
 ## Platform recommendations


### PR DESCRIPTION
### What does this PR do ?

This PR adds documentation about installing and using Maesh with SMI enabled.

Fixes #320 

### How to test this PR ?

Check Netlify deployment.

### Additional information

Installation in SMI mode is based on the changes to the helm chart introduced in #346. 