### PR TITLE
Wait fort the k3s cluster to come up before running tests

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -151,6 +151,7 @@ func (s *BaseSuite) startk3s(c *check.C, requiredImages []string) {
 		"--server-arg", "--no-deploy=traefik",
 		"--server-arg", "--no-deploy=coredns",
 		"--image", fmt.Sprintf("%s:%s", k3sImage, k3sVersion),
+		"--wait", "30",
 	)
 	cmd.Env = os.Environ()
 


### PR DESCRIPTION
This PR addresses a bug discovered by @dtomcej while running integration tests.

SMI integration tests were failing because we weren't waiting for the cluster to be ready before starting the tests.

k3d provides the `--wait <seconds>` option to wait for the cluster to come up before returning. An error will be returned if it takes more than <seconds>.

The timeout has been set to 30 seconds.

Fixes: #434