### PR TITLE
Update regex rule for HTTPRouteGroup

### DIFF
--- a/integration/smi_test.go
+++ b/integration/smi_test.go
@@ -180,7 +180,7 @@ func (s *SMISuite) TestSMIAccessControl(c *check.C) {
 
 	for _, test := range testCases {
 		argSlice := []string{
-			"exec", "-it", test.source, "--", "curl", "-v", test.destination + test.path, "--max-time", "5",
+			"exec", "-i", test.source, "--", "curl", "-v", test.destination + test.path, "--max-time", "5",
 		}
 
 		c.Log(test.desc)

--- a/integration/smi_test.go
+++ b/integration/smi_test.go
@@ -350,7 +350,7 @@ func (s *SMISuite) TestSMITrafficSplit(c *check.C) {
 		}
 
 		argSlice := []string{
-			"exec", "-it", test.source, "--", "curl", "-v", test.destinationHost + test.destinationPath, "--max-time", "5",
+			"exec", "-i", test.source, "--", "curl", "-v", test.destinationHost + test.destinationPath, "--max-time", "5",
 		}
 
 		c.Log(test.desc)

--- a/internal/providers/smi/provider.go
+++ b/internal/providers/smi/provider.go
@@ -376,11 +376,14 @@ func (p *Provider) buildTCPRouterFromTrafficTarget(trafficTarget *access.Traffic
 
 func (p *Provider) buildRuleSnippetFromServiceAndMatch(name, namespace, ip string, match specs.HTTPMatch) string {
 	var result []string
+
 	if len(match.PathRegex) > 0 {
 		preparedPath := match.PathRegex
+
 		if strings.HasPrefix(match.PathRegex, "/") {
 			preparedPath = strings.TrimPrefix(preparedPath, "/")
 		}
+
 		result = append(result, fmt.Sprintf("PathPrefix(`/{path:%s}`)", preparedPath))
 	}
 

--- a/internal/providers/smi/provider.go
+++ b/internal/providers/smi/provider.go
@@ -377,7 +377,11 @@ func (p *Provider) buildTCPRouterFromTrafficTarget(trafficTarget *access.Traffic
 func (p *Provider) buildRuleSnippetFromServiceAndMatch(name, namespace, ip string, match specs.HTTPMatch) string {
 	var result []string
 	if len(match.PathRegex) > 0 {
-		result = append(result, fmt.Sprintf("PathPrefix(`{path:%s}`)", match.PathRegex))
+		preparedPath := match.PathRegex
+		if strings.HasPrefix(match.PathRegex, "/") {
+			preparedPath = strings.TrimPrefix(preparedPath, "/")
+		}
+		result = append(result, fmt.Sprintf("PathPrefix(`/{path:%s}`)", preparedPath))
 	}
 
 	if len(match.Methods) > 0 && match.Methods[0] != "*" {

--- a/internal/providers/smi/provider.go
+++ b/internal/providers/smi/provider.go
@@ -377,7 +377,7 @@ func (p *Provider) buildTCPRouterFromTrafficTarget(trafficTarget *access.Traffic
 func (p *Provider) buildRuleSnippetFromServiceAndMatch(name, namespace, ip string, match specs.HTTPMatch) string {
 	var result []string
 	if len(match.PathRegex) > 0 {
-		result = append(result, fmt.Sprintf("PathPrefix(`%s`)", match.PathRegex))
+		result = append(result, fmt.Sprintf("PathPrefix(`{path:%s}`)", match.PathRegex))
 	}
 
 	if len(match.Methods) > 0 && match.Methods[0] != "*" {

--- a/internal/providers/smi/provider_test.go
+++ b/internal/providers/smi/provider_test.go
@@ -38,7 +38,7 @@ func TestBuildRuleSnippetFromServiceAndMatch(t *testing.T) {
 	}{
 		{
 			desc:     "method and regex in match",
-			expected: "PathPrefix(`{path:/foo}`) && Method(`GET`,`POST`) && (Host(`test.foo.maesh`) || Host(`10.0.0.1`))",
+			expected: "PathPrefix(`/{path:foo}`) && Method(`GET`,`POST`) && (Host(`test.foo.maesh`) || Host(`10.0.0.1`))",
 			match: specsv1alpha1.HTTPMatch{
 				Name:      "test",
 				Methods:   []string{"GET", "POST"},
@@ -55,7 +55,7 @@ func TestBuildRuleSnippetFromServiceAndMatch(t *testing.T) {
 		},
 		{
 			desc:     "prefix only in match",
-			expected: "PathPrefix(`{path:/foo}`) && (Host(`test.foo.maesh`) || Host(`10.0.0.1`))",
+			expected: "PathPrefix(`/{path:foo}`) && (Host(`test.foo.maesh`) || Host(`10.0.0.1`))",
 			match: specsv1alpha1.HTTPMatch{
 				Name:      "test",
 				PathRegex: "/foo",
@@ -63,7 +63,7 @@ func TestBuildRuleSnippetFromServiceAndMatch(t *testing.T) {
 		},
 		{
 			desc:     "prefix only with regex in match",
-			expected: "PathPrefix(`{path:.*}`) && (Host(`test.foo.maesh`) || Host(`10.0.0.1`))",
+			expected: "PathPrefix(`/{path:.*}`) && (Host(`test.foo.maesh`) || Host(`10.0.0.1`))",
 			match: specsv1alpha1.HTTPMatch{
 				Name:      "test",
 				PathRegex: ".*",
@@ -227,7 +227,7 @@ func TestBuildHTTPRouterFromTrafficTarget(t *testing.T) {
 			expected: &dynamic.Router{
 				EntryPoints: []string{"http-81"},
 				Service:     "example",
-				Rule:        "(PathPrefix(`{path:/metrics}`) && Method(`GET`) && (Host(`test.default.maesh`) || Host(`10.0.0.1`)))",
+				Rule:        "(PathPrefix(`/{path:metrics}`) && Method(`GET`) && (Host(`test.default.maesh`) || Host(`10.0.0.1`)))",
 				Middlewares: []string{"block-all"},
 			},
 		},
@@ -1290,7 +1290,7 @@ func TestBuildConfiguration(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"demo-servi-default-80-api-servic-default-5bb66e727779b5ba": {
 							EntryPoints: []string{"http-5000"},
-							Rule:        "(PathPrefix(`{path:/metrics}`) && Method(`GET`) && (Host(`demo-service.default.maesh`) || Host(`10.1.0.1`)))",
+							Rule:        "(PathPrefix(`/{path:metrics}`) && Method(`GET`) && (Host(`demo-service.default.maesh`) || Host(`10.1.0.1`)))",
 							Service:     "demo-servi-default-80-api-servic-default-5bb66e727779b5ba",
 							Middlewares: []string{"api-service-metrics-default-demo-servi-default-80-api-servic-default-5bb66e727779b5ba-whitelist"},
 						},

--- a/internal/providers/smi/provider_test.go
+++ b/internal/providers/smi/provider_test.go
@@ -38,7 +38,7 @@ func TestBuildRuleSnippetFromServiceAndMatch(t *testing.T) {
 	}{
 		{
 			desc:     "method and regex in match",
-			expected: "PathPrefix(`/foo`) && Method(`GET`,`POST`) && (Host(`test.foo.maesh`) || Host(`10.0.0.1`))",
+			expected: "PathPrefix(`{path:/foo}`) && Method(`GET`,`POST`) && (Host(`test.foo.maesh`) || Host(`10.0.0.1`))",
 			match: specsv1alpha1.HTTPMatch{
 				Name:      "test",
 				Methods:   []string{"GET", "POST"},
@@ -55,10 +55,18 @@ func TestBuildRuleSnippetFromServiceAndMatch(t *testing.T) {
 		},
 		{
 			desc:     "prefix only in match",
-			expected: "PathPrefix(`/foo`) && (Host(`test.foo.maesh`) || Host(`10.0.0.1`))",
+			expected: "PathPrefix(`{path:/foo}`) && (Host(`test.foo.maesh`) || Host(`10.0.0.1`))",
 			match: specsv1alpha1.HTTPMatch{
 				Name:      "test",
 				PathRegex: "/foo",
+			},
+		},
+		{
+			desc:     "prefix only with regex in match",
+			expected: "PathPrefix(`{path:.*}`) && (Host(`test.foo.maesh`) || Host(`10.0.0.1`))",
+			match: specsv1alpha1.HTTPMatch{
+				Name:      "test",
+				PathRegex: ".*",
 			},
 		},
 	}
@@ -219,7 +227,7 @@ func TestBuildHTTPRouterFromTrafficTarget(t *testing.T) {
 			expected: &dynamic.Router{
 				EntryPoints: []string{"http-81"},
 				Service:     "example",
-				Rule:        "(PathPrefix(`/metrics`) && Method(`GET`) && (Host(`test.default.maesh`) || Host(`10.0.0.1`)))",
+				Rule:        "(PathPrefix(`{path:/metrics}`) && Method(`GET`) && (Host(`test.default.maesh`) || Host(`10.0.0.1`)))",
 				Middlewares: []string{"block-all"},
 			},
 		},
@@ -1282,7 +1290,7 @@ func TestBuildConfiguration(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"demo-servi-default-80-api-servic-default-5bb66e727779b5ba": {
 							EntryPoints: []string{"http-5000"},
-							Rule:        "(PathPrefix(`/metrics`) && Method(`GET`) && (Host(`demo-service.default.maesh`) || Host(`10.1.0.1`)))",
+							Rule:        "(PathPrefix(`{path:/metrics}`) && Method(`GET`) && (Host(`demo-service.default.maesh`) || Host(`10.1.0.1`)))",
 							Service:     "demo-servi-default-80-api-servic-default-5bb66e727779b5ba",
 							Middlewares: []string{"api-service-metrics-default-demo-servi-default-80-api-servic-default-5bb66e727779b5ba-whitelist"},
 						},


### PR DESCRIPTION
This PR:

- Updates the rule construction to be in goregexp format, as required by Traefik (https://docs.traefik.io/v2.1/routing/routers/#rule)

This is becuase the PathMatch field is a user-provided regex, but it will not be in goregexp format.

Fixes #414 