### PR TITLE
Add host to API bind

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -14,6 +14,7 @@ type MaeshConfiguration struct {
 	Namespace        string   `description:"The namespace that maesh is installed in." export:"true"`
 	IgnoreNamespaces []string `description:"The namespace that maesh should be ignoring." export:"true"`
 	APIPort          int32    `description:"API port for the controller" export:"true"`
+	APIHost          string   `description:"API host for the controller to bind to" export:"true"`
 	LimitTCPPort     int32    `description:"Number of TCP ports allocated" export:"true"`
 	LimitHTTPPort    int32    `description:"Number of HTTP ports allocated" export:"true"`
 }
@@ -28,6 +29,7 @@ func NewMaeshConfiguration() *MaeshConfiguration {
 		DefaultMode:   "http",
 		Namespace:     "maesh",
 		APIPort:       9000,
+		APIHost:       "",
 		LimitTCPPort:  25,
 		LimitHTTPPort: 10,
 	}

--- a/cmd/maesh/maesh.go
+++ b/cmd/maesh/maesh.go
@@ -81,6 +81,7 @@ func maeshCommand(iConfig *cmd.MaeshConfiguration) error {
 		Namespace:        iConfig.Namespace,
 		IgnoreNamespaces: iConfig.IgnoreNamespaces,
 		APIPort:          iConfig.APIPort,
+		APIHost:          iConfig.APIHost,
 		MinTCPPort:       minTCPPort,
 		MaxTCPPort:       minTCPPort + iConfig.LimitTCPPort,
 		MinHTTPPort:      minHTTPPort,

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -101,7 +101,13 @@ type BaseSuite struct {
 }
 
 func (s *BaseSuite) maeshStartControllerWithArgsCmd(args ...string) *exec.Cmd {
-	controllerArgSlice := []string{fmt.Sprintf("--masterurl=%s", masterURL), fmt.Sprintf("--kubeconfig=%s", os.Getenv("KUBECONFIG")), "--debug", fmt.Sprintf("--namespace=%s", maeshNamespace)}
+	controllerArgSlice := []string{
+		fmt.Sprintf("--masterurl=%s", masterURL),
+		fmt.Sprintf("--kubeconfig=%s", os.Getenv("KUBECONFIG")),
+		"--debug",
+		fmt.Sprintf("--namespace=%s", maeshNamespace),
+		"--apihost=127.0.0.1",
+	}
 	args = append(controllerArgSlice, args...)
 
 	return exec.Command(maeshBinary, args...)

--- a/pkg/controller/api.go
+++ b/pkg/controller/api.go
@@ -21,6 +21,7 @@ type API struct {
 	readiness         bool
 	lastConfiguration *safe.Safe
 	apiPort           int32
+	apiHost           string
 	deployLog         *DeployLog
 	meshNamespace     string
 	podLister         listers.PodLister
@@ -33,11 +34,12 @@ type podInfo struct {
 }
 
 // NewAPI creates a new api.
-func NewAPI(apiPort int32, lastConfiguration *safe.Safe, deployLog *DeployLog, podLister listers.PodLister, meshNamespace string) *API {
+func NewAPI(apiPort int32, apiHost string, lastConfiguration *safe.Safe, deployLog *DeployLog, podLister listers.PodLister, meshNamespace string) *API {
 	a := &API{
 		readiness:         false,
 		lastConfiguration: lastConfiguration,
 		apiPort:           apiPort,
+		apiHost:           apiHost,
 		deployLog:         deployLog,
 		podLister:         podLister,
 		meshNamespace:     meshNamespace,
@@ -74,7 +76,7 @@ func (a *API) Start() {
 
 // Run wraps the listenAndServe method.
 func (a *API) Run() {
-	log.Error(http.ListenAndServe(fmt.Sprintf(":%d", a.apiPort), a.router))
+	log.Error(http.ListenAndServe(fmt.Sprintf("%s:%d", a.apiHost, a.apiPort), a.router))
 }
 
 // EnableReadiness enables the readiness flag in the API.

--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -12,9 +12,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	localhost = "127.0.0.1"
+)
+
 func TestEnableReadiness(t *testing.T) {
 	config := safe.Safe{}
-	api := NewAPI(9000, &config, nil, nil, "foo")
+	api := NewAPI(9000, localhost, &config, nil, nil, "foo")
 
 	assert.Equal(t, false, api.readiness)
 
@@ -46,7 +50,7 @@ func TestGetReadiness(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			config := safe.Safe{}
-			api := NewAPI(9000, &config, nil, nil, "foo")
+			api := NewAPI(9000, localhost, &config, nil, nil, "foo")
 			api.readiness = test.readiness
 
 			res := httptest.NewRecorder()
@@ -61,7 +65,7 @@ func TestGetReadiness(t *testing.T) {
 
 func TestGetCurrentConfiguration(t *testing.T) {
 	config := safe.Safe{}
-	api := NewAPI(9000, &config, nil, nil, "foo")
+	api := NewAPI(9000, localhost, &config, nil, nil, "foo")
 
 	config.Set("foo")
 
@@ -76,7 +80,7 @@ func TestGetCurrentConfiguration(t *testing.T) {
 func TestGetDeployLog(t *testing.T) {
 	config := safe.Safe{}
 	log := NewDeployLog(1000)
-	api := NewAPI(9000, &config, log, nil, "foo")
+	api := NewAPI(9000, localhost, &config, log, nil, "foo")
 
 	currentTime := time.Now()
 	log.LogDeploy(currentTime, "foo", "bar", true, "blabla")

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -62,7 +62,8 @@ type Controller struct {
 	tcpStateTable        TCPPortMapper
 	lastConfiguration    safe.Safe
 	api                  *API
-	apiPort              int32
+	apiPort              int
+	apiHost              string
 	deployLog            *DeployLog
 	PodLister            listers.PodLister
 	ServiceLister        listers.ServiceLister
@@ -82,6 +83,7 @@ type MeshControllerConfig struct {
 	Namespace        string
 	IgnoreNamespaces []string
 	APIPort          int32
+	APIHost          string
 	MinTCPPort       int32
 	MaxTCPPort       int32
 	MinHTTPPort      int32
@@ -119,6 +121,7 @@ func NewMeshController(clients *k8s.ClientWrapper, cfg MeshControllerConfig) (*C
 		defaultMode:       cfg.DefaultMode,
 		meshNamespace:     cfg.Namespace,
 		apiPort:           cfg.APIPort,
+		apiHost:           cfg.APIHost,
 		tcpStateTable:     tcpStateTable,
 		minHTTPPort:       cfg.MinHTTPPort,
 		maxHTTPPort:       cfg.MaxHTTPPort,
@@ -145,7 +148,7 @@ func (c *Controller) init() {
 	c.EndpointsLister = c.kubernetesFactory.Core().V1().Endpoints().Lister()
 
 	c.deployLog = NewDeployLog(1000)
-	c.api = NewAPI(c.apiPort, &c.lastConfiguration, c.deployLog, c.PodLister, c.meshNamespace)
+	c.api = NewAPI(c.apiPort, c.apiHost, &c.lastConfiguration, c.deployLog, c.PodLister, c.meshNamespace)
 
 	if c.smiEnabled {
 		// Create new SharedInformerFactories, and register the event handler to informers.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -62,7 +62,7 @@ type Controller struct {
 	tcpStateTable        TCPPortMapper
 	lastConfiguration    safe.Safe
 	api                  *API
-	apiPort              int
+	apiPort              int32
 	apiHost              string
 	deployLog            *DeployLog
 	PodLister            listers.PodLister


### PR DESCRIPTION
This PR:

- Adds the ability to define a host/IP for the API to bind to, not just ports.

Fixes #404 

This prevents warnings and error popups on Mac integration tests (and some unit tests)