### PR TITLE
Rework test condition

### DIFF
--- a/internal/providers/smi/provider_test.go
+++ b/internal/providers/smi/provider_test.go
@@ -161,7 +161,11 @@ func TestGetTrafficTargetsWithDestinationInNamespace(t *testing.T) {
 	assert.NoError(t, err)
 
 	actual := provider.getTrafficTargetsWithDestinationInNamespace("foo", allTrafficTargets)
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, len(actual), len(expected))
+
+	for _, expectedValue := range expected {
+		assert.Contains(t, actual, expectedValue)
+	}
 }
 
 func TestBuildHTTPRouterFromTrafficTarget(t *testing.T) {


### PR DESCRIPTION
This PR:

- Reworks a test condition so that the contents of a slice are checked to exist, rather than the slice explicitly being equal.

Kubernetes does not guarantee results are returned in any order, and therefore we can end up with the same list of objects in a different order.

This is not equal in golang, but is equal for kubernetes, and therefore we can relax our testing to ensure that the results are the same length, and that they contain all of our expected elements.

Fixes #397 