### PR TITLE
Fix panics in SMI & Kubernetes provider

### DIFF
--- a/internal/providers/kubernetes/provider.go
+++ b/internal/providers/kubernetes/provider.go
@@ -241,6 +241,10 @@ func buildRateLimitMiddleware(annotations map[string]string) *dynamic.RateLimit 
 }
 
 func (p *Provider) getMeshPort(serviceName, serviceNamespace string, servicePort int32) int {
+	if p.tcpStateTable == nil {
+		return 0
+	}
+
 	for port, v := range p.tcpStateTable.Table {
 		if v.Name == serviceName && v.Namespace == serviceNamespace && v.Port == servicePort {
 			return port


### PR DESCRIPTION
### Goal of this PR

This PR fixes #358 by doing the following changes:

In `smi/provider.go`:

* Verify that endpoints are non-nil before accessing their subsets
* Verify that address target references are non-nil before accessing their name/namespace
* Verify that tcpStateTables are non-nil before accessing their table

In `kubernetes/provider.go`

* Verify that tcpStateTables are non-nil before accessing their table

### How to test it

Use the configuration files provided in the issue #358 in the provider unit tests and ensure that they pass. It should not be the case with the current state of master.

### Additional Notes

This PR will most likely be blocking for the next PR I plan on making, which introduces a unit test of building a TCP configuration in the SMI provider. It's while building the configuration that I found the issues described here, so it might just be that I misconfigured it, in which case the PR won't be blocking.