### PR TITLE
Ensure only correct port endpoints get added to proxy service

### DIFF
--- a/internal/providers/kubernetes/fixtures/build_configuration_multiple_ports.yaml
+++ b/internal/providers/kubernetes/fixtures/build_configuration_multiple_ports.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+  namespace: foo
+spec:
+  clusterIP: 10.1.0.1
+  selector:
+    app: test
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+  - protocol: TCP
+    port: 443
+    targetPort: 443
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: test
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.0.0.1
+  ports:
+  - port: 80
+- addresses:
+  - ip: 10.0.0.2
+  ports:
+  - port: 80
+- addresses:
+  - ip: 10.0.0.3
+  ports:
+  - port: 443
+- addresses:
+  - ip: 10.0.0.4
+  ports:
+  - port: 443
+  

--- a/internal/providers/kubernetes/fixtures/build_configuration_multiple_ports_tcp.yaml
+++ b/internal/providers/kubernetes/fixtures/build_configuration_multiple_ports_tcp.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+  namespace: foo
+  annotations:
+    maesh.containo.us/traffic-type: tcp
+spec:
+  clusterIP: 10.1.0.1
+  selector:
+    app: test
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+  - protocol: TCP
+    port: 443
+    targetPort: 443
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: test
+  namespace: foo
+subsets:
+- addresses:
+  - ip: 10.0.0.1
+  ports:
+  - port: 80
+- addresses:
+  - ip: 10.0.0.2
+  ports:
+  - port: 80
+- addresses:
+  - ip: 10.0.0.3
+  ports:
+  - port: 443
+- addresses:
+  - ip: 10.0.0.4
+  ports:
+  - port: 443
+  


### PR DESCRIPTION
This PR:

- Ensures that the correct endpoints on the proxy service are used.

Because we were not checking the intended port in the loop, it added all the ports for all endpoints, not only the ones we wanted.

Fixes #423 