### PR TITLE
Make metrics subchart more configurable

### DIFF
--- a/helm/chart/maesh/Guidelines.md
+++ b/helm/chart/maesh/Guidelines.md
@@ -28,7 +28,7 @@ This feature is critical, and therefore is defined clearly in the `values.yaml` 
 
 This feature is non-critical, and therefore is commented out by default in the `values.yaml` file.
 
-To allow this, template blocks that use this need to recursively test for existance of values before using them:
+To allow this, template blocks that use this need to recursively test for existence of values before using them:
 
 ```yaml
 {{- if .Values.storage}}
@@ -52,10 +52,10 @@ The non-critical feature defaults should be populated so that they can be enable
 ```
 
 The `volume` option is clearly optional, and non-critical.
-It is commented out (apart from the storage section comment block), and is also preceeded by a comment of `# (Optional)` in the preceeding line.
+It is commented out (apart from the storage section comment block), and is also preceded by a comment of `# (Optional)` in the preceding line.
 This facilitates configuration, when the storage section is uncommented, the optional features are still disabled by default.
 
-Similar to non-critical feaures, these options need to be tested for existance before use in the template.
+Similar to non-critical features, these options need to be tested for existence before use in the template.
 
 #### Note
 
@@ -90,7 +90,7 @@ Conditionals should chomp whitespace:
 {{- end }}
 ```
 
-There should be an empty commented line between each primary key in the `values.yaml` file to separate features from eachother.
+There should be an empty commented line between each primary key in the `values.yaml` file to separate features from each other.
 
 ## Values YAML Design
 

--- a/helm/chart/maesh/charts/metrics/templates/grafana.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/grafana.yaml
@@ -35,13 +35,9 @@ spec:
         ports:
         - name: web
           containerPort: 3000
-        resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
+        {{- if .Values.grafana.resources }}
+        {{- toYaml .Values.grafana.resources | indent 8 }}
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /api/health

--- a/helm/chart/maesh/charts/metrics/templates/prometheus.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/prometheus.yaml
@@ -116,13 +116,9 @@ spec:
             path: "/-/healthy"
             port: webui
           initialDelaySeconds: 5
-        resources:
-          requests:
-            cpu: 500m
-            memory: 500M
-          limits:
-            cpu: 500m
-            memory: 500M
+        {{- if .Values.prometheus.resources }}
+        {{- toYaml .Values.prometheus.resources | indent 8 }}
+        {{- end }}
         volumeMounts:
         - name: config-volume
           mountPath: /prometheus/config

--- a/helm/chart/maesh/charts/metrics/templates/storage.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/storage.yaml
@@ -14,7 +14,9 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: {{ .Values.storageClass }}
+  {{- if .Values.grafana.storageClassName }}
+  storageClassName: "{{ .Values.grafana.storageClassName }}"
+  {{- end }}
 
 ---
 apiVersion: v1
@@ -32,4 +34,6 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: {{ .Values.storageClass }}
+  {{- if .Values.prometheus.storageClassName }}
+  storageClassName: "{{ .Values.prometheus.storageClassName }}"
+  {{- end }}

--- a/helm/chart/maesh/charts/metrics/values.yaml
+++ b/helm/chart/maesh/charts/metrics/values.yaml
@@ -5,9 +5,9 @@ image:
 
 grafana:
   ## storageClassName: "" disables dynamic provisioning
-  ## if undefined (default) or null, no storageClassName spec is
+  ## if undefined or null, no storageClassName spec is
   ##   set, choosing the default provisioner
-  # storageClassName: ""
+  storageClassName: null
   ## resource requests and limits. none if not set.
   # resources:
   #   limit:
@@ -19,9 +19,9 @@ grafana:
 
 prometheus:
   ## storageClassName: "" disables dynamic provisioning
-  ## if undefined (default) or null, no storageClassName spec is
+  ## if undefined or null, no storageClassName spec is
   ##   set, choosing the default provisioner
-  # storageClassName: ""
+  storageClassName: null
   ## resource requests and limits. none if not set.
   # resources:
   #   limit:

--- a/helm/chart/maesh/charts/metrics/values.yaml
+++ b/helm/chart/maesh/charts/metrics/values.yaml
@@ -8,8 +8,25 @@ grafana:
   ## if undefined (default) or null, no storageClassName spec is
   ##   set, choosing the default provisioner
   # storageClassName: ""
+  ## resource requests and limits. none if not set.
+  # resources:
+  #   limit:
+  #     mem: "100Mi"
+  #     cpu: "100m"
+  #   request:
+  #     mem: "100Mi"
+  #     cpu: "100m"
+
 prometheus:
   ## storageClassName: "" disables dynamic provisioning
   ## if undefined (default) or null, no storageClassName spec is
   ##   set, choosing the default provisioner
   # storageClassName: ""
+  ## resource requests and limits. none if not set.
+  # resources:
+  #   limit:
+  #     mem: "500Mi"
+  #     cpu: "500m"
+  #   request:
+  #     mem: "500Mi"
+  #     cpu: "500m"

--- a/helm/chart/maesh/charts/metrics/values.yaml
+++ b/helm/chart/maesh/charts/metrics/values.yaml
@@ -2,4 +2,14 @@ image:
   prometheus: prom/prometheus:v2.11.1
   grafana: grafana/grafana:6.2.5
   configmapReload: jimmidyson/configmap-reload:v0.2.2
-storageClass: local-path
+
+grafana:
+  ## storageClassName: "" disables dynamic provisioning
+  ## if undefined (default) or null, no storageClassName spec is
+  ##   set, choosing the default provisioner
+  # storageClassName: ""
+prometheus:
+  ## storageClassName: "" disables dynamic provisioning
+  ## if undefined (default) or null, no storageClassName spec is
+  ##   set, choosing the default provisioner
+  # storageClassName: ""

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -54,7 +54,7 @@ mesh:
 tracing:
   deploy: true
   jaeger:
-    image: 
+    image:
       name: groundnuty/k8s-wait-for:v1.2
     enabled: true
     localagenthostport: ""
@@ -65,8 +65,11 @@ tracing:
 #
 metrics:
   deploy: true
-  prometheus:
-    enabled: true
+  ## you can override values of the metrics subchart here.
+  ## check charts/metrics/values.yaml for the defaults.
+  ## example:
+  # grafana:
+  #   storageClassName: "metrics-storage"
 
 smi:
   deploycrds: true

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -66,7 +66,7 @@ tracing:
 metrics:
   deploy: true
   prometheus:
-    # whether to expose Proometheus metrics
+    # whether to expose Prometheus metrics
     enabled: true
   ## you can override values of the metrics subchart here.
   ## check charts/metrics/values.yaml for the defaults.

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -70,6 +70,14 @@ metrics:
   ## example:
   # grafana:
   #   storageClassName: "metrics-storage"
+  # prometheus:
+  #   resources:
+  #     limit:
+  #       mem: "500Mi"
+  #       cpu: "500m"
+  #     request:
+  #       mem: "200Mi"
+  #       cpu: "200m"
 
 smi:
   deploycrds: true

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -65,12 +65,14 @@ tracing:
 #
 metrics:
   deploy: true
+  prometheus:
+    # whether to expose Proometheus metrics
+    enabled: true
   ## you can override values of the metrics subchart here.
   ## check charts/metrics/values.yaml for the defaults.
   ## example:
   # grafana:
   #   storageClassName: "metrics-storage"
-  # prometheus:
   #   resources:
   #     limit:
   #       mem: "500Mi"


### PR DESCRIPTION
This PR:
* fixes some typos in Guidlines.md
* makes it possible to pass StorageClassName to Grafana/Prometheus in the metrics subchart
* makes it possible to pass resource requests/limits to the metrics subchart (the default requests were pretty high, especially for Prometheus)

Fixes #360 