### PR TITLE
Experiment with multiple workers and workqueues.

### DIFF
--- a/cmd/maesh/maesh.go
+++ b/cmd/maesh/maesh.go
@@ -76,7 +76,7 @@ func maeshCommand(cfg *cmd.MaeshConfiguration) error {
 		clientSet,
 		30*time.Second,
 		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
-			opts.FieldSelector = "metadata.namespace!=kube-system,metadata.name!=kubernetes"
+			opts.FieldSelector = "metadata.namespace!=kube-system,metadata.name!=kubernetes,metadata.namespace!=local-path-storage"
 		}),
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/vdemeester/shakers v0.1.0
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0
 	k8s.io/api v0.0.0-20190819141258-3544db3b9e44
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/client-go v0.0.0-20190819141724-e14f31a72a77

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,7 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/exoscale/egoscale v0.18.1/go.mod h1:Z7OOdzzTOz1Q1PjQXumlz9Wn/CddH0zSYdCF3rnBKXE=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
@@ -556,6 +557,7 @@ k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.2 h1:qvP/U6CcZ6qyi/qSHlJKdlAboCzo3mT0DAm0XAarpz4=
 k8s.io/klog v0.3.2/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
+k8s.io/kube-openapi v0.0.0-20190502190224-411b2483e503 h1:IrnrEIp9du1SngrzGC1fdYEdos7Il6I6EVxwFQHJwCg=
 k8s.io/kube-openapi v0.0.0-20190502190224-411b2483e503/go.mod h1:iU+ZGYsNlvU9XKUSso6SQfKTCCw7lFduMZy26Mgr2Fw=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da h1:ElyM7RPonbKnQqOcw7dG2IK5uvQQn3b/WPHqD5mBvP4=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=

--- a/internal/configurator/controller.go
+++ b/internal/configurator/controller.go
@@ -1,0 +1,172 @@
+package configurator
+
+import (
+	"context"
+
+	"github.com/containous/maesh/internal/providers/base"
+	"github.com/containous/maesh/internal/resource"
+	"github.com/containous/traefik/v2/pkg/config/dynamic"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const moduleName = "configurator"
+
+// Deployer deploys a confiugration to a set of pods.
+type Deployer interface {
+	Deploy(pods []*corev1.Pod, cfg *dynamic.Configuration) error
+}
+
+// Controller is in charge of watching meaningfull resources and triggering mesh node reconfiguration.
+type Controller struct {
+	provider base.Provider
+	deployer Deployer
+	pods     listersv1.PodLister
+
+	currentNamespace string
+
+	queue  workqueue.RateLimitingInterface
+	exited chan struct{}
+
+	logger logrus.FieldLogger
+}
+
+// NewController returns a configurator controller.
+func NewController(informerFactory informers.SharedInformerFactory, provider base.Provider, deployer Deployer, currentNamespace string, l logrus.FieldLogger) *Controller {
+	q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), moduleName)
+
+	// Watch the mesh-services
+	svcInformer := informerFactory.Core().V1().Services()
+	svcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { enqueueSvcEvent(q, obj, l) },
+		UpdateFunc: func(_, obj interface{}) { enqueueSvcEvent(q, obj, l) },
+		DeleteFunc: func(obj interface{}) { enqueueSvcEvent(q, obj, l) },
+	})
+
+	// Watch all the endpoints.
+	endpointsInformer := informerFactory.Core().V1().Endpoints()
+	endpointsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(_ interface{}) { q.Add(struct{}{}) },
+		UpdateFunc: func(_, _ interface{}) { q.Add(struct{}{}) },
+		DeleteFunc: func(_ interface{}) { q.Add(struct{}{}) },
+	})
+
+	// Watch the mesh nodes pods.
+	podsInformer := informerFactory.Core().V1().Pods()
+	podsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { enqueuePodEvent(q, obj, l) },
+		UpdateFunc: func(_, obj interface{}) { enqueuePodEvent(q, obj, l) },
+		DeleteFunc: func(obj interface{}) { enqueuePodEvent(q, obj, l) },
+	})
+
+	return &Controller{
+		deployer:         deployer,
+		provider:         provider,
+		pods:             podsInformer.Lister(),
+		queue:            q,
+		exited:           make(chan struct{}),
+		currentNamespace: currentNamespace,
+		logger:           l.WithField("module", moduleName),
+	}
+}
+
+// Run process all events coming from the workqueue until shutdown is signaled.
+func (c *Controller) Run() {
+	defer close(c.exited)
+
+	for c.processEvent() {
+	}
+}
+
+// ShutDown shutdowns the controller.
+func (c *Controller) ShutDown() {
+	c.queue.ShutDown()
+}
+
+// Wait waits for the termination of the controller loop.
+func (c *Controller) Wait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.exited:
+		return nil
+	}
+}
+
+func (c *Controller) processEvent() bool {
+	item, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+
+	defer c.queue.Done(item)
+
+	cfg, err := c.provider.BuildConfig()
+	if err != nil {
+		c.handleError(item, err)
+		return true
+	}
+
+	maeshNodes, err := c.pods.Pods(c.currentNamespace).List(resource.MeshPodsLabelsSelector())
+	if err != nil {
+		c.handleError(item, err)
+		return true
+	}
+
+	if err = c.deployer.Deploy(maeshNodes, cfg); err != nil {
+		c.handleError(item, err)
+		return true
+	}
+
+	c.queue.Forget(item)
+
+	return true
+}
+
+const (
+	maxAttempts = 3
+)
+
+func (c *Controller) handleError(item interface{}, err error) {
+	l := c.logger.WithError(err)
+
+	attempt := c.queue.NumRequeues(item)
+	if attempt < maxAttempts {
+		l.Errorf("(%d/%d) unable to process item, retrying", attempt+1, maxAttempts)
+		c.queue.AddRateLimited(item)
+		return
+	}
+
+	l.Errorf("Max attempt reached, ignoring failing event")
+	c.queue.Forget(item)
+}
+
+func enqueueSvcEvent(q workqueue.RateLimitingInterface, obj interface{}, log logrus.FieldLogger) {
+	isMeshSvc, err := resource.IsMeshService(obj)
+	if err != nil {
+		log.WithError(err).Error("unable to determine if event comes from a mesh service, skipping")
+		return
+	}
+	if !isMeshSvc {
+		return
+	}
+
+	q.Add(struct{}{})
+}
+
+func enqueuePodEvent(q workqueue.RateLimitingInterface, obj interface{}, log logrus.FieldLogger) {
+	isMeshPod, err := resource.IsMeshPod(obj)
+	if err != nil {
+		log.WithError(err).Error("unable to determine if event comes from a mesh pod, skipping")
+		return
+	}
+	if !isMeshPod {
+		return
+	}
+
+	q.Add(struct{}{})
+}

--- a/internal/configurator/controller.go
+++ b/internal/configurator/controller.go
@@ -22,7 +22,7 @@ type Deployer interface {
 	Deploy(pods []*corev1.Pod, cfg *dynamic.Configuration) error
 }
 
-// Controller is in charge of watching meaningfull resources and triggering mesh node reconfiguration.
+// Controller is in charge of watching meaningful resources and triggering mesh node reconfiguration.
 type Controller struct {
 	provider base.Provider
 	deployer Deployer
@@ -88,7 +88,7 @@ func (c *Controller) Run() {
 	}
 }
 
-// ShutDown shutdowns the controller.
+// ShutDown shuts the controller down.
 func (c *Controller) ShutDown() {
 	c.queue.ShutDown()
 }

--- a/internal/deployer/rest.go
+++ b/internal/deployer/rest.go
@@ -1,0 +1,94 @@
+package deployer
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/cenkalti/backoff/v3"
+	"github.com/containous/traefik/v2/pkg/config/dynamic"
+	"github.com/containous/traefik/v2/pkg/safe"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// REST is a deployer that pushes dynamic configuration to maesh-nodes using traefik's rest provider.
+type REST struct {
+	client *http.Client
+	logger logrus.FieldLogger
+}
+
+func NewREST(logger logrus.FieldLogger) *REST {
+	return &REST{
+		client: &http.Client{Timeout: time.Second},
+		logger: logger.WithField("module", "deployer"),
+	}
+}
+
+func (pr *REST) Deploy(pods []*corev1.Pod, cfg *dynamic.Configuration) error {
+	rawCfg, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("unable to marshal configuration: %v", err)
+	}
+
+	var errg errgroup.Group
+
+	for _, p := range pods {
+		pod := p
+
+		errg.Go(func() error {
+			b := backoff.NewExponentialBackOff()
+			b.MaxElapsedTime = 15 * time.Second
+
+			op := func() error {
+				if err := pr.deployToPod(pod, rawCfg); err != nil {
+					pr.logger.Errorf(
+						"unable to deploy dynamic configuration to pod %q: %v",
+						pod.GetName(),
+						err,
+					)
+
+					return err
+				}
+
+				return nil
+			}
+
+			return backoff.Retry(safe.OperationWithRecover(op), b)
+		})
+	}
+
+	if err := errg.Wait(); err != nil {
+		return fmt.Errorf("one or more deployment has failed: %w", err)
+	}
+
+	return nil
+}
+
+func (pr *REST) deployToPod(pod *corev1.Pod, cfg []byte) error {
+	req, err := http.NewRequest(
+		http.MethodPut,
+		fmt.Sprintf("http://%s:8080/api/providers/rest", pod.Status.PodIP),
+		bytes.NewBuffer(cfg),
+	)
+	if err != nil {
+		return fmt.Errorf("unable to create request: %w", err)
+	}
+
+	resp, err := pr.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("unable to deploy configuration: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("node answered HTTP status %d != 200", resp.StatusCode)
+	}
+
+	pr.logger.Infof("Successfully updated pod %q configuration", pod.GetName())
+
+	return nil
+}

--- a/internal/mesher/controller.go
+++ b/internal/mesher/controller.go
@@ -1,0 +1,73 @@
+package mesher
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	informersv1 "k8s.io/client-go/informers/core/v1"
+	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// Filter is a type that can match a k8s object.
+type Filter interface {
+	Match(metav1.Object) bool
+}
+
+// Controller is running the control loop to maintain the list of mesh services.
+type Controller struct {
+	svcCache  listersv1.ServiceLister
+	svcClient clientv1.ServiceInterface
+
+	queue  workqueue.RateLimitingInterface
+	exited chan struct{}
+}
+
+// NewController setup event handlers on the service informer and returns a controller.
+func NewController(client clientv1.ServiceInterface, informer informersv1.ServiceInformer, filter Filter) *Controller {
+	q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "mesher")
+
+	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) {},
+		UpdateFunc: func(oldObj, newObj interface{}) {},
+		DeleteFunc: func(obj interface{}) {},
+	})
+
+	return &Controller{
+		svcCache:  informer.Lister(),
+		svcClient: client,
+		queue:     q,
+		exited:    make(chan struct{}),
+	}
+}
+
+// Run runs the controller.
+func (c *Controller) Run() {
+	for {
+		evt, shutdown := c.queue.Get()
+		if shutdown {
+			close(c.exited)
+			return
+		}
+
+		defer c.queue.Done(evt)
+
+		c.queue.Forget(evt)
+	}
+}
+
+// ShutDown shutdowns the controller.
+func (c *Controller) ShutDown() {
+	c.queue.ShutDown()
+}
+
+func (c *Controller) Wait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.exited:
+		return nil
+	}
+}

--- a/internal/mesher/controller.go
+++ b/internal/mesher/controller.go
@@ -33,7 +33,7 @@ type Controller struct {
 	logger logrus.FieldLogger
 }
 
-// NewController setup event handlers on the service informer and returns a controller.
+// NewController sets up event handlers on the service informer and returns a controller.
 func NewController(clientSet kubernetes.Interface, informerFactory informers.SharedInformerFactory, ns string, l logrus.FieldLogger) *Controller {
 	q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), moduleName)
 
@@ -55,7 +55,7 @@ func NewController(clientSet kubernetes.Interface, informerFactory informers.Sha
 	}
 }
 
-// Run process all events coming from the workqueue until shutdown is signaled.
+// Run processes events coming from the workqueue until shutdown.
 func (c *Controller) Run() {
 	defer close(c.exited)
 
@@ -63,7 +63,7 @@ func (c *Controller) Run() {
 	}
 }
 
-// ShutDown shutdowns the controller.
+// ShutDown shuts the controller down.
 func (c *Controller) ShutDown() {
 	c.queue.ShutDown()
 }
@@ -158,7 +158,7 @@ func (c *Controller) createMeshService(key string) error {
 	}
 
 	c.logger.Infof(
-		"Created mesh service %q, because of the creation service %q in namespace %q",
+		"Created mesh service %q, because of the creation of service %q in namespace %q",
 		meshSvcName,
 		name,
 		ns,

--- a/internal/mesher/controller.go
+++ b/internal/mesher/controller.go
@@ -2,9 +2,16 @@ package mesher
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	informersv1 "k8s.io/client-go/informers/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -16,6 +23,8 @@ type Filter interface {
 	Match(metav1.Object) bool
 }
 
+const moduleName = "mesher"
+
 // Controller is running the control loop to maintain the list of mesh services.
 type Controller struct {
 	svcCache  listersv1.ServiceLister
@@ -23,39 +32,74 @@ type Controller struct {
 
 	queue  workqueue.RateLimitingInterface
 	exited chan struct{}
+
+	currentNamespace string
+
+	logger logrus.FieldLogger
 }
 
 // NewController setup event handlers on the service informer and returns a controller.
-func NewController(client clientv1.ServiceInterface, informer informersv1.ServiceInformer, filter Filter) *Controller {
-	q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "mesher")
+func NewController(clientSet kubernetes.Interface, informerFactory informers.SharedInformerFactory, ns string, l logrus.FieldLogger) *Controller {
+	q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), moduleName)
 
-	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) {},
-		UpdateFunc: func(oldObj, newObj interface{}) {},
-		DeleteFunc: func(obj interface{}) {},
+	svcInformer := informerFactory.Core().V1().Services()
+
+	svcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { enqueueObj(q, l, typeAdd, obj) },
+		UpdateFunc: func(_, obj interface{}) { enqueueObj(q, l, typeUpdate, obj) },
+		DeleteFunc: func(obj interface{}) { enqueueObj(q, l, typeDelete, obj) },
 	})
 
 	return &Controller{
-		svcCache:  informer.Lister(),
-		svcClient: client,
-		queue:     q,
-		exited:    make(chan struct{}),
+		svcCache:         svcInformer.Lister(),
+		svcClient:        clientSet.CoreV1().Services(ns),
+		queue:            q,
+		exited:           make(chan struct{}),
+		currentNamespace: ns,
+		logger:           l.WithField("module", moduleName),
 	}
 }
 
-// Run runs the controller.
+// Run process all events coming from the workqueue until shutdown is signaled.
 func (c *Controller) Run() {
-	for {
-		evt, shutdown := c.queue.Get()
-		if shutdown {
-			close(c.exited)
-			return
-		}
+	defer close(c.exited)
 
-		defer c.queue.Done(evt)
-
-		c.queue.Forget(evt)
+	for c.processEvent() {
 	}
+}
+
+func (c *Controller) processEvent() bool {
+	item, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+
+	defer c.queue.Done(item)
+
+	evt := item.(event)
+
+	var err error
+
+	switch evt.Type {
+	case typeAdd:
+		err = c.createMeshService(evt.Key)
+	case typeUpdate:
+		err = c.updateMeshService(evt.Key)
+	case typeDelete:
+		err = c.deleteMeshService(evt.Key)
+	default:
+		c.logger.Errorf("Unknown event type %q, ignoring", evt.Type)
+		c.queue.Forget(item)
+		return true
+	}
+
+	if err != nil {
+		c.handleError(item, err)
+		return true
+	}
+
+	c.queue.Forget(item)
+	return true
 }
 
 // ShutDown shutdowns the controller.
@@ -70,4 +114,211 @@ func (c *Controller) Wait(ctx context.Context) error {
 	case <-c.exited:
 		return nil
 	}
+}
+
+const (
+	maxAttempts = 3
+)
+
+func (c *Controller) handleError(item interface{}, err error) {
+	l := c.logger.WithError(err)
+
+	attempt := c.queue.NumRequeues(item)
+	if attempt < maxAttempts {
+		l.Errorf("(%d/%d) unable to process item, retrying", attempt+1, maxAttempts)
+		c.queue.AddRateLimited(item)
+		return
+	}
+
+	l.Errorf("Max attempt reached, ignoring failing event")
+	c.queue.Forget(item)
+}
+
+func (c *Controller) createMeshService(key string) error {
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return fmt.Errorf("unable to parse key: %w", err)
+	}
+
+	addedSvc, err := c.svcCache.Services(ns).Get(name)
+	if err != nil {
+		return fmt.Errorf("unable to get added svc from cache: %v", err)
+	}
+
+	meshSvcName := meshServiceName(name, ns, c.currentNamespace)
+
+	_, err = c.svcCache.Services(c.currentNamespace).Get(meshSvcName)
+	if err == nil {
+		// If there is a maesh service already present, then we try to update it.
+		return c.updateMeshService(key)
+	}
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("unable to lookup for maesh service: %w", err)
+	}
+
+	_, err = c.svcClient.Create(c.buildMeshSvc(meshSvcName, addedSvc))
+	if err != nil {
+		return fmt.Errorf("unable to create mesh service: %v", err)
+	}
+
+	c.logger.Infof(
+		"Created mesh service %q, from created service %q from namespace %q",
+		meshSvcName,
+		name,
+		ns,
+	)
+
+	return nil
+}
+
+func (c *Controller) updateMeshService(key string) error {
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return fmt.Errorf("unable to parse key: %w", err)
+	}
+
+	updatedService, err := c.svcCache.Services(ns).Get(name)
+	if err != nil {
+		return fmt.Errorf("unable to get updated svc from cache: %v", err)
+	}
+
+	meshSvcName := meshServiceName(name, ns, c.currentNamespace)
+
+	_, err = c.svcClient.Update(c.buildMeshSvc(meshSvcName, updatedService))
+	if err != nil {
+		return fmt.Errorf("unable to update mesh service: %v", err)
+	}
+
+	c.logger.Infof(
+		"Updated mesh service %q, from an updated of service %q from namespace %q",
+		meshSvcName,
+		name,
+		ns,
+	)
+
+	return nil
+}
+
+func (c *Controller) deleteMeshService(key string) error {
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return fmt.Errorf("unable to parse key: %w", err)
+	}
+
+	meshSvcName := meshServiceName(name, ns, c.currentNamespace)
+
+	if err = c.svcClient.Delete(meshSvcName, nil); err != nil {
+		return fmt.Errorf("unable to delete mesh service: %v", err)
+	}
+
+	c.logger.Infof(
+		"Deleted mesh service %q, because of deletion of service %q from namespace %q",
+		meshSvcName,
+		name,
+		ns,
+	)
+
+	return nil
+}
+
+const (
+	portRangeStart = 5000
+
+	appLabel       = "app"
+	componentLabel = "component"
+
+	appLabelMaesh          = "maesh"
+	componentLabelMeshSvc  = "mesh-svc"
+	componentLabelMeshNode = "mesh-node"
+)
+
+func (c *Controller) buildMeshSvc(name string, sourceSvc *corev1.Service) *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: c.currentNamespace,
+			Labels: map[string]string{
+				appLabel:       appLabelMaesh,
+				componentLabel: componentLabelMeshSvc,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				appLabel:       appLabelMaesh,
+				componentLabel: componentLabelMeshNode,
+			},
+		},
+	}
+
+	for id, port := range sourceSvc.Spec.Ports {
+		port := corev1.ServicePort{
+			Name:       port.Name,
+			Protocol:   port.Protocol,
+			Port:       port.Port,
+			TargetPort: intstr.FromInt(portRangeStart + id),
+		}
+
+		svc.Spec.Ports = append(svc.Spec.Ports, port)
+	}
+
+	return svc
+}
+
+func meshServiceName(name, ns, currentNs string) string {
+	return fmt.Sprintf("%s-%s-%s", currentNs, name, ns)
+}
+
+func isMeshService(obj interface{}) (bool, error) {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return false, err
+	}
+
+	objLabels := objMeta.GetLabels()
+
+	isMaeshService := objLabels[appLabel] == appLabelMaesh
+	isMeshSvc := objLabels[componentLabel] == componentLabelMeshSvc
+
+	return isMaeshService && isMeshSvc, nil
+}
+
+func enqueueObj(q workqueue.RateLimitingInterface, log logrus.FieldLogger, t eventType, obj interface{}) {
+	isMeshSvc, err := isMeshService(obj)
+	if err != nil {
+		log.WithError(err).Error("unable to detect mesh service from event, ignoring")
+		return
+	}
+
+	if isMeshSvc {
+		return
+	}
+
+	var key string
+
+	if t == typeDelete {
+		key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	} else {
+		key, err = cache.MetaNamespaceKeyFunc(obj)
+	}
+
+	if err != nil {
+		log.Errorf("ignoring item, unable to calculate meta namespace key: %v", err)
+		return
+	}
+
+	q.Add(event{Type: t, Key: key})
+}
+
+type eventType int8
+
+const (
+	typeUnknown eventType = iota
+	typeAdd
+	typeUpdate
+	typeDelete
+)
+
+type event struct {
+	Type eventType
+	Key  string
 }

--- a/internal/mesher/controller.go
+++ b/internal/mesher/controller.go
@@ -18,11 +18,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-// Filter is a type that can match a k8s object.
-type Filter interface {
-	Match(metav1.Object) bool
-}
-
 const moduleName = "mesher"
 
 // Controller is running the control loop to maintain the list of mesh services.

--- a/internal/mesher/controller_test.go
+++ b/internal/mesher/controller_test.go
@@ -2,16 +2,177 @@ package mesher_test
 
 import (
 	"context"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/containous/maesh/internal/mesher"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+const meshNamespace = "maesh"
+
+func TestController(t *testing.T) {
+	tests := []struct {
+		name            string
+		createResources func(*testing.T, *fake.Clientset)
+		updateResources func(*testing.T, *fake.Clientset)
+
+		wantService             *corev1.Service
+		wantMeshServiceDeletion bool
+	}{
+		{
+			name: "creates mesh service on add",
+			createResources: func(t *testing.T, c *fake.Clientset) {
+				t.Helper()
+				_, err := c.CoreV1().Services("app").Create(generateAppService(8080))
+				require.NoError(t, err)
+			},
+			wantService: generateMeshService(8080),
+		},
+		{
+			name: "update mesh service on add if it already exists",
+			createResources: func(t *testing.T, c *fake.Clientset) {
+				t.Helper()
+				_, err := c.CoreV1().Services("app").Create(generateAppService(8080))
+				require.NoError(t, err)
+
+				_, err = c.CoreV1().Services(meshNamespace).Create(generateMeshService(9090))
+				require.NoError(t, err)
+			},
+			wantService: generateMeshService(8080),
+		},
+		{
+			name: "updates mesh service",
+			createResources: func(t *testing.T, c *fake.Clientset) {
+				t.Helper()
+				_, err := c.CoreV1().Services("app").Create(generateAppService(9999))
+				require.NoError(t, err)
+			},
+			updateResources: func(t *testing.T, c *fake.Clientset) {
+				_, err := c.CoreV1().Services("app").Update(generateAppService(8080))
+				require.NoError(t, err)
+			},
+			wantService: generateMeshService(8080),
+		},
+		{
+			name: "deletes mesh service",
+			createResources: func(t *testing.T, c *fake.Clientset) {
+				t.Helper()
+				_, err := c.CoreV1().Services("app").Create(generateAppService(8080))
+				require.NoError(t, err)
+			},
+			updateResources: func(t *testing.T, c *fake.Clientset) {
+				t.Helper()
+				err := c.CoreV1().Services("app").Delete("foo", nil)
+				require.NoError(t, err)
+			},
+			wantMeshServiceDeletion: true,
+			wantService:             generateMeshService(8080),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			clientSet := fake.NewSimpleClientset()
+			factory := informers.NewSharedInformerFactory(clientSet, 0)
+
+			controller := mesher.NewController(clientSet, factory, meshNamespace, logger())
+
+			factory.Start(ctx.Done())
+
+			test.createResources(t, clientSet)
+			factory.WaitForCacheSync(ctx.Done())
+
+			go controller.Run()
+
+			// Forces the processing of the createResources events by the controller.
+			time.Sleep(time.Millisecond)
+
+			if test.updateResources != nil {
+				test.updateResources(t, clientSet)
+				factory.WaitForCacheSync(ctx.Done())
+			}
+
+			controller.ShutDown()
+			_ = controller.Wait(ctx)
+
+			if test.wantMeshServiceDeletion {
+				assertMeshServiceDeletion(t, clientSet, test.wantService)
+				return
+			}
+
+			assertHasService(t, clientSet, test.wantService)
+		})
+	}
+}
+
+func generateAppService(port int32) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "app",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       port,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+
+			Selector: map[string]string{
+				"app": "foo",
+			},
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+}
+
+func generateMeshService(port int32) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "maesh-foo-app",
+			Namespace: meshNamespace,
+			Labels: map[string]string{
+				"app":       "maesh",
+				"component": "mesh-svc",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       port,
+					TargetPort: intstr.FromInt(5000),
+				},
+			},
+			Selector: map[string]string{
+				"app":       "maesh",
+				"component": "mesh-node",
+			},
+		},
+	}
+}
+
+func updateRessourceDeleteService(t *testing.T, c *fake.Clientset) {
+	t.Helper()
+	err := c.CoreV1().Services("app").Delete("foo", &metav1.DeleteOptions{})
+	require.NoError(t, err)
+}
 
 func assertHasService(t *testing.T, c *fake.Clientset, want *corev1.Service) {
 	t.Helper()
@@ -23,64 +184,17 @@ func assertHasService(t *testing.T, c *fake.Clientset, want *corev1.Service) {
 	assert.Equal(t, want, got)
 }
 
-func TestController(t *testing.T) {
-	tests := []struct {
-		name            string
-		createResources func(*testing.T, *fake.Clientset)
+func assertMeshServiceDeletion(t *testing.T, c *fake.Clientset, svc *corev1.Service) {
+	t.Helper()
 
-		wantService *corev1.Service
-	}{
-		{
-			name: "creates mesh service",
-			createResources: func(t *testing.T, c *fake.Clientset) {
-				t.Helper()
-				c.CoreV1().Services("test").Create(&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "svc",
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name:       "http",
-								Protocol:   corev1.ProtocolTCP,
-								Port:       8080,
-								TargetPort: intstr.FromInt(8080),
-							},
-						},
-						Selector: map[string]string{
-							"app": "foo",
-						},
-						Type: corev1.ServiceTypeClusterIP,
-					},
-				})
-			},
-			wantService: &corev1.Service{},
-		},
-	}
+	_, err := c.CoreV1().Services(meshNamespace).Get(svc.GetName(), metav1.GetOptions{})
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
-
-			clientSet := fake.NewSimpleClientset()
-			factory := informers.NewSharedInformerFactory(clientSet, 0)
-
-			factory.Start(ctx.Done())
-			factory.WaitForCacheSync(ctx.Done())
-
-			controller := mesher.NewController(
-				clientSet.CoreV1().Services(metav1.NamespaceAll),
-				factory.Core().V1().Services(),
-				nil, // TODO ?
-			)
-
-			go controller.Run()
-
-			test.createResources(t, clientSet)
-			controller.ShutDown()
-			controller.Wait(ctx)
-
-			assertHasService(t, clientSet, test.wantService)
-		})
-	}
+func logger() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetOutput(os.Stdout)
+	l.SetLevel(logrus.InfoLevel)
+	return l
 }

--- a/internal/mesher/controller_test.go
+++ b/internal/mesher/controller_test.go
@@ -64,6 +64,23 @@ func TestController(t *testing.T) {
 			wantService: generateMeshService(8080),
 		},
 		{
+			name: "creates mesh service on update if deleted",
+			createResources: func(t *testing.T, c *fake.Clientset) {
+				t.Helper()
+				_, err := c.CoreV1().Services("app").Create(generateAppService(9999))
+				require.NoError(t, err)
+			},
+			updateResources: func(t *testing.T, c *fake.Clientset) {
+				t.Helper()
+				err := c.CoreV1().Services(meshNamespace).Delete("maesh-foo-app", nil)
+				require.NoError(t, err)
+
+				_, err = c.CoreV1().Services("app").Update(generateAppService(8080))
+				require.NoError(t, err)
+			},
+			wantService: generateMeshService(8080),
+		},
+		{
 			name: "deletes mesh service",
 			createResources: func(t *testing.T, c *fake.Clientset) {
 				t.Helper()

--- a/internal/mesher/controller_test.go
+++ b/internal/mesher/controller_test.go
@@ -1,0 +1,86 @@
+package mesher_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containous/maesh/internal/mesher"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func assertHasService(t *testing.T, c *fake.Clientset, want *corev1.Service) {
+	t.Helper()
+
+	got, err := c.CoreV1().Services(want.GetNamespace()).Get(want.GetName(), metav1.GetOptions{})
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestController(t *testing.T) {
+	tests := []struct {
+		name            string
+		createResources func(*testing.T, *fake.Clientset)
+
+		wantService *corev1.Service
+	}{
+		{
+			name: "creates mesh service",
+			createResources: func(t *testing.T, c *fake.Clientset) {
+				t.Helper()
+				c.CoreV1().Services("test").Create(&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "svc",
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Protocol:   corev1.ProtocolTCP,
+								Port:       8080,
+								TargetPort: intstr.FromInt(8080),
+							},
+						},
+						Selector: map[string]string{
+							"app": "foo",
+						},
+						Type: corev1.ServiceTypeClusterIP,
+					},
+				})
+			},
+			wantService: &corev1.Service{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			clientSet := fake.NewSimpleClientset()
+			factory := informers.NewSharedInformerFactory(clientSet, 0)
+
+			factory.Start(ctx.Done())
+			factory.WaitForCacheSync(ctx.Done())
+
+			controller := mesher.NewController(
+				clientSet.CoreV1().Services(metav1.NamespaceAll),
+				factory.Core().V1().Services(),
+				nil, // TODO ?
+			)
+
+			go controller.Run()
+
+			test.createResources(t, clientSet)
+			controller.ShutDown()
+			controller.Wait(ctx)
+
+			assertHasService(t, clientSet, test.wantService)
+		})
+	}
+}

--- a/internal/providers/base/base.go
+++ b/internal/providers/base/base.go
@@ -13,7 +13,6 @@ func Bool(v bool) *bool { return &v }
 // Provider is an interface for providers that allows the controller to interact with providers
 // without having to deal with specifics of said providers.
 type Provider interface {
-	Init()
 	BuildConfig() (*dynamic.Configuration, error)
 }
 

--- a/internal/resource/identifier.go
+++ b/internal/resource/identifier.go
@@ -1,0 +1,79 @@
+package resource
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+// Maesh resources labels.
+const (
+	AppLabel       = "app"
+	ComponentLabel = "component"
+
+	AppLabelMaesh          = "maesh"
+	ComponentLabelMeshSvc  = "mesh-svc"
+	ComponentLabelMeshNode = "mesh-node"
+)
+
+// MeshServiceLabels returns the labels to apply to a mesh service
+func MeshServiceLabels() map[string]string {
+	return map[string]string{
+		AppLabel:       AppLabelMaesh,
+		ComponentLabel: ComponentLabelMeshSvc,
+	}
+}
+
+// MeshServiceSelector returns the selectors carried by a mesh service.
+func MeshServiceSelector() map[string]string {
+	return map[string]string{
+		AppLabel:       AppLabelMaesh,
+		ComponentLabel: ComponentLabelMeshNode,
+	}
+}
+
+// IsMeshService returns true if a service is a mesh service.
+func IsMeshService(obj interface{}) (bool, error) {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return false, err
+	}
+
+	objLabels := objMeta.GetLabels()
+
+	isMaeshResource := objLabels[AppLabel] == AppLabelMaesh
+	isMeshSvc := objLabels[ComponentLabel] == ComponentLabelMeshSvc
+
+	return isMaeshResource && isMeshSvc, nil
+}
+
+// IsMeshPod returns true if an object is a mesh pod.
+func IsMeshPod(obj interface{}) (bool, error) {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return false, err
+	}
+
+	objLabels := objMeta.GetLabels()
+
+	isMaeshResource := objLabels[AppLabel] == AppLabelMaesh
+	isMeshNode := objLabels[ComponentLabel] == ComponentLabelMeshNode
+
+	return isMaeshResource && isMeshNode, nil
+}
+
+// MeshPodsLabelsSelector returns the selector to apply when looking for maesh pods.
+func MeshPodsLabelsSelector() labels.Selector {
+	sel := labels.Everything()
+	sel = sel.Add(mustRequirement(labels.NewRequirement(AppLabel, selection.Equals, []string{AppLabelMaesh})))
+	sel = sel.Add(mustRequirement(labels.NewRequirement(ComponentLabel, selection.Equals, []string{ComponentLabelMeshNode})))
+	return sel
+}
+
+func mustRequirement(c *labels.Requirement, err error) labels.Requirement {
+	if err != nil {
+		panic(err)
+	}
+
+	return *c
+}


### PR DESCRIPTION
Hello hello,

### What does this PR do ? 

I spent some time thinking about this controller issue trying to split it.

To sum up what I've did:

I split the controller into two control loops, to make sure that one control loop does only one thing, this is what's recommended when writing a k8s controllers.

- The `mesher` loop, in charge of maintaining the collection of maesh services. 
- The `configurator` loop, in charge of watching every elements impacting the mesh nodes dynamic configuration and reconfigure all the mesh nodes. 

The second loop is highly subject to events (mostly because it actually depends/watches on a lot of resources) so I reintroduced back the workqueues in this controller which provides rate limiting easily in that case.
It also provides retries at event level, if the control loop cannot handle an error for some reason, then it gets requeued and will be processed after a while.

To finish, it fully relies on observers Listers.

WDYT of this ?

### How to test it ?

Build and update and image on your k8s cluster, and deploy a set of mesh nodes (applying this directory [here for instance](https://github.com/jlevesy/maesh-dev/tree/master/k8s/maesh)).

### Additional information

- It's a naive implementation, my goal is is demonstrate that this architecture works. It doesn't support TCP nor SMI.
- Test coverage is not complete.