### PR TITLE
Setup semaphore v2

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,13 @@
+version: v1.0
+name: Initial Pipeline
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: 'Block #1'
+    task:
+      jobs:
+        - name: 'Job #1'
+          commands:
+            - checkout

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,9 +1,15 @@
 version: v1.0
 name: Maesh Pipeline
+
 agent:
   machine:
     type: e1-standard-2
     os_image: ubuntu1804
+
+auto_cancel:
+  running:
+    when: "branch != 'master'"
+
 blocks:
   - name: Tests
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,7 +12,6 @@ blocks:
           - sem-version go 1.13
           - go version
           - checkout
-          - sudo ./.semaphore/setup.sh
       jobs:
         - name: Make
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,12 +22,12 @@ blocks:
         - name: Kubernetes Suite
           commands:
             -  "make test-integration TESTFLAGS=\"-check.f KubernetesSuite\""
-        # - name: CoreDNS Suite
-        #   commands:
-        #     -  make test-integration TESTFLAGS="-check.f CoreDNSSuite"
-        # - name: KubeDNS Suite
-        #   commands:
-        #     -  make test-integration TESTFLAGS="-check.f KubeDNSSuite"
-        # - name: Helm Suite
-        #   commands:
-        #     -  make test-integration TESTFLAGS="-check.f HelmSuite"
+        - name: CoreDNS Suite
+          commands:
+            -  "make test-integration TESTFLAGS=\"-check.f CoreDNSSuite\""
+        - name: KubeDNS Suite
+          commands:
+            -  "make test-integration TESTFLAGS=\"-check.f KubeDNSSuite\""
+        - name: Helm Suite
+          commands:
+            -  "make test-integration TESTFLAGS=\"-check.f HelmSuite\""

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,16 +18,16 @@ blocks:
             - make
         - name: SMI Integration Suite
           commands:
-            -  "retry make test-integration TESTFLAGS=\"-check.f SMISuite\""
+            -  "make test-integration TESTFLAGS=\"-check.f SMISuite\""
         - name: Kubernetes Suite
           commands:
-            -  "retry make test-integration TESTFLAGS=\"-check.f KubernetesSuite\""
+            -  "make test-integration TESTFLAGS=\"-check.f KubernetesSuite\""
         - name: CoreDNS Suite
           commands:
-            -  "retry make test-integration TESTFLAGS=\"-check.f CoreDNSSuite\""
+            -  "make test-integration TESTFLAGS=\"-check.f CoreDNSSuite\""
         - name: KubeDNS Suite
           commands:
-            -  "retry make test-integration TESTFLAGS=\"-check.f KubeDNSSuite\""
+            -  "make test-integration TESTFLAGS=\"-check.f KubeDNSSuite\""
         - name: Helm Suite
           commands:
-            -  "retry make test-integration TESTFLAGS=\"-check.f HelmSuite\""
+            -  "make test-integration TESTFLAGS=\"-check.f HelmSuite\""

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,9 +5,40 @@ agent:
     type: e1-standard-2
     os_image: ubuntu1804
 blocks:
-  - name: 'Block #1'
+  - name: 'Unit Tests'
     task:
+      prologue:
+        commands:
+          - sem-version go 1.13
+          - go version
+          - checkout
+          - ./.semaphore/setup.sh
       jobs:
-        - name: 'Job #1'
+        - name: 'Make'
           commands:
-            - checkout
+            - make
+  - name: 'Integration Tests'
+    task:
+      prologue:
+        commands:
+          - sem-version go 1.13
+          - go version
+          - checkout
+          - ./.semaphore/setup.sh
+      jobs:
+        - name: 'SMI Suite'
+          commands:
+            -  make test-integration TESTFLAGS="-check.f SMISuite"
+        - name: 'Kubernetes Suite'
+          commands:
+            -  make test-integration TESTFLAGS="-check.f KubernetesSuite"
+        - name: 'CoreDNS Suite'
+          commands:
+            -  make test-integration TESTFLAGS="-check.f CoreDNSSuite"
+        - name: 'KubeDNS Suite'
+          commands:
+            -  make test-integration TESTFLAGS="-check.f KubeDNSSuite"
+        - name: 'Helm Suite'
+          commands:
+            -  make test-integration TESTFLAGS="-check.f HelmSuite"
+  dependencies: []

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,11 +1,11 @@
 version: v1.0
-name: Initial Pipeline
+name: Maesh Pipeline
 agent:
   machine:
     type: e1-standard-2
     os_image: ubuntu1804
 blocks:
-  - name: 'Unit Tests'
+  - name: Unit Tests
     task:
       prologue:
         commands:
@@ -14,10 +14,10 @@ blocks:
           - checkout
           - ./.semaphore/setup.sh
       jobs:
-        - name: 'Make'
+        - name: Make
           commands:
             - make
-  - name: 'Integration Tests'
+  - name: Integration Tests
     task:
       prologue:
         commands:
@@ -26,19 +26,18 @@ blocks:
           - checkout
           - ./.semaphore/setup.sh
       jobs:
-        - name: 'SMI Suite'
+        - name: SMI Suite
           commands:
-            -  make test-integration TESTFLAGS="-check.f SMISuite"
-        - name: 'Kubernetes Suite'
-          commands:
-            -  make test-integration TESTFLAGS="-check.f KubernetesSuite"
-        - name: 'CoreDNS Suite'
-          commands:
-            -  make test-integration TESTFLAGS="-check.f CoreDNSSuite"
-        - name: 'KubeDNS Suite'
-          commands:
-            -  make test-integration TESTFLAGS="-check.f KubeDNSSuite"
-        - name: 'Helm Suite'
-          commands:
-            -  make test-integration TESTFLAGS="-check.f HelmSuite"
-  dependencies: []
+            -  "make test-integration TESTFLAGS=\"-check.f SMISuite\""
+        # - name: Kubernetes Suite
+        #   commands:
+        #     -  make test-integration TESTFLAGS="-check.f KubernetesSuite"
+        # - name: CoreDNS Suite
+        #   commands:
+        #     -  make test-integration TESTFLAGS="-check.f CoreDNSSuite"
+        # - name: KubeDNS Suite
+        #   commands:
+        #     -  make test-integration TESTFLAGS="-check.f KubeDNSSuite"
+        # - name: Helm Suite
+        #   commands:
+        #     -  make test-integration TESTFLAGS="-check.f HelmSuite"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,21 +13,21 @@ blocks:
           - go version
           - checkout
       jobs:
-        - name: Make
+        - name: Build and Unit Tests
           commands:
             - make
         - name: SMI Integration Suite
           commands:
-            -  "make test-integration TESTFLAGS=\"-check.f SMISuite\""
+            -  "retry make test-integration TESTFLAGS=\"-check.f SMISuite\""
         - name: Kubernetes Suite
           commands:
-            -  "make test-integration TESTFLAGS=\"-check.f KubernetesSuite\""
+            -  "retry make test-integration TESTFLAGS=\"-check.f KubernetesSuite\""
         - name: CoreDNS Suite
           commands:
-            -  "make test-integration TESTFLAGS=\"-check.f CoreDNSSuite\""
+            -  "retry make test-integration TESTFLAGS=\"-check.f CoreDNSSuite\""
         - name: KubeDNS Suite
           commands:
-            -  "make test-integration TESTFLAGS=\"-check.f KubeDNSSuite\""
+            -  "retry make test-integration TESTFLAGS=\"-check.f KubeDNSSuite\""
         - name: Helm Suite
           commands:
-            -  "make test-integration TESTFLAGS=\"-check.f HelmSuite\""
+            -  "retry make test-integration TESTFLAGS=\"-check.f HelmSuite\""

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,6 +10,10 @@ auto_cancel:
   running:
     when: "branch != 'master'"
 
+fail_fast:
+  stop:
+    when: "branch != 'master'"
+    
 blocks:
   - name: Tests
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,28 +5,19 @@ agent:
     type: e1-standard-2
     os_image: ubuntu1804
 blocks:
-  - name: Unit Tests
+  - name: Tests
     task:
       prologue:
         commands:
           - sem-version go 1.13
           - go version
           - checkout
-          - ./.semaphore/setup.sh
+          - sudo ./.semaphore/setup.sh
       jobs:
         - name: Make
           commands:
             - make
-  - name: Integration Tests
-    task:
-      prologue:
-        commands:
-          - sem-version go 1.13
-          - go version
-          - checkout
-          - ./.semaphore/setup.sh
-      jobs:
-        - name: SMI Suite
+        - name: SMI Integration Suite
           commands:
             -  "make test-integration TESTFLAGS=\"-check.f SMISuite\""
         # - name: Kubernetes Suite

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,9 +19,9 @@ blocks:
         - name: SMI Integration Suite
           commands:
             -  "make test-integration TESTFLAGS=\"-check.f SMISuite\""
-        # - name: Kubernetes Suite
-        #   commands:
-        #     -  make test-integration TESTFLAGS="-check.f KubernetesSuite"
+        - name: Kubernetes Suite
+          commands:
+            -  "make test-integration TESTFLAGS=\"-check.f KubernetesSuite\""
         # - name: CoreDNS Suite
         #   commands:
         #     -  make test-integration TESTFLAGS="-check.f CoreDNSSuite"

--- a/.semaphore/setup.sh
+++ b/.semaphore/setup.sh
@@ -1,7 +1,0 @@
-mkdir -p /home/runner/src/github.com/containous
-cp -r /home/runner/maesh /home/runner/src/github.com/containous
-cd /home/runner/src/github.com/containous/maesh
-if [ -f "./go.mod" ]; then export GO111MODULE=on; fi
-if [ -f "./go.mod" ]; then export GOPROXY=https://proxy.golang.org; fi
-if [ -f "./go.mod" ]; then go mod download; fi
-df

--- a/.semaphore/setup.sh
+++ b/.semaphore/setup.sh
@@ -1,0 +1,7 @@
+mkdir -p /home/runner/src/github.com/containous
+cp -r /home/runner/maesh /home/runner/src/github.com/containous
+cd /home/runner/src/github.com/containous/maesh
+if [ -f "./go.mod" ]; then export GO111MODULE=on; fi
+if [ -f "./go.mod" ]; then export GOPROXY=https://proxy.golang.org; fi
+if [ -f "./go.mod" ]; then go mod download; fi
+df

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test-integration: $(DIST_DIR) kubectl helm build k3d
 else
 test-integration: $(DIST_DIR) kubectl helm build local-build k3d
 endif
-	CGO_ENABLED=0 go test ./integration -integration $(INTEGRATION_TEST_OPTS)
+	CGO_ENABLED=0 go test ./integration -integration $(INTEGRATION_TEST_OPTS) $(TESTFLAGS)
 
 test-integration-nobuild: $(DIST_DIR) kubectl helm k3d
 	CGO_ENABLED=0 go test ./integration -integration $(INTEGRATION_TEST_OPTS) $(TESTFLAGS)


### PR DESCRIPTION
This PR:

- Adds the configuration for Semaphore v2, with the suites running independently

There will be performance improvements to be made regarding building/running/caching and such, but for the time being, it can reduce our ~10 minute CI runs to ~5 minutes-ish, with much faster fails.

The other benifit of keeping test runs short is that they are much easier to debug, since you aren't waiting 6 minutes for a test to fail. This is why I have not ported over any retry functionality.

We should fix failing tests instead of just running them again.

I tried doing some build - cache - test, but I couldn't get it to work much faster without reworking the whole build/test process, which might be a goal moving forward.
