### PR TITLE
Use custom separator for service name and namespace

### DIFF
--- a/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
@@ -30,8 +30,8 @@ data:
     maesh:53 {
         errors
         rewrite continue {
-            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh maesh-{1}-bWFlc2g-{2}.maesh.svc.{{ default "cluster.local" .Values.clusterDomain }}
-            answer name maesh-([a-zA-Z0-9-_]*)-bWFlc2g-([a-zA-Z0-9-_]*)\.maesh\.svc\.{{ default "cluster.local" .Values.clusterDomain | replace "." "\\." }} {1}.{2}.maesh
+            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh maesh-{1}-6d61657368-{2}.maesh.svc.{{ default "cluster.local" .Values.clusterDomain }}
+            answer name maesh-([a-zA-Z0-9-_]*)-6d61657368-([a-zA-Z0-9-_]*)\.maesh\.svc\.{{ default "cluster.local" .Values.clusterDomain | replace "." "\\." }} {1}.{2}.maesh
         }
         kubernetes {{ default "cluster.local" .Values.clusterDomain }} in-addr.arpa ip6.arpa {
             pods insecure

--- a/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
@@ -30,8 +30,8 @@ data:
     maesh:53 {
         errors
         rewrite continue {
-            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh maesh-{1}-shadow-service-{2}.maesh.svc.{{ default "cluster.local" .Values.clusterDomain }}
-            answer name maesh-([a-zA-Z0-9-_]*)-shadow-service-([a-zA-Z0-9-_]*)\.maesh\.svc\.{{ default "cluster.local" .Values.clusterDomain | replace "." "\\." }} {1}.{2}.maesh
+            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh maesh-{1}-bWFlc2g-{2}.maesh.svc.{{ default "cluster.local" .Values.clusterDomain }}
+            answer name maesh-([a-zA-Z0-9-_]*)-bWFlc2g-([a-zA-Z0-9-_]*)\.maesh\.svc\.{{ default "cluster.local" .Values.clusterDomain | replace "." "\\." }} {1}.{2}.maesh
         }
         kubernetes {{ default "cluster.local" .Values.clusterDomain }} in-addr.arpa ip6.arpa {
             pods insecure

--- a/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
@@ -30,8 +30,8 @@ data:
     maesh:53 {
         errors
         rewrite continue {
-            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh maesh-{1}-{2}.maesh.svc.{{ default "cluster.local" .Values.clusterDomain }}
-            answer name maesh-([a-zA-Z0-9-_]*)-([a-zA-Z0-9-_]*)\.maesh\.svc\.{{ default "cluster.local" .Values.clusterDomain | replace "." "\\." }} {1}.{2}.maesh
+            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh maesh-{1}-shadow-service-{2}.maesh.svc.{{ default "cluster.local" .Values.clusterDomain }}
+            answer name maesh-([a-zA-Z0-9-_]*)-shadow-service-([a-zA-Z0-9-_]*)\.maesh\.svc\.{{ default "cluster.local" .Values.clusterDomain | replace "." "\\." }} {1}.{2}.maesh
         }
         kubernetes {{ default "cluster.local" .Values.clusterDomain }} in-addr.arpa ip6.arpa {
             pods insecure

--- a/integration/kubernetes_test.go
+++ b/integration/kubernetes_test.go
@@ -34,6 +34,17 @@ func (s *KubernetesSuite) TestHTTPCURL(c *check.C) {
 	s.waitKubectlExecCommand(c, argSlice, "whoami")
 }
 
+func (s *KubernetesSuite) TestHTTPCURLWithDashInNamespace(c *check.C) {
+	// Get the tools pod service in whoami namespace
+	pod := s.getToolsPodMaesh(c)
+	c.Assert(pod, checker.NotNil)
+
+	argSlice := []string{
+		"exec", "-it", pod.Name, "-n", pod.Namespace, "-c", pod.Spec.Containers[0].Name, "--", "curl", "whoami.whoami-test.maesh", "--max-time", "5",
+	}
+	s.waitKubectlExecCommand(c, argSlice, "whoami")
+}
+
 func (s *KubernetesSuite) TestTCPCURL(c *check.C) {
 	// Get the tools pod service in whoami namespace
 	pod := s.getToolsPodMaesh(c)
@@ -41,6 +52,17 @@ func (s *KubernetesSuite) TestTCPCURL(c *check.C) {
 
 	argSlice := []string{
 		"exec", "-it", pod.Name, "-n", pod.Namespace, "-c", pod.Spec.Containers[0].Name, "--", "curl", "whoami-tcp.whoami.maesh", "--max-time", "5",
+	}
+	s.waitKubectlExecCommand(c, argSlice, "whoami-tcp")
+}
+
+func (s *KubernetesSuite) TestTCPCURLWithDashInNamespace(c *check.C) {
+	// Get the tools pod service in whoami namespace
+	pod := s.getToolsPodMaesh(c)
+	c.Assert(pod, checker.NotNil)
+
+	argSlice := []string{
+		"exec", "-it", pod.Name, "-n", pod.Namespace, "-c", pod.Spec.Containers[0].Name, "--", "curl", "whoami-tcp.whoami-test.maesh", "--max-time", "5",
 	}
 	s.waitKubectlExecCommand(c, argSlice, "whoami-tcp")
 }

--- a/integration/resources/whoami/0-namespace.yaml
+++ b/integration/resources/whoami/0-namespace.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: whoami

--- a/integration/resources/whoami/0-namespaces.yaml
+++ b/integration/resources/whoami/0-namespaces.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: whoami
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: whoami-test

--- a/integration/resources/whoami/whoami-test.yaml
+++ b/integration/resources/whoami/whoami-test.yaml
@@ -1,0 +1,55 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: whoami
+  namespace: whoami-test
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: whoami
+  template:
+    metadata:
+      labels:
+        app: whoami
+    spec:
+      containers:
+      - name: whoami
+        image: containous/whoami:v1.0.1
+        imagePullPolicy: IfNotPresent
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+  namespace: whoami-test
+  labels:
+    app: whoami
+  annotations:
+    maesh.containo.us/traffic-type: "http"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    name: whoami
+  selector:
+    app: whoami
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami-tcp
+  namespace: whoami-test
+  labels:
+    app: whoami
+  annotations:
+    maesh.containo.us/traffic-type: "tcp"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: whoami
+  selector:
+    app: whoami

--- a/integration/smi_test.go
+++ b/integration/smi_test.go
@@ -33,8 +33,7 @@ func (s *SMISuite) TestSMIAccessControl(c *check.C) {
 	err := s.installHelmMaesh(c, true, false)
 	c.Assert(err, checker.IsNil)
 	s.waitForMaeshControllerStarted(c)
-	s.createResources(c, "resources/smi/access-control/")
-	time.Sleep(5 * time.Second)
+	s.createResources(c, "resources/smi/access-control/", 10*time.Second)
 
 	testCases := []struct {
 		desc        string
@@ -193,9 +192,7 @@ func (s *SMISuite) TestSMIAccessControl(c *check.C) {
 }
 
 func (s *SMISuite) TestSMITrafficSplit(c *check.C) {
-	s.createResources(c, "resources/smi/traffic-split")
-
-	time.Sleep(10 * time.Second)
+	s.createResources(c, "resources/smi/traffic-split", 10*time.Second)
 
 	err := s.installHelmMaesh(c, true, false)
 	c.Assert(err, checker.IsNil)
@@ -339,9 +336,7 @@ func (s *SMISuite) TestSMITrafficSplit(c *check.C) {
 
 			err = s.client.KubeClient.CoreV1().Services("default").Delete("b", &metav1.DeleteOptions{})
 			c.Assert(err, checker.IsNil)
-			s.createResources(c, "resources/smi/traffic-split")
-
-			time.Sleep(10 * time.Second)
+			s.createResources(c, "resources/smi/traffic-split", 10*time.Second)
 		}
 
 		argSlice := []string{
@@ -397,13 +392,14 @@ func (s *SMISuite) getLineContent(data string) string {
 	return ""
 }
 
-func (s *SMISuite) createResources(c *check.C, dirPath string) {
+func (s *SMISuite) createResources(c *check.C, dirPath string, waitTime time.Duration) {
 	// Create the required objects from the smi directory
 	cmd := exec.Command("kubectl", "apply",
 		"-f", path.Join(s.dir, dirPath))
 	cmd.Env = os.Environ()
 	_, err := cmd.CombinedOutput()
 	c.Assert(err, checker.IsNil)
+	time.Sleep(waitTime)
 }
 
 func (s *SMISuite) deleteResources(c *check.C, dirPath string, force bool) {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -415,7 +415,7 @@ func (c *Controller) updateMeshService(oldUserService *corev1.Service, newUserSe
 
 // userServiceToMeshServiceName converts a User service with a namespace to a mesh service name.
 func (c *Controller) userServiceToMeshServiceName(serviceName string, namespace string) string {
-	return fmt.Sprintf("%s-%s-bWFlc2g-%s", c.meshNamespace, serviceName, namespace)
+	return fmt.Sprintf("%s-%s-6d61657368-%s", c.meshNamespace, serviceName, namespace)
 }
 
 func (c *Controller) loadTCPStateTable() (*k8s.State, error) {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -415,7 +415,7 @@ func (c *Controller) updateMeshService(oldUserService *corev1.Service, newUserSe
 
 // userServiceToMeshServiceName converts a User service with a namespace to a mesh service name.
 func (c *Controller) userServiceToMeshServiceName(serviceName string, namespace string) string {
-	return fmt.Sprintf("%s-%s-%s", c.meshNamespace, serviceName, namespace)
+	return fmt.Sprintf("%s-%s-shadow-service-%s", c.meshNamespace, serviceName, namespace)
 }
 
 func (c *Controller) loadTCPStateTable() (*k8s.State, error) {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -415,7 +415,7 @@ func (c *Controller) updateMeshService(oldUserService *corev1.Service, newUserSe
 
 // userServiceToMeshServiceName converts a User service with a namespace to a mesh service name.
 func (c *Controller) userServiceToMeshServiceName(serviceName string, namespace string) string {
-	return fmt.Sprintf("%s-%s-shadow-service-%s", c.meshNamespace, serviceName, namespace)
+	return fmt.Sprintf("%s-%s-bWFlc2g-%s", c.meshNamespace, serviceName, namespace)
 }
 
 func (c *Controller) loadTCPStateTable() (*k8s.State, error) {

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -362,8 +362,8 @@ func (w *ClientWrapper) patchCoreDNSConfigMap(coreDeployment *appsv1.Deployment,
 maesh:53 {
     errors
     rewrite continue {
-        name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh %[3]s-{1}-shadow-service-{2}.%[3]s.svc.%[1]s
-        answer name %[3]s-([a-zA-Z0-9-_]*)-shadow-service-([a-zA-Z0-9-_]*)\.%[3]s\.svc\.%[2]s {1}.{2}.maesh
+        name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh %[3]s-{1}-bWFlc2g-{2}.%[3]s.svc.%[1]s
+        answer name %[3]s-([a-zA-Z0-9-_]*)-bWFlc2g-([a-zA-Z0-9-_]*)\.%[3]s\.svc\.%[2]s {1}.{2}.maesh
     }
     kubernetes %[1]s in-addr.arpa ip6.arpa {
         pods insecure

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -362,8 +362,8 @@ func (w *ClientWrapper) patchCoreDNSConfigMap(coreDeployment *appsv1.Deployment,
 maesh:53 {
     errors
     rewrite continue {
-        name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh %[3]s-{1}-bWFlc2g-{2}.%[3]s.svc.%[1]s
-        answer name %[3]s-([a-zA-Z0-9-_]*)-bWFlc2g-([a-zA-Z0-9-_]*)\.%[3]s\.svc\.%[2]s {1}.{2}.maesh
+        name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh %[3]s-{1}-6d61657368-{2}.%[3]s.svc.%[1]s
+        answer name %[3]s-([a-zA-Z0-9-_]*)-6d61657368-([a-zA-Z0-9-_]*)\.%[3]s\.svc\.%[2]s {1}.{2}.maesh
     }
     kubernetes %[1]s in-addr.arpa ip6.arpa {
         pods insecure

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -362,8 +362,8 @@ func (w *ClientWrapper) patchCoreDNSConfigMap(coreDeployment *appsv1.Deployment,
 maesh:53 {
     errors
     rewrite continue {
-        name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh %[3]s-{1}-{2}.%[3]s.svc.%[1]s
-        answer name %[3]s-([a-zA-Z0-9-_]*)-([a-zA-Z0-9-_]*)\.%[3]s\.svc\.%[2]s {1}.{2}.maesh
+        name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh %[3]s-{1}-shadow-service-{2}.%[3]s.svc.%[1]s
+        answer name %[3]s-([a-zA-Z0-9-_]*)-shadow-service-([a-zA-Z0-9-_]*)\.%[3]s\.svc\.%[2]s {1}.{2}.maesh
     }
     kubernetes %[1]s in-addr.arpa ip6.arpa {
         pods insecure


### PR DESCRIPTION
This PR:

- Uses a custom separator `-shadow-service-` instead of `-` to separate name and namespace
- Adds integration tests to ensure dashes in names and namespaces work

Fixes #378 