### PR TITLE
Increase legacy integration test timeouts

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -44,4 +44,3 @@ blocks:
       env_vars:
         - name: CI_TIMEOUT_MULTIPLIER
           value: 3
-              

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -43,4 +43,4 @@ blocks:
             - "make test-integration TESTFLAGS=\"-check.f HelmSuite\""
       env_vars:
         - name: CI_TIMEOUT_MULTIPLIER
-          value: 3
+          value: "3"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -41,3 +41,7 @@ blocks:
         - name: Helm Suite
           commands:
             - "make test-integration TESTFLAGS=\"-check.f HelmSuite\""
+      env_vars:
+        - name: CI_TIMEOUT_MULTIPLIER
+          value: 3
+              

--- a/integration/smi_test.go
+++ b/integration/smi_test.go
@@ -185,7 +185,9 @@ func (s *SMISuite) TestSMIAccessControl(c *check.C) {
 
 		c.Log(test.desc)
 		s.digHost(c, test.source, test.destination)
-		s.waitKubectlExecCommand(c, argSlice, fmt.Sprintf("HTTP/1.1 %d", test.expected))
+
+		err := s.try.WaitCommandExecute("kubectl", argSlice, fmt.Sprintf("HTTP/1.1 %d", test.expected), 30*time.Second)
+		c.Assert(err, checker.IsNil)
 	}
 
 	s.unInstallHelmMaesh(c)


### PR DESCRIPTION
This PR:

- Increases the legacy integration test timeouts to match the old CI

May reduce the fails on the v1.1 branch.