### PR TITLE
Use initContainers to fix volume permissions

### DIFF
--- a/helm/chart/maesh/charts/metrics/templates/grafana.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/grafana.yaml
@@ -62,6 +62,16 @@ spec:
         - name: grafana-config
           mountPath: /etc/grafana
           readOnly: true
+      initContainers:
+      - name: metrics-storage-permission-fix
+        image: busybox
+        command: ["chown", "-R", "472:472", "/var/lib/grafana"]
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+        volumeMounts:
+        - name: metrics-storage
+          mountPath: /var/lib/grafana
       volumes:
       - name: metrics-storage
         persistentVolumeClaim:

--- a/helm/chart/maesh/charts/metrics/templates/prometheus.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/prometheus.yaml
@@ -147,6 +147,16 @@ spec:
           requests:
             cpu: 10m
             memory: 10Mi
+      initContainers:
+      - name: prometheus-storage-permission-fix
+        image: busybox
+        command: ["/bin/chown", "-R", "1000:2000", "/prometheus"]
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+        volumeMounts:
+        - name: prometheus-storage
+          mountPath: /prometheus
       volumes:
       - name: prometheus-storage
         persistentVolumeClaim:


### PR DESCRIPTION
When using Maesh with minikube the first time you run `helm install --name=maesh --namespace=maesh` everthing works nice. But minikube being a local development thingy it is quite common to `minikube stop` the cluster and then `minikube start` it again. Also known as rebooting. :wink: 

After the reboot the grafana and prometheus pods would not start and report some permission error. After digging around a while I figured the pods are run with a specific uid/gid and the volumes are mounted with root user id.

I'm not sure if I have provided a workaround or an actual fix. Maybe this PR needs more polishing. If so, please let me know.