### PR TITLE
Enforce HSTS with netlify toml config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,4 +10,4 @@ command = "sh -x scripts/netlify-run.sh"
   # Define which paths this specific [[headers]] block will cover.
   for = "/*"
   [headers.values]
-    Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload;"
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,9 @@ base = "docs"
 
 # Path relative to the "base" directory
 command = "sh -x scripts/netlify-run.sh"
+
+[[headers]]
+  # Define which paths this specific [[headers]] block will cover.
+  for = "/*"
+  [headers.values]
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload;"


### PR DESCRIPTION
Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>

Result:

```bash
curl -I https://deploy-preview-362--maesh-doc.netlify.com/
HTTP/2 200 
# (...)
strict-transport-security: max-age=31536000; includeSubDomains; preload;
# (...)
```