### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -10,7 +10,7 @@ The API can be accessed by making a `GET` request to `http://<control pod IP>:90
 This endpoint provides raw json of the current configuration built by the controller.
 
 !!! Note
-    This may change each request, as it is a live data structure.
+    This may change on each request, as it is a live data structure.
 
 ## `/api/status/nodes`
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -5,7 +5,7 @@ The static configuration is configured when the Maesh service mesh is installed,
 
 ## Static configuration
 
-- The Maesh image version can be manually defined if needed, as can the version for the Traefik CE mesh nodes.
+- The Maesh image version can be manually defined if needed, as can the version for the Traefik mesh nodes.
 
 - Debug logging can be globally enabled.
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -1,12 +1,11 @@
 # Configuration
 
-The configuration for maesh is broken down into two parts: the static configuration, and the dynamic configuration.
-The static configuration is configured when the maesh service mesh is installed,
-and is configured via the values.yaml file in the helm install.
+The configuration for Maesh is broken down into two parts: the static configuration, and the dynamic configuration.
+The static configuration is configured when the Maesh service mesh is installed, and is configured via the values.yaml file in the helm install.
 
 ## Static configuration
 
-- The maesh image version can be manually defined if needed, as can the version for the Traefik CE mesh nodes.
+- The Maesh image version can be manually defined if needed, as can the version for the Traefik CE mesh nodes.
 
 - Debug logging can be globally enabled.
 
@@ -16,9 +15,9 @@ and is configured via the values.yaml file in the helm install.
 - Tracing can be enabled.
 
 - Service Mesh Interface (SMI) mode can be enabled.
-    This configures maesh to run in SMI mode, where access and routes are explicitly enabled.
-    Note: By default, all routes and access is denied.
-    Please see the [SMI Specification](https://github.com/servicemeshinterface/smi-spec) for more information
+    This configures Maesh to run in SMI mode, where access and routes are explicitly enabled.
+    Note: By default, all routes and access are denied.
+    Please see the [SMI Specification](https://github.com/servicemeshinterface/smi-spec) for more information.
 
 ## Dynamic configuration
 
@@ -28,7 +27,7 @@ Dynamic configuration can be provided to Maesh using either annotations on kuber
 
 #### Traffic type
 
-Annotations on services are the main way to configure maesh behavior.
+Annotations on services are the main way to configure Maesh behavior.
 
 The service mode can be enabled by using the following annotation:
 
@@ -61,7 +60,7 @@ Retries can be enabled by using the following annotation:
 maesh.containo.us/retry-attempts: "2"
 ```
 
-This annotation sets the number of retry attempts that maesh will make if a network error occurrs.
+This annotation sets the number of retry attempts that Maesh will make if a network error occurs.
 Please note that this value is a string, and needs to be quoted.
 
 #### Circuit breaker
@@ -76,7 +75,7 @@ This annotation sets the expression for circuit breaking.
 The circuit breaker protects your system from stacking requests to unhealthy services (resulting in cascading failures).
 When your system is healthy, the circuit is closed (normal operations). When your system becomes unhealthy, the circuit opens, and requests are no longer forwarded (but handled by a fallback mechanism).
 
-All configuration options are available [here](https://docs.traefik.io/v2.0/middlewares/circuitbreaker/#configuration-options)
+All configuration options are available [here](https://docs.traefik.io/v2.0/middlewares/circuitbreaker/#configuration-options).
 
 #### Rate Limit
 
@@ -90,7 +89,7 @@ maesh.containo.us/ratelimit-burst: "200"
 These annotation sets average and burst requests per second limit for the service.
 Please note that this value is a string, and needs to be quoted.
 
-Further details about the rate limiting can be found [here](https://docs.traefik.io/v2.0/middlewares/ratelimit/#configuration-options)
+Further details about the rate limiting can be found [here](https://docs.traefik.io/v2.0/middlewares/ratelimit/#configuration-options).
 
 ### With Service Mesh Interface
 
@@ -118,8 +117,8 @@ In this example, we define a set of HTTP routes for our `server` application.
 
 More precisely, the `server` app is composed by two routes:
 
-- The `api` route under the `/api` path, accepting all methods
-- The `metrics` routes under the `/metrics` path, accepting only `GET` requests
+- The `api` route under the `/api` path, accepting all methods.
+- The `metrics` routes under the `/metrics` path, accepting only `GET` requests.
 
 Other types of route groups and detailed information are available [in the specification](https://github.com/servicemeshinterface/smi-spec/blob/master/traffic-specs.md).
 

--- a/docs/content/examples.md
+++ b/docs/content/examples.md
@@ -3,7 +3,7 @@
 Here are some examples on how to easily deploy Maesh on your cluster.
 
 ??? Note "Prerequisites"
-    Before following those examples, make sure your cluster follows [the prerequisites for deploying Maesh](quickstart.md#prerequisites)
+    Before following those examples, make sure your cluster follows [the prerequisites for deploying Maesh](quickstart.md#prerequisites).
 
 ## Simple Example
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -8,8 +8,7 @@ Maesh is a lightweight and simpler service mesh designed from the ground up to b
 
 Built on top of Traefik, Maesh fits as your de-facto service mesh in your Kubernetes cluster supporting the latest Service Mesh Interface specification (SMI).
 
-Moreover, Maesh is opt-in by default,
-which means that your existing services are unaffected until you decide to add them to the mesh.
+Moreover, Maesh is opt-in by default, which means that your existing services are unaffected until you decide to add them to the mesh.
 
 <p align="center">
 <a href="https://smi-spec.io" target="_blank"><img width="150" src="assets/img/smi.png" alt="SMI" title="SMI" /></a>

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -76,7 +76,7 @@ helm install maesh --namespace=maesh maesh/maesh --set smi.enable=true`
     If you are re-installing into a cluster with the CRDs already present, helm may give you a warning.
     If you do not want to install them, or want to avoid the warning during a re-install,
     please use the new `--skip-crds` flag.
-    More information can be found on the [helm documentation](https://helm.sh/docs/topics/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you).
+    More information can be found on the [helm documentation](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you).
 
 ## Platform recommendations
 

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -1,13 +1,13 @@
 # Installation
 
-To install maesh, the installation method is quite simple:
+To install Maesh, the installation method is quite simple:
 
 ```bash
 helm repo add maesh https://containous.github.io/maesh/charts
 helm repo update
 ```
 
-Install maesh helm chart:
+Install Maesh helm chart:
 
 ```bash
 helm install maesh maesh/maesh
@@ -18,7 +18,7 @@ helm install maesh maesh/maesh
 !!! Note Supported Installations
     Please be aware that the supported installation method is via Helm, using official releases.
     If you want to build/install/run Maesh from source, we may not be able to provide support.
-    Installing from source is intended for development/contributing .
+    Installing from source is intended for development/contributing.
 
 To build the image locally, run:
 
@@ -26,13 +26,12 @@ To build the image locally, run:
 make
 ```
 
- to build the binary and build/tag the local image.
 You will then be able to use the tagged image as your image in your `values.yaml` file.
 
-## Deploy helm chart
+### Deploy helm chart
 
 ??? Note "Helm V3"
-    Please keep in mind, that our current Helm Chart (v1.0.0) is v2 compatible only. The v3 compatible Chart will be released with v1.1 of Maesh.
+    Please keep in mind, that our current Helm Chart (v1.1.0) is v3 compatible only.
 
 To deploy the helm chart, run:
 
@@ -42,7 +41,7 @@ helm install maesh helm/chart/maesh --set controller.image.pullPolicy=IfNotPrese
 
 ## KubeDNS support
 
-Maesh can support KubeDNS
+Maesh can support KubeDNS:
 
 ```bash
 helm install maesh maesh/maesh --set kubedns=true
@@ -77,7 +76,7 @@ helm install maesh --namespace=maesh maesh/maesh --set smi.enable=true`
     If you are re-installing into a cluster with the CRDs already present, helm may give you a warning.
     If you do not want to install them, or want to avoid the warning during a re-install,
     please use the new `--skip-crds` flag.
-    More informationcan be found on the [helm documentation](https://helm.sh/docs/topics/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you)
+    More information can be found on the [helm documentation](https://helm.sh/docs/topics/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you).
 
 ## Platform recommendations
 
@@ -122,7 +121,7 @@ replicaset.apps/maesh-controller-676fb86b89   1         1         0       28s
 
 ## Usage
 
-To use maesh, instead of referencing services via their normal `<servicename>.<namespace>`, instead use `<servicename>.<namespace>.maesh`.
-This will access the maesh service mesh, and will allow you to route requests through maesh.
+To use Maesh, instead of referencing services via their normal `<servicename>.<namespace>`, instead use `<servicename>.<namespace>.maesh`.
+This will access the Maesh service mesh, and will allow you to route requests through Maesh.
 
-By default, maesh is opt-in, meaning you have to use the maesh service names to access the mesh, so you can have some services running through the mesh, and some services not.
+By default, Maesh is opt-in, meaning you have to use the Maesh service names to access the mesh, so you can have some services running through the mesh, and some services not.

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -121,7 +121,7 @@ spec:
             - "infinity"
 ```
 
-Create the namespace then deploy those two applications
+Create the namespace then deploy those two applications:
 
 ```bash
 kubectl create namespace maesh-test
@@ -129,7 +129,7 @@ kubectl apply -f server.yaml
 kubectl apply -f client.yaml
 ```
 
-You should now see the following output
+You should now see the following output:
 
 ```bash tab="Command"
 kubectl get all -n maesh-test


### PR DESCRIPTION
### What does this PR do?

This PR fixes some little typos I've found while reading the documentation and the `helm documentation` link reported by the HTML checker on `make`.