### PR TITLE
Add semaphore build cache

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -44,6 +44,7 @@ blocks:
         commands:
           - sem-version go 1.14
           - checkout
+          - cache restore
       jobs:
         - name: Unit Tests
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,6 +24,10 @@ blocks:
          - sem-version go 1.14
          - checkout
       jobs:
+        - name: Cache Dependencies
+          commands:
+            - go mod download
+            - cache store
         - name: Build and Check
           commands:
             - make check build
@@ -39,6 +43,7 @@ blocks:
         commands:
           - sem-version go 1.14
           - checkout
+          - cache restore
           - cache restore maesh-dist-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA
           - cache restore maesh-img-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA
           - docker load < maesh-img.tar

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,6 +15,22 @@ fail_fast:
     when: "branch != 'master'"
     
 blocks:
+  - name: Build and Check
+    skip:
+     when: "branch = 'gh-pages'"
+    task:
+      prologue:
+       commands:
+         - sem-version go 1.14
+         - checkout
+      jobs:
+        - name: Build and Check
+          commands:
+            - make check build
+            - cache store maesh-dist-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA dist
+            - docker save containous/maesh:latest > maesh-img.tar
+            - cache store maesh-img-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA maesh-img.tar
+
   - name: Tests
     skip:
       when: "branch = 'gh-pages'"
@@ -22,24 +38,26 @@ blocks:
       prologue:
         commands:
           - sem-version go 1.14
-          - go version
           - checkout
+          - cache restore maesh-dist-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA
+          - cache restore maesh-img-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA
+          - docker load < maesh-img.tar
       jobs:
-        - name: Build and Unit Tests
+        - name: Unit Tests
           commands:
-            - make
+            - make test
         - name: SMI Integration Suite
           commands:
-            -  "make test-integration TESTFLAGS=\"-check.f SMISuite\""
+            -  "make test-integration-nobuild TESTFLAGS=\"-check.f SMISuite\""
         - name: Kubernetes Suite
           commands:
-            -  "make test-integration TESTFLAGS=\"-check.f KubernetesSuite\""
+            -  "make test-integration-nobuild TESTFLAGS=\"-check.f KubernetesSuite\""
         - name: CoreDNS Suite
           commands:
-            -  "make test-integration TESTFLAGS=\"-check.f CoreDNSSuite\""
+            -  "make test-integration-nobuild TESTFLAGS=\"-check.f CoreDNSSuite\""
         - name: KubeDNS Suite
           commands:
-            -  "make test-integration TESTFLAGS=\"-check.f KubeDNSSuite\""
+            -  "make test-integration-nobuild TESTFLAGS=\"-check.f KubeDNSSuite\""
         - name: Helm Suite
           commands:
-            -  "make test-integration TESTFLAGS=\"-check.f HelmSuite\""
+            -  "make test-integration-nobuild TESTFLAGS=\"-check.f HelmSuite\""

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -26,6 +26,7 @@ blocks:
       jobs:
         - name: Cache Go dependencies
           commands:
+            - cache restore
             - go mod download
             - cache store
         - name: Build and check

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,9 +31,9 @@ blocks:
         - name: Build and check
           commands:
             - make check build
-            - cache store maesh-dist-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA dist
+            - cache store maesh-dist-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_WORKFLOW_ID dist
             - docker save containous/maesh:latest > maesh-img.tar
-            - cache store maesh-img-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA maesh-img.tar
+            - cache store maesh-img-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_WORKFLOW_ID maesh-img.tar
 
   - name: Tests
     skip:
@@ -44,8 +44,8 @@ blocks:
           - sem-version go 1.14
           - checkout
           - cache restore
-          - cache restore maesh-dist-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA
-          - cache restore maesh-img-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA
+          - cache restore maesh-dist-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_WORKFLOW_ID
+          - cache restore maesh-img-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_WORKFLOW_ID
           - docker load < maesh-img.tar
       jobs:
         - name: Unit Tests

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,16 +13,16 @@ auto_cancel:
 fail_fast:
   stop:
     when: "branch != 'master'"
-    
+
 blocks:
   - name: Build
     skip:
-     when: "branch = 'gh-pages'"
+      when: "branch = 'gh-pages'"
     task:
       prologue:
-       commands:
-         - sem-version go 1.14
-         - checkout
+        commands:
+          - sem-version go 1.14
+          - checkout
       jobs:
         - name: Cache Go dependencies
           commands:
@@ -47,7 +47,7 @@ blocks:
       jobs:
         - name: Unit Tests
           commands:
-              - make local-test
+            - make local-test
 
   - name: Integration Tests
     skip:
@@ -64,16 +64,16 @@ blocks:
       jobs:
         - name: SMI Integration Suite
           commands:
-            -  "make test-integration-nobuild TESTFLAGS=\"-check.f SMISuite\""
+            - "make test-integration-nobuild TESTFLAGS=\"-check.f SMISuite\""
         - name: Kubernetes Suite
           commands:
-            -  "make test-integration-nobuild TESTFLAGS=\"-check.f KubernetesSuite\""
+            - "make test-integration-nobuild TESTFLAGS=\"-check.f KubernetesSuite\""
         - name: CoreDNS Suite
           commands:
-            -  "make test-integration-nobuild TESTFLAGS=\"-check.f CoreDNSSuite\""
+            - "make test-integration-nobuild TESTFLAGS=\"-check.f CoreDNSSuite\""
         - name: KubeDNS Suite
           commands:
-            -  "make test-integration-nobuild TESTFLAGS=\"-check.f KubeDNSSuite\""
+            - "make test-integration-nobuild TESTFLAGS=\"-check.f KubeDNSSuite\""
         - name: Helm Suite
           commands:
-            -  "make test-integration-nobuild TESTFLAGS=\"-check.f HelmSuite\""
+            - "make test-integration-nobuild TESTFLAGS=\"-check.f HelmSuite\""

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,7 +36,20 @@ blocks:
             - docker save containous/maesh:latest > maesh-img.tar
             - cache store maesh-img-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_WORKFLOW_ID maesh-img.tar
 
-  - name: Tests
+  - name: Unit Tests
+    skip:
+      when: "branch = 'gh-pages'"
+    task:
+      prologue:
+        commands:
+          - sem-version go 1.14
+          - checkout
+      jobs:
+        - name: Unit Tests
+          commands:
+              - make local-test
+
+  - name: Integration Tests
     skip:
       when: "branch = 'gh-pages'"
     task:
@@ -49,9 +62,6 @@ blocks:
           - cache restore maesh-img-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_WORKFLOW_ID
           - docker load < maesh-img.tar
       jobs:
-        - name: Unit Tests
-          commands:
-            - make test
         - name: SMI Integration Suite
           commands:
             -  "make test-integration-nobuild TESTFLAGS=\"-check.f SMISuite\""

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,7 +27,7 @@ blocks:
         - name: Cache Go dependencies
           commands:
             - cache restore
-            - go mod download
+            - go mod download -x
             - cache store
         - name: Build and check
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,7 +15,7 @@ fail_fast:
     when: "branch != 'master'"
     
 blocks:
-  - name: Build and Check
+  - name: Build
     skip:
      when: "branch = 'gh-pages'"
     task:
@@ -24,11 +24,11 @@ blocks:
          - sem-version go 1.14
          - checkout
       jobs:
-        - name: Cache Dependencies
+        - name: Cache Go dependencies
           commands:
             - go mod download
             - cache store
-        - name: Build and Check
+        - name: Build and check
           commands:
             - make check build
             - cache store maesh-dist-$SEMAPHORE_GIT_BRANCH-$SEMAPHORE_GIT_SHA dist


### PR DESCRIPTION
### What does this PR do?

Fixes #481.

Currently, every job downloads Go dependencies and build Maesh. This PR uses the available [Semaphore CI cache](https://docs.semaphoreci.com/essentials/caching-dependencies-and-directories/#cache-restore-keysecond-key) to avoid unnecessary work.

Note: `helm` and `k3d` dependencies are not cached. To cache these dependencies, we have to use a [custom container](https://docs.semaphoreci.com/ci-cd-environment/custom-ci-cd-environment-with-docker/#building-a-minimal-docker-image-for-semaphore) which seems a bit unnecessary (`helm` and `k3d` installations seem to be fast).

WDYT?