### PR TITLE
Add a note about helm v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To run this app, you require the following:
 - CoreDNS installed as [Cluster DNS Provider](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/) (versions 1.3+ supported)
 - Helm v3
 
-## Install
+## Install (Helm v2 only)
 
 ```shell
 helm repo add maesh https://containous.github.io/maesh/charts

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -26,7 +26,7 @@ make
 ## Deploy helm chart
 
 ??? Note "Helm V3"
-    Please keep in mind, that our current Helm Chart is v2 compatible only. The v3 compatible Chart will be released with v1.1 of Maesh.
+    Please keep in mind, that our current Helm Chart (v1.0.0) is v2 compatible only. The v3 compatible Chart will be released with v1.1 of Maesh.
 
 To deploy the helm chart, run:
 

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -25,6 +25,9 @@ make
 
 ## Deploy helm chart
 
+??? Note "Helm V3"
+    Please keep in mind, that our current Helm Chart is v2 compatible only. The v3 compatible Chart will be released with v1.1 of Maesh.
+
 To deploy the helm chart, run:
 
 ```shell


### PR DESCRIPTION
Fixes #392 

The installation of the chart will fail with Helm v3. Adding a temporary note might make things clearer.