### PR TITLE
Allow users to limit what service ports are exposed

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -26,6 +26,22 @@ Dynamic configuration can be provided to Maesh using either annotations on kuber
 
 ### With Kubernetes Services
 
+#### Exposed ports
+
+By default, all ports on services are exposed by maesh.
+If you would like to define which ports are exposed, you can use the following annotation:
+
+```yaml
+maesh.containo.us/exposed-ports: "http, admin, 8553"
+```
+
+The list of ports can be names or port numbers.
+Any ports that match will be exposed via maesh.
+
+??? Note "TargetPorts"
+    Please keep in mind, that the matching is done against the service ports only.
+    TargetPorts are not checked at the time being.
+
 #### Traffic type
 
 Annotations on services are the main way to configure maesh behavior.

--- a/pkg/k8s/constants.go
+++ b/pkg/k8s/constants.go
@@ -20,6 +20,8 @@ const (
 
 	// AnnotationServiceType service type annotation.
 	AnnotationServiceType = baseAnnotation + "traffic-type"
+	// AnnotationServiceExposedPorts service ports annotation.
+	AnnotationServiceExposedPorts = baseAnnotation + "exposed-ports"
 	// AnnotationScheme scheme.
 	AnnotationScheme = baseAnnotation + "scheme"
 	// AnnotationRetryAttempts retry attempts annotation.


### PR DESCRIPTION
This PR:

- Checks annotations for matching ports, and only creates shadow services with those ports

TODO:

- Update providers to only create routers on matching ports

Fixes #330 