### PR TITLE
Allow single test suites to be run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ endif
 	CGO_ENABLED=0 go test ./integration -integration $(INTEGRATION_TEST_OPTS)
 
 test-integration-nobuild: $(DIST_DIR) kubectl helm k3d
-	CGO_ENABLED=0 go test ./integration -integration $(INTEGRATION_TEST_OPTS)
+	CGO_ENABLED=0 go test ./integration -integration $(INTEGRATION_TEST_OPTS) $(TESTFLAGS)
 
 kubectl:
 	@command -v kubectl >/dev/null 2>&1 || (curl -LO https://storage.googleapis.com/kubernetes-release/release/$(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv ./kubectl /usr/local/bin/kubectl)

--- a/docs/content/building.md
+++ b/docs/content/building.md
@@ -20,6 +20,7 @@ TESTFLAGS="-check.f MyTestSuite.My" make test-integration
 # Run every tests ending with "Test", in the MyTest suite
 TESTFLAGS="-check.f MyTestSuite.*Test" make test-integration
 ```
+
 This will allow specific suites to be run.
 
 More: https://labix.org/gocheck

--- a/docs/content/building.md
+++ b/docs/content/building.md
@@ -1,0 +1,25 @@
+# Building
+
+Maesh can be built from source by running `make`, which will build a docker image of Maesh.
+A binary will also be built as `./dist/maesh`, which can be run via a shell for testing.
+
+## Integration testing options
+
+For development purposes, you can specify which tests to run by using (only works the `test-integration` target):
+
+```bash
+# Run every tests in the MyTest suite
+TESTFLAGS="-check.f MyTestSuite" make test-integration
+
+# Run the test "MyTest" in the MyTest suite
+TESTFLAGS="-check.f MyTestSuite.MyTest" make test-integration
+
+# Run every tests starting with "My", in the MyTest suite
+TESTFLAGS="-check.f MyTestSuite.My" make test-integration
+
+# Run every tests ending with "Test", in the MyTest suite
+TESTFLAGS="-check.f MyTestSuite.*Test" make test-integration
+```
+This will allow specific suites to be run.
+
+More: https://labix.org/gocheck


### PR DESCRIPTION
This PR:

- Adds `TESTFLAGS` env var, which can allow individual suites to be run

This PR prepares the way for parallel integration test runs.

Fixes #405 