### PR TITLE
Disable mesh proxy dashboard in Helm chart

### DIFF
--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -149,7 +149,7 @@ spec:
             - "--tracing.haystack.baggagePrefixHeaderName={{ .Values.tracing.haystack.baggagePrefixHeaderName }}"
               {{- end }}
             {{- end }}
-            - "--api.dashboard"
+            - "--api.dashboard=false"
             - "--api.insecure"
             - "--ping"
             - "--log.level={{ .Values.mesh.logging }}"


### PR DESCRIPTION
### What does this PR do?

Fixes #515.

This PR disables the mesh proxy dashboard in the Helm chart.