### PR TITLE
ignore non-go 1.14 code

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,10 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
+      - goos: freebsd
+        goarch: arm64
+      - goos: openbsd
+        goarch: arm64
 
 archives:
   - id: maesh


### PR DESCRIPTION
This PR:

- Ignores GOOS/GOARCH combinations only supported by go 1.14