### PR TITLE
Update k3s to use k8s 1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ helm-lint: helm
 	helm lint helm/chart/maesh
 
 k3d:
-	@command -v k3d >/dev/null 2>&1 || curl -s https://raw.githubusercontent.com/rancher/k3d/v1.3.4/install.sh | TAG=v1.3.4 bash
+	@command -v k3d >/dev/null 2>&1 || curl -s https://raw.githubusercontent.com/rancher/k3d/v1.5.1/install.sh | TAG=v1.5.1 bash
 
 pages:
 	mkdir -p $(CURDIR)/pages


### PR DESCRIPTION
This PR:

- Updates k3d to 1.5.1, which uses k3s 1.17

This PR paves the way for dev on #385 