### PR TITLE
Cleanup TCPPortMapping when updating/deleting a shadow service

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -40,13 +40,14 @@ import (
 type TCPPortMapper interface {
 	Find(svc k8s.ServiceWithPort) (int32, bool)
 	Add(svc *k8s.ServiceWithPort) (int32, error)
+	Remove(svc k8s.ServiceWithPort) (int32, error)
 }
 
 // ServiceManager is capable of managing kubernetes services.
 type ServiceManager interface {
 	Create(userSvc *corev1.Service) error
-	Update(userSvc *corev1.Service) (*corev1.Service, error)
-	Delete(serviceName, serviceNamespace string) error
+	Update(oldUserSvc, newUserSvc *corev1.Service) (*corev1.Service, error)
+	Delete(userSvc *corev1.Service) error
 }
 
 // Controller hold controller configuration.

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -67,11 +67,13 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 		if h.ignored.IsIgnored(obj.ObjectMeta) {
 			return
 		}
+
 		oldSvc, ok := oldObj.(*corev1.Service)
 		if !ok {
 			log.Errorf("Old object is not a kubernetes Service")
 			return
 		}
+
 		if _, err := h.serviceManager.Update(oldSvc, obj); err != nil {
 			log.Errorf("Could not update mesh service: %v", err)
 		}

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -50,6 +50,7 @@ func (s *ShadowServiceManager) Create(userSvc *corev1.Service) error {
 	if err == nil {
 		return nil
 	}
+
 	if !kerrors.IsNotFound(err) {
 		return fmt.Errorf("unable to get shadow service %q: %w", name, err)
 	}

--- a/pkg/controller/service_test.go
+++ b/pkg/controller/service_test.go
@@ -336,7 +336,9 @@ func Test_ServiceUpdate(t *testing.T) {
 			},
 		},
 	}
+
 	var addedPortMapping k8s.ServiceWithPort
+
 	var removedPortMapping k8s.ServiceWithPort
 
 	tcpPortMapper := tcpPortMapperMock{
@@ -397,7 +399,6 @@ func Test_ServiceUpdate(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, &expected, svcGot)
-
 }
 
 func Test_ServiceDelete(t *testing.T) {
@@ -440,6 +441,7 @@ func Test_ServiceDelete(t *testing.T) {
 	}
 
 	var removedPortMapping k8s.ServiceWithPort
+
 	tcpPortMapper := tcpPortMapperMock{
 		removeFunc: func(svc k8s.ServiceWithPort) (int32, error) {
 			removedPortMapping = svc

--- a/pkg/k8s/tcpportmapping_test.go
+++ b/pkg/k8s/tcpportmapping_test.go
@@ -260,7 +260,7 @@ func TestTCPPortMapping_Remove(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(10000), port)
 
-	port, err = m.Remove(svc)
+	_, err = m.Remove(svc)
 	assert.Error(t, err)
 
 	unknownSvc := ServiceWithPort{
@@ -268,6 +268,6 @@ func TestTCPPortMapping_Remove(t *testing.T) {
 		Name:      "my-unknown-app",
 		Port:      8088,
 	}
-	port, err = m.Remove(unknownSvc)
+	_, err = m.Remove(unknownSvc)
 	assert.Error(t, err)
 }

--- a/pkg/k8s/tcpportmapping_test.go
+++ b/pkg/k8s/tcpportmapping_test.go
@@ -235,3 +235,39 @@ func TestFormatServiceNamePort(t *testing.T) {
 	got := formatServiceNamePort("svc-name", "ns", 8080)
 	assert.Equal(t, "ns/svc-name:8080", got)
 }
+
+func TestTCPPortMapping_Remove(t *testing.T) {
+	cfgMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tcp-state-table",
+			Namespace: "maesh",
+		},
+		Data: map[string]string{
+			"10000": "my-ns/my-app:9090",
+		},
+	}
+	client := fake.NewSimpleClientset(cfgMap)
+
+	m, err := NewTCPPortMapping(client, "maesh", "tcp-state-table", 10000, 10200)
+	require.NoError(t, err)
+
+	svc := ServiceWithPort{
+		Namespace: "my-ns",
+		Name:      "my-app",
+		Port:      9090,
+	}
+	port, err := m.Remove(svc)
+	require.NoError(t, err)
+	assert.Equal(t, int32(10000), port)
+
+	port, err = m.Remove(svc)
+	assert.Error(t, err)
+
+	unknownSvc := ServiceWithPort{
+		Namespace: "my-unknown-ns",
+		Name:      "my-unknown-app",
+		Port:      8088,
+	}
+	port, err = m.Remove(unknownSvc)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
This PR updates the `ShadowServiceManager` to cleanup the TCPPortMapping before a shadow service get updated or deleted. This way, we can reuse HTTP and TCP ports when a Service gets updated. 

Fixes: https://github.com/containous/maesh/issues/442

How to reproduce the issue:
- Install Maesh on a cluster with the following static configuration: 
```
helm install maesh helm/chart/maesh --namespace=maesh --set controller.image.pullPolicy=IfNotPresent --set controller.image.name=maesh-dev --set controller.image.tag=latest --set limits.tcp=2 --set limits.http=2
```
- Deploy a TCP server and a Service:
```
---
kind: Deployment
apiVersion: apps/v1
metadata:
  name: whoami-tcp-server
  namespace: whoami
spec:
  selector:
    matchLabels:
      app: whoami-tcp-server
  replicas: 2
  template:
    metadata:
      labels:
        app: whoami-tcp-server
    spec:
      containers:
        - name: whoami-tcp-server
          image: containous/whoamitcp
          imagePullPolicy: Always

---
apiVersion: v1
kind: Service
metadata:
  name: whoami-tcp-svc
  namespace: whoami
  labels:
    app: whoami-tcp-svc
  annotations:
    maesh.containo.us/traffic-type: "tcp"
spec:
  type: ClusterIP
  ports:
    - port: 8081
      name: whoami-tcp-server
  selector:
    app: whoami-tcp-server
```
- Check the port mapping: `kubectl -n maesh describe service/maesh-whoami-tcp-svc-6d61657368-whoami`
You should see `TargetPort: 10000/TCP`
- Update the service port to 8081
- Check again the port mapping. At this point you will see `TargetPort: 10001`/TCP`