### PR TITLE
Add informer sync test to prepare command

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -36,6 +36,7 @@ type PrepareConfig struct {
 	Debug         bool   `description:"Debug mode" export:"true"`
 	Namespace     string `description:"The namespace that maesh is installed in." export:"true"`
 	ClusterDomain string `description:"Your internal K8s cluster domain." export:"true"`
+	SMI           bool   `description:"Enable SMI operation" export:"true"`
 }
 
 // NewPrepareConfig creates PrepareConfig.
@@ -45,5 +46,6 @@ func NewPrepareConfig() *PrepareConfig {
 		Debug:         false,
 		Namespace:     "maesh",
 		ClusterDomain: "cluster.local",
+		SMI:           false,
 	}
 }

--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -10,20 +10,20 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// NewCmd builds a new Patch command.
+// NewCmd builds a new Prepare command.
 func NewCmd(pConfig *cmd.PrepareConfig, loaders []cli.ResourceLoader) *cli.Command {
 	return &cli.Command{
 		Name:          "prepare",
 		Description:   `Prepare command.`,
 		Configuration: pConfig,
 		Run: func(_ []string) error {
-			return patchCommand(pConfig)
+			return prepareCommand(pConfig)
 		},
 		Resources: loaders,
 	}
 }
 
-func patchCommand(pConfig *cmd.PrepareConfig) error {
+func prepareCommand(pConfig *cmd.PrepareConfig) error {
 	log.SetOutput(os.Stdout)
 	log.SetLevel(log.InfoLevel)
 

--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -45,7 +45,7 @@ func patchCommand(pConfig *cmd.PrepareConfig) error {
 	}
 
 	if err = clients.CheckInformersStart(pConfig.SMI); err != nil {
-		return fmt.Errorf("error during informer check: %v", err)
+		return fmt.Errorf("error during informer check: %v, this can be caused by pre-existing objects in your cluster that do not conform to the spec", err)
 	}
 
 	if err = clients.InitCluster(pConfig.Namespace, pConfig.ClusterDomain); err != nil {

--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -44,6 +44,10 @@ func patchCommand(pConfig *cmd.PrepareConfig) error {
 		return fmt.Errorf("error during cluster check: %v", err)
 	}
 
+	if err = clients.CheckInformersStart(pConfig.SMI); err != nil {
+		return fmt.Errorf("error during informer check: %v", err)
+	}
+
 	if err = clients.InitCluster(pConfig.Namespace, pConfig.ClusterDomain); err != nil {
 		return fmt.Errorf("error initializing cluster: %v", err)
 	}

--- a/helm/chart/maesh/templates/controller/controller-deployment.yaml
+++ b/helm/chart/maesh/templates/controller/controller-deployment.yaml
@@ -111,6 +111,9 @@ spec:
             {{- if .Values.controller.logging.debug }}
             - "--debug"
             {{- end }}
+            {{- if .Values.smi.enable }}
+            - "--smi"
+            {{- end }}
             - "--clusterdomain"
             - {{ default "cluster.local" .Values.clusterDomain | quote }}
             - "--namespace=$(POD_NAMESPACE)"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -116,16 +116,15 @@ func (s *BaseSuite) maeshPrepareWithArgs(args ...string) *exec.Cmd {
 
 func (s *BaseSuite) startMaeshBinaryCmd(c *check.C, smi bool) *exec.Cmd {
 	args := []string{}
+	if smi {
+		args = append(args, "--smi")
+	}
 
 	cmd := s.maeshPrepareWithArgs(args...)
 	cmd.Env = os.Environ()
 	output, err := cmd.CombinedOutput()
 	c.Log(string(output))
 	c.Assert(err, checker.IsNil)
-
-	if smi {
-		args = []string{"--smi"}
-	}
 
 	// Ignore the kube-system namespace since we don't care about system events.
 	args = append(args, "--ignoreNamespaces=kube-system")

--- a/integration/resources/smi/access-control-broken/1.tts.yaml
+++ b/integration/resources/smi/access-control-broken/1.tts.yaml
@@ -1,0 +1,20 @@
+---
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha1
+metadata:
+  name: a-b
+  namespace: test
+destination:
+  kind: ServiceAccount
+  name: true
+  namespace: test
+specs:
+- kind: HTTPRouteGroup
+  name: app-routes
+  namespace: 0
+  matches:
+  - foo
+sources:
+- kind: ServiceAccount
+  name: a
+  namespace: false

--- a/integration/smi_test.go
+++ b/integration/smi_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/go-check/check"
@@ -43,6 +44,19 @@ func (s *SMISuite) TestSMIAccessControl(c *check.C) {
 	s.checkWhitelistSourceRanges(c, config)
 	s.checkHTTPServiceServerURLs(c, config)
 	s.checkTCPServiceServerURLs(c, config)
+}
+
+func (s *SMISuite) TestSMIAccessControlPrepareFail(c *check.C) {
+	s.createResources(c, "resources/smi/access-control-broken/")
+	defer s.deleteResources(c, "resources/smi/access-control-broken/", true)
+
+	args := []string{"--smi"}
+	cmd := s.maeshPrepareWithArgs(args...)
+	cmd.Env = os.Environ()
+	output, err := cmd.CombinedOutput()
+
+	c.Log(string(output))
+	c.Assert(err, checker.NotNil)
 }
 
 func (s *SMISuite) TestSMITrafficSplit(c *check.C) {

--- a/integration/smi_test.go
+++ b/integration/smi_test.go
@@ -48,7 +48,7 @@ func (s *SMISuite) TestSMIAccessControl(c *check.C) {
 
 func (s *SMISuite) TestSMIAccessControlPrepareFail(c *check.C) {
 	s.createResources(c, "resources/smi/access-control-broken/")
-	defer s.deleteResources(c, "resources/smi/access-control-broken/", true)
+	defer s.deleteResources(c, "resources/smi/access-control-broken/", false)
 
 	args := []string{"--smi"}
 	cmd := s.maeshPrepareWithArgs(args...)


### PR DESCRIPTION
This PR:

- Adds an informer sync test to the prepare command to ensure that the informers will start when the controller starts.

This prevents a situation where the controller starts, but the sync doesn't occur, and the result is empty listers that create empty configurations.

Fixes #413 