### PR TITLE
Remove Helm v2 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To run this app, you require the following:
 - CoreDNS installed as [Cluster DNS Provider](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/) (versions 1.3+ supported)
 - Helm v3
 
-## Install (Helm v2 only)
+## Install
 
 ```shell
 helm repo add maesh https://containous.github.io/maesh/charts

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -26,7 +26,7 @@ make
 ## Deploy helm chart
 
 ??? Note "Helm V3"
-    Please keep in mind, that our current Helm Chart (v1.0.0) is v2 compatible only. The v3 compatible Chart will be released with v1.1 of Maesh.
+    Please keep in mind, that the helm chart is v3 compatible only, and will not function properly with helm v2.
 
 To deploy the helm chart, run:
 


### PR DESCRIPTION
This PR:

- Removes helm v2 references from the documentation

Fixes #463 