### PR TITLE
Remove deprecated SMI option in the Helm chart

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -15,7 +15,7 @@ helm install maesh maesh/maesh
 
 ## Install from source
 
-!!! Note Supported Installations
+!!! Note "Supported Installations"
     Please be aware that the supported installation method is via Helm, using official releases.
     If you want to build/install/run Maesh from source, we may not be able to provide support.
     Installing from source is intended for development/contributing.
@@ -73,26 +73,15 @@ helm install maesh --namespace=maesh maesh/maesh --set acl=true
 Maesh supports the [SMI specification](https://smi-spec.io/) which defines a set of custom resources
 to provide a fine-grained control over instrumentation, routing and access control of east-west communications.
 
-!!! Note CRDs
-    Helm v3 automatically will install the CRDs in the `/crds` directory.
-    If you are re-installing into a cluster with the CRDs already present, Helm may print a warning.
-    If you do not want to install them, or want to avoid the warning during a re-install,
-    please use the new `--skip-crds` flag.
-    More information can be found on the [helm documentation](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you).
+!!! Note "CRDs"
+    Helm v3 will install automatically the CRDs in the `/crds` directory.
+    If you are (re)installing into a cluster with the CRDs already present, Helm may print a warning.
+    If you do not want to install them, or want to avoid the warning, use the new `--skip-crds` flag.
+    More information can be found in the [Helm documentation](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you).
 
-## SMI Mode (Deprecated)
-
-Maesh supports the SMI specification which defines a set of custom resources to provide a fine-grained control over instrumentation, routing and access control of east-west communications.
-
-To enable SMI, install maesh in SMI mode by setting the smi.enable helm chart option to true.
-
-```bash
-helm install maesh --namespace=maesh maesh/maesh --set smi.enable=true`
-```
-
-The smi.enable option makes Maesh process SMI resources.
-
-!!! Note This option is deprecated. Please consider using `--acl` instead.
+!!! Warning "SMI Mode (Deprecated)"
+    The SMI mode is deprecated, and you should consider the use of the backward compatible ACL mode described above. 
+    For that reason, the corresponding option `smi.enable`, has been removed from the Helm Chart (v2.0.0). 
 
 ## Platform recommendations
 

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -79,10 +79,6 @@ to provide a fine-grained control over instrumentation, routing and access contr
     If you do not want to install them, or want to avoid the warning, use the new `--skip-crds` flag.
     More information can be found in the [Helm documentation](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you).
 
-!!! Warning "SMI Mode (Deprecated)"
-    The SMI mode is deprecated, and you should consider the use of the backward compatible ACL mode described above. 
-    For that reason, the corresponding option `smi.enable`, has been removed from the Helm Chart (v2.0.0). 
-
 ## Platform recommendations
 
 Maesh works on Kubernetes environments that conforms to the global Kubernetes specification.

--- a/docs/content/migration/helm-chart.md
+++ b/docs/content/migration/helm-chart.md
@@ -1,0 +1,17 @@
+# Migrations
+
+Helm Chart
+{: .subtitle }
+
+## v1.x to v2.0
+
+### SMI Mode
+
+The `smi.enable` Helm option has been deprecated and removed. You should use the new and backward compatible ACL mode 
+option as described in the [documentation](../install.md#access-control-list). 
+
+### Docker image version
+
+Since version `v1.2`, Maesh uses [Traefik](https://github.com/containous/traefik/) as a library and does not rely on its 
+Docker image anymore. Therefore, the `controller.image` and `mesh.image` Helm options have been removed. You should use 
+the new `image` option as described in the [documentation](../install.md#deploy-helm-chart).    

--- a/docs/content/migration/maesh-v1.md
+++ b/docs/content/migration/maesh-v1.md
@@ -1,0 +1,11 @@
+# Minor Migrations
+
+Maesh v1
+{: .subtitle }
+
+## v1.1 to v1.2
+
+### SMI Mode
+
+The `--smi` CLI flag is deprecated and will be removed in a future Major release. Instead, you should use the new and 
+backward compatible `--acl` flag.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -69,6 +69,9 @@ nav:
   - 'Configuration': 'configuration.md'
   - 'Examples': 'examples.md'
   - 'API': 'api.md'
+  - 'Migration':
+      - 'Maesh v1': 'migration/maesh-v1.md'
+      - 'Helm Chart': 'migration/helm-chart.md'
   - 'Contributing':
       - 'Thank You!': 'contributing/thank-you.md'
       - 'Submitting Issues': 'contributing/submitting-issues.md'

--- a/docs/scripts/verify.sh
+++ b/docs/scripts/verify.sh
@@ -22,7 +22,7 @@ find "${PATH_TO_SITE}" -type f -not -path "/app/site/theme/*" \
   --alt_ignore="/maesh-logo.png/" \
   --alt_ignore="/maesh-logo.svg/" \
   --http_status_ignore="0,500,501,503" \
-  --url_ignore="/fonts.gstatic.com/,/docs.mae.sh/" \
+  --url_ignore="/fonts.gstatic.com/,/docs.mae.sh/,/github.com\/containous\/maesh\/edit*/" \
   '{}' 1>/dev/null
 ## HTML-proofer options at https://github.com/gjtorikian/html-proofer#configuration
 

--- a/helm/chart/maesh/Guidelines.md
+++ b/helm/chart/maesh/Guidelines.md
@@ -13,7 +13,7 @@ This allows minimal configuration, and ease of extension.
 
 ```yaml
 image:
-  name: store/containous/traefikee
+  name: containous/maesh
 ```
 
 This feature is critical, and therefore is defined clearly in the `values.yaml` file.

--- a/helm/chart/maesh/templates/controller/controller-deployment.yaml
+++ b/helm/chart/maesh/templates/controller/controller-deployment.yaml
@@ -73,9 +73,6 @@ spec:
             {{- if .Values.acl }}
             - "--acl"
             {{- end }}
-            {{- if .Values.smi.enable }}
-            - "--smi"
-            {{- end }}
             - "--namespace=$(POD_NAMESPACE)"
             {{- if .Values.controller.ignoreNamespaces }}
             - {{ include "maesh.controllerIgnoreNamespaces" . | quote }}
@@ -119,9 +116,6 @@ spec:
             - "prepare"
             {{- if .Values.controller.logging.debug }}
             - "--debug"
-            {{- end }}
-            {{- if .Values.smi.enable }}
-            - "--smi"
             {{- end }}
             {{- if .Values.acl }}
             - "--acl"

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -142,9 +142,6 @@ metrics:
 
 acl: false
 
-smi:
-  enable: false
-
 limits:
   http: 10
   tcp: 25

--- a/integration/acl_enabled_test.go
+++ b/integration/acl_enabled_test.go
@@ -19,7 +19,7 @@ func (s *ACLEnabledSuite) SetUpSuite(c *check.C) {
 	}
 	s.startk3s(c, requiredImages)
 	s.startAndWaitForCoreDNS(c)
-	err := s.installHelmMaesh(c, false, false, true)
+	err := s.installHelmMaesh(c, true, false)
 	c.Assert(err, checker.IsNil)
 	s.waitForMaeshControllerStarted(c)
 }

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -24,7 +24,7 @@ func (s *HelmSuite) TearDownSuite(c *check.C) {
 }
 
 func (s *HelmSuite) TestACLDisabled(c *check.C) {
-	err := s.installHelmMaesh(c, false, false, false)
+	err := s.installHelmMaesh(c, false, false)
 	c.Assert(err, checker.IsNil)
 
 	defer s.unInstallHelmMaesh(c)
@@ -33,16 +33,7 @@ func (s *HelmSuite) TestACLDisabled(c *check.C) {
 }
 
 func (s *HelmSuite) TestACLEnabled(c *check.C) {
-	err := s.installHelmMaesh(c, false, false, true)
-	c.Assert(err, checker.IsNil)
-
-	defer s.unInstallHelmMaesh(c)
-
-	s.waitForMaeshControllerStarted(c)
-}
-
-func (s *HelmSuite) TestSMIEnabled(c *check.C) {
-	err := s.installHelmMaesh(c, true, false, false)
+	err := s.installHelmMaesh(c, true, false)
 	c.Assert(err, checker.IsNil)
 
 	defer s.unInstallHelmMaesh(c)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -337,15 +337,10 @@ func (s *BaseSuite) createRequiredNamespaces(c *check.C) {
 	s.kubectlCommand(c, "create", "namespace", testNamespace)
 }
 
-func (s *BaseSuite) installHelmMaesh(c *check.C, smi bool, kubeDNS bool, acl bool) error {
+func (s *BaseSuite) installHelmMaesh(c *check.C, acl bool, kubeDNS bool) error {
 	c.Log("Installing Maesh via helm...")
 	// Install the helm chart.
 	argSlice := []string{"install", "powpow", "../helm/chart/maesh", "--values", "resources/values.yaml", "--namespace", maeshNamespace}
-
-	if smi {
-		// Skip CRD installation as they are installed as part of the SMI test suite setup.
-		argSlice = append(argSlice, "--set", "smi.enable=true", "--skip-crds")
-	}
 
 	if kubeDNS {
 		argSlice = append(argSlice, "--set", "kubedns=true")

--- a/integration/kubedns_test.go
+++ b/integration/kubedns_test.go
@@ -35,7 +35,7 @@ func (s *KubeDNSSuite) TestKubeDNS(c *check.C) {
 		"exec", "-it", pod.Name, "-n", pod.Namespace, "-c", pod.Spec.Containers[0].Name, "--", "curl", "whoami.whoami.svc.cluster.local", "--max-time", "5",
 	}
 
-	err := s.installHelmMaesh(c, false, true, false)
+	err := s.installHelmMaesh(c, false, true)
 	c.Assert(err, checker.IsNil)
 	s.waitForMaeshControllerStarted(c)
 	s.waitKubectlExecCommand(c, argSlice, "whoami")

--- a/integration/resources/values.yaml
+++ b/integration/resources/values.yaml
@@ -48,9 +48,6 @@ metrics:
   prometheus:
     enabled: false
 
-smi:
-  enable: false
-
 kubedns: false
 
 limits:


### PR DESCRIPTION
### What does this PR do?

Fixes #502.

This PR removes the deprecated SMI option in the Helm chart.

### Additional Notes

This PR removes also the Traefik EE reference in the Helm chart guidelines.