### PR TITLE
Fix discrepancy in prepare interface

### DIFF
--- a/pkg/prepare/prepare.go
+++ b/pkg/prepare/prepare.go
@@ -45,7 +45,7 @@ var supportedCoreDNSVersions = []string{
 type Preparer interface {
 	CheckDNSProvider() (DNSProvider, error)
 	StartInformers(acl bool) error
-	ConfigureCoreDNS(namespace, clusterDomain string) error
+	ConfigureCoreDNS(clusterDomain, namespace string) error
 	ConfigureKubeDNS() error
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes a discrepancy in the `Preparer` interface which was misleading and let to two mistakes already where arguments were inverted and a lot of time lost.
