### PR TITLE
Wait for Pod IPs to be assigned in Integration test

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -641,7 +641,6 @@ k8s.io/client-go v0.0.0-20181213151034-8d9ed539ba31/go.mod h1:7vJpHMYJwNQCWgzmNV
 k8s.io/client-go v0.0.0-20190718183610-8e956561bbf5/go.mod h1:ozblAqkW495yoAX60QZyxQBq5W0YixE9Ffn4F91RO0g=
 k8s.io/client-go v0.0.0-20190819141724-e14f31a72a77 h1:w1BoabVnPpPqQCY3sHK4qVwa12Lk8ip1pKMR1C+qbdo=
 k8s.io/client-go v0.0.0-20190819141724-e14f31a72a77/go.mod h1:DmkJD5UDP87MVqUQ5VJ6Tj9Oen8WzXPhk3la4qpyG4g=
-k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/code-generator v0.0.0-20181114232248-ae218e241252/go.mod h1:IPqxl/YHk05nodzupwjke6ctMjyNRdV2zZ5/j3/F204=
 k8s.io/code-generator v0.0.0-20190612205613-18da4a14b22b/go.mod h1:G8bQwmHm2eafm5bgtX67XDZQ8CWKSGu9DekI+yN4Y5I=
 k8s.io/gengo v0.0.0-20181106084056-51747d6e00da/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/go.sum
+++ b/go.sum
@@ -641,6 +641,7 @@ k8s.io/client-go v0.0.0-20181213151034-8d9ed539ba31/go.mod h1:7vJpHMYJwNQCWgzmNV
 k8s.io/client-go v0.0.0-20190718183610-8e956561bbf5/go.mod h1:ozblAqkW495yoAX60QZyxQBq5W0YixE9Ffn4F91RO0g=
 k8s.io/client-go v0.0.0-20190819141724-e14f31a72a77 h1:w1BoabVnPpPqQCY3sHK4qVwa12Lk8ip1pKMR1C+qbdo=
 k8s.io/client-go v0.0.0-20190819141724-e14f31a72a77/go.mod h1:DmkJD5UDP87MVqUQ5VJ6Tj9Oen8WzXPhk3la4qpyG4g=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/code-generator v0.0.0-20181114232248-ae218e241252/go.mod h1:IPqxl/YHk05nodzupwjke6ctMjyNRdV2zZ5/j3/F204=
 k8s.io/code-generator v0.0.0-20190612205613-18da4a14b22b/go.mod h1:G8bQwmHm2eafm5bgtX67XDZQ8CWKSGu9DekI+yN4Y5I=
 k8s.io/gengo v0.0.0-20181106084056-51747d6e00da/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/integration/smi_test.go
+++ b/integration/smi_test.go
@@ -87,7 +87,7 @@ func (s *SMISuite) checkWhitelistSourceRanges(c *check.C, config *dynamic.Config
 		// Test for block-all-middleware.
 		if name == "smi-block-all-middleware" {
 			c.Assert(middleware.IPWhiteList.SourceRange[0], checker.Equals, "255.255.255.255")
-			c.Log("Middleware " + name + " has the correct source range.")
+			c.Logf("Middleware %q has the correct source range.", name)
 
 			continue
 		}
@@ -107,14 +107,14 @@ func (s *SMISuite) checkWhitelistSourceRanges(c *check.C, config *dynamic.Config
 		actual := middleware.IPWhiteList.SourceRange
 		// Assert that the sourceRange is the correct length.
 		c.Assert(len(actual), checker.Equals, len(expected), check.Commentf("Expected length %d, got %d for middleware %s in config: %v", len(expected), len(actual), name, config))
-		c.Log("Middleware " + name + " has the correct length.")
+		c.Logf("Middleware %q has the correct length.", name)
 
 		// Assert that the sourceRange contains the expected values.
 		for _, expectedValue := range expected {
 			c.Assert(contains(actual, expectedValue), checker.True)
 		}
 
-		c.Log("Middleware " + name + " has the correct expected values.")
+		c.Logf("Middleware %q has the correct expected values.", name)
 	}
 }
 
@@ -123,7 +123,7 @@ func (s *SMISuite) checkHTTPServiceServerURLs(c *check.C, config *dynamic.Config
 		// Test for readiness.
 		if name == "readiness" {
 			c.Assert(service.LoadBalancer.Servers[0].URL, checker.Equals, "http://127.0.0.1:8080")
-			c.Log("service " + name + " has the correct url.")
+			c.Logf("service %q has the correct url.", name)
 
 			continue
 		}
@@ -153,7 +153,7 @@ func (s *SMISuite) checkHTTPServiceServerURLs(c *check.C, config *dynamic.Config
 			}
 		}
 
-		c.Log("Service " + name + " has the correct expected values.")
+		c.Logf("Service %q has the correct expected values.", name)
 	}
 }
 
@@ -184,13 +184,13 @@ func (s *SMISuite) checkTCPServiceServerURLs(c *check.C, config *dynamic.Configu
 			}
 		}
 
-		c.Log("Service " + name + " has the correct expected values.")
+		c.Logf("Service %q has the correct expected values.", name)
 	}
 }
 
 func (s *SMISuite) waitForPodIPs(c *check.C, pods []string) {
 	for _, pod := range pods {
-		c.Log("Waiting for pod: \"" + pod + "\" to have IP assigned.")
+		c.Logf("Waiting for pod: %q to have IP assigned.", pod)
 		c.Assert(s.try.WaitPodIPAssigned(pod, testNamespace, 30*time.Second), checker.IsNil)
 	}
 }

--- a/integration/smi_test.go
+++ b/integration/smi_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/go-check/check"
@@ -34,6 +35,10 @@ func (s *SMISuite) TestSMIAccessControl(c *check.C) {
 	s.createResources(c, "resources/smi/access-control/")
 	defer s.deleteResources(c, "resources/smi/access-control/", true)
 
+	podsCreated := []string{"a", "b", "c", "d", "e", "tcp"}
+
+	s.waitForPodIPs(c, podsCreated)
+
 	cmd := s.startMaeshBinaryCmd(c, true)
 	err := cmd.Start()
 
@@ -50,6 +55,10 @@ func (s *SMISuite) TestSMIAccessControl(c *check.C) {
 func (s *SMISuite) TestSMIAccessControlPrepareFail(c *check.C) {
 	s.createResources(c, "resources/smi/access-control-broken/")
 	defer s.deleteResources(c, "resources/smi/access-control-broken/", false)
+
+	podsCreated := []string{"a-tools", "b-v1", "b-v2"}
+
+	s.waitForPodIPs(c, podsCreated)
 
 	args := []string{"--smi"}
 	cmd := s.maeshPrepareWithArgs(args...)
@@ -176,5 +185,11 @@ func (s *SMISuite) checkTCPServiceServerURLs(c *check.C, config *dynamic.Configu
 		}
 
 		c.Log("Service " + name + " has the correct expected values.")
+	}
+}
+
+func (s *SMISuite) waitForPodIPs(c *check.C, pods []string) {
+	for _, pod := range pods {
+		c.Assert(s.try.WaitPodIPAssigned(pod, testNamespace, 30*time.Second), checker.IsNil)
 	}
 }

--- a/integration/smi_test.go
+++ b/integration/smi_test.go
@@ -56,10 +56,6 @@ func (s *SMISuite) TestSMIAccessControlPrepareFail(c *check.C) {
 	s.createResources(c, "resources/smi/access-control-broken/")
 	defer s.deleteResources(c, "resources/smi/access-control-broken/", false)
 
-	podsCreated := []string{"a-tools", "b-v1", "b-v2"}
-
-	s.waitForPodIPs(c, podsCreated)
-
 	args := []string{"--smi"}
 	cmd := s.maeshPrepareWithArgs(args...)
 	cmd.Env = os.Environ()
@@ -72,6 +68,10 @@ func (s *SMISuite) TestSMIAccessControlPrepareFail(c *check.C) {
 func (s *SMISuite) TestSMITrafficSplit(c *check.C) {
 	s.createResources(c, "resources/smi/traffic-split/")
 	defer s.deleteResources(c, "resources/smi/traffic-split/", true)
+
+	podsCreated := []string{"a-tools", "b-v1", "b-v2"}
+
+	s.waitForPodIPs(c, podsCreated)
 
 	cmd := s.startMaeshBinaryCmd(c, true)
 	err := cmd.Start()
@@ -190,6 +190,7 @@ func (s *SMISuite) checkTCPServiceServerURLs(c *check.C, config *dynamic.Configu
 
 func (s *SMISuite) waitForPodIPs(c *check.C, pods []string) {
 	for _, pod := range pods {
+		c.Log("Waiting for pod: \"" + pod + "\" to have IP assigned.")
 		c.Assert(s.try.WaitPodIPAssigned(pod, testNamespace, 30*time.Second), checker.IsNil)
 	}
 }

--- a/integration/try/try.go
+++ b/integration/try/try.go
@@ -120,12 +120,13 @@ func (t *Try) WaitPodIPAssigned(name string, namespace string, timeout time.Dura
 			}
 
 			// IP is assigned
+			fmt.Println("Pod \"" + name + "\" has IP: " + pod.Status.PodIP)
 			return nil
 		}
 
-		return errors.New("pod IP not assigned")
+		return errors.New("pod does not have an IP assigned")
 	}), ebo); err != nil {
-		return fmt.Errorf("unable get the pod list in namespace %q: %v", namespace, err)
+		return fmt.Errorf("unable get the pod IP for pod %s: %v", name, err)
 	}
 
 	return nil

--- a/integration/try/try.go
+++ b/integration/try/try.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containous/traefik/v2/pkg/safe"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -96,6 +97,35 @@ func (t *Try) WaitDeleteDeployment(name string, namespace string, timeout time.D
 		return nil
 	}), ebo); err != nil {
 		return fmt.Errorf("unable get the deployment %q in namespace %q: %v", name, namespace, err)
+	}
+
+	return nil
+}
+
+// WaitPodIPAssigned wait until the pod is assigned an IP.
+func (t *Try) WaitPodIPAssigned(name string, namespace string, timeout time.Duration) error {
+	ebo := backoff.NewExponentialBackOff()
+	ebo.MaxElapsedTime = applyCIMultiplier(timeout)
+
+	if err := backoff.Retry(safe.OperationWithRecover(func() error {
+		podList, err := t.client.ListPodWithOptions(namespace, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("unable get the pod list in namespace %q: %v", namespace, err)
+		}
+
+		for _, pod := range podList.Items {
+			// If the pod name doesn't match or the IP is empty, go to next.
+			if pod.Name != name || pod.Status.PodIP == "" {
+				continue
+			}
+
+			// IP is assigned
+			return nil
+		}
+
+		return errors.New("pod IP not assigned")
+	}), ebo); err != nil {
+		return fmt.Errorf("unable get the pod list in namespace %q: %v", namespace, err)
 	}
 
 	return nil


### PR DESCRIPTION
This PR:

- Adds waiting functionality for Pod IPs so that we don't create partial configurations.

This should hopefully reduce the failure rate of the SMI provider.

Fixes #434 

I hope.