### PR TITLE
Add Cleanup Command

### DIFF
--- a/cmd/cleanup/cleanup.go
+++ b/cmd/cleanup/cleanup.go
@@ -1,0 +1,54 @@
+package cleanup
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/containous/maesh/cmd"
+	"github.com/containous/maesh/pkg/cleanup"
+	"github.com/containous/maesh/pkg/k8s"
+	"github.com/containous/traefik/v2/pkg/cli"
+	"github.com/sirupsen/logrus"
+)
+
+// NewCmd builds a new Cleanup command.
+func NewCmd(cConfig *cmd.CleanupConfiguration, loaders []cli.ResourceLoader) *cli.Command {
+	return &cli.Command{
+		Name:          "cleanup",
+		Description:   `Cleanup command.`,
+		Configuration: cConfig,
+		Run: func(_ []string) error {
+			return cleanupCommand(cConfig)
+		},
+		Resources: loaders,
+	}
+}
+
+func cleanupCommand(cConfig *cmd.CleanupConfiguration) error {
+	log := logrus.New()
+
+	log.SetOutput(os.Stdout)
+	log.SetLevel(logrus.InfoLevel)
+
+	if cConfig.Debug {
+		log.SetLevel(logrus.DebugLevel)
+	}
+
+	log.Debugln("Starting maesh cleanup...")
+	log.Debugf("Using masterURL: %q", cConfig.MasterURL)
+	log.Debugf("Using kubeconfig: %q", cConfig.KubeConfig)
+
+	clients, err := k8s.NewClient(log, cConfig.MasterURL, cConfig.KubeConfig)
+	if err != nil {
+		return fmt.Errorf("error building clients: %v", err)
+	}
+
+	c := cleanup.NewCleanup(log, clients)
+
+	err = c.CleanShadowServices()
+	if err != nil {
+		return fmt.Errorf("error encountered during cluster cleanup: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/cleanup/cleanup.go
+++ b/cmd/cleanup/cleanup.go
@@ -28,11 +28,15 @@ func cleanupCommand(cConfig *cmd.CleanupConfiguration) error {
 	log := logrus.New()
 
 	log.SetOutput(os.Stdout)
-	log.SetLevel(logrus.InfoLevel)
 
-	if cConfig.Debug {
-		log.SetLevel(logrus.DebugLevel)
+	logLevelStr := cConfig.LogLevel
+
+	logLevel, err := logrus.ParseLevel(logLevelStr)
+	if err != nil {
+		return err
 	}
+
+	log.SetLevel(logLevel)
 
 	log.Debugln("Starting maesh cleanup...")
 	log.Debugf("Using masterURL: %q", cConfig.MasterURL)

--- a/cmd/cleanup/cleanup.go
+++ b/cmd/cleanup/cleanup.go
@@ -45,7 +45,7 @@ func cleanupCommand(cConfig *cmd.CleanupConfiguration) error {
 
 	c := cleanup.NewCleanup(log, clients)
 
-	if err := c.CleanShadowServices(); err != nil {
+	if err := c.CleanShadowServices(cConfig.Namespace); err != nil {
 		return fmt.Errorf("error encountered during cluster cleanup: %w", err)
 	}
 

--- a/cmd/cleanup/cleanup.go
+++ b/cmd/cleanup/cleanup.go
@@ -40,12 +40,12 @@ func cleanupCommand(cConfig *cmd.CleanupConfiguration) error {
 
 	clients, err := k8s.NewClient(log, cConfig.MasterURL, cConfig.KubeConfig)
 	if err != nil {
-		return fmt.Errorf("error building clients: %wß", err)
+		return fmt.Errorf("error building clients: %w", err)
 	}
 
-	c := cleanup.NewCleanup(log, clients)
+	c := cleanup.NewCleanup(log, clients, cConfig.Namespace)
 
-	if err := c.CleanShadowServices(cConfig.Namespace); err != nil {
+	if err := c.CleanShadowServices(); err != nil {
 		return fmt.Errorf("error encountered during cluster cleanup: %w", err)
 	}
 

--- a/cmd/cleanup/cleanup.go
+++ b/cmd/cleanup/cleanup.go
@@ -29,9 +29,7 @@ func cleanupCommand(cConfig *cmd.CleanupConfiguration) error {
 
 	log.SetOutput(os.Stdout)
 
-	logLevelStr := cConfig.LogLevel
-
-	logLevel, err := logrus.ParseLevel(logLevelStr)
+	logLevel, err := logrus.ParseLevel(cConfig.LogLevel)
 	if err != nil {
 		return err
 	}

--- a/cmd/cleanup/cleanup.go
+++ b/cmd/cleanup/cleanup.go
@@ -15,7 +15,7 @@ import (
 func NewCmd(cConfig *cmd.CleanupConfiguration, loaders []cli.ResourceLoader) *cli.Command {
 	return &cli.Command{
 		Name:          "cleanup",
-		Description:   `Cleanup command.`,
+		Description:   `Removes Maesh shadow services from a Kubernetes cluster.`,
 		Configuration: cConfig,
 		Run: func(_ []string) error {
 			return cleanupCommand(cConfig)
@@ -40,13 +40,12 @@ func cleanupCommand(cConfig *cmd.CleanupConfiguration) error {
 
 	clients, err := k8s.NewClient(log, cConfig.MasterURL, cConfig.KubeConfig)
 	if err != nil {
-		return fmt.Errorf("error building clients: %v", err)
+		return fmt.Errorf("error building clients: %wß", err)
 	}
 
 	c := cleanup.NewCleanup(log, clients)
 
-	err = c.CleanShadowServices()
-	if err != nil {
+	if err := c.CleanShadowServices(); err != nil {
 		return fmt.Errorf("error encountered during cluster cleanup: %w", err)
 	}
 

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -101,15 +101,15 @@ func NewProxyConfiguration() *ProxyConfiguration {
 type CleanupConfiguration struct {
 	KubeConfig string `description:"Path to a kubeconfig. Only required if out-of-cluster." export:"true"`
 	MasterURL  string `description:"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster." export:"true"`
-	Debug      bool   `description:"Debug mode." export:"true"`
 	Namespace  string `description:"The namespace that maesh is installed in." export:"true"`
+	LogLevel   string `description:"The log level." export:"true"`
 }
 
 // NewCleanupConfiguration creates CleanupConfiguration.
 func NewCleanupConfiguration() *CleanupConfiguration {
 	return &CleanupConfiguration{
 		KubeConfig: os.Getenv("KUBECONFIG"),
-		Debug:      false,
 		Namespace:  "maesh",
+		LogLevel:   "error",
 	}
 }

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -96,3 +96,20 @@ func NewProxyConfiguration() *ProxyConfiguration {
 		},
 	}
 }
+
+// CleanupConfiguration holds the configuration for the cleanup command.
+type CleanupConfiguration struct {
+	KubeConfig string `description:"Path to a kubeconfig. Only required if out-of-cluster." export:"true"`
+	MasterURL  string `description:"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster." export:"true"`
+	Debug      bool   `description:"Debug mode." export:"true"`
+	Namespace  string `description:"The namespace that maesh is installed in." export:"true"`
+}
+
+// NewCleanupConfiguration creates CleanupConfiguration.
+func NewCleanupConfiguration() *CleanupConfiguration {
+	return &CleanupConfiguration{
+		KubeConfig: os.Getenv("KUBECONFIG"),
+		Debug:      false,
+		Namespace:  "maesh",
+	}
+}

--- a/cmd/maesh/maesh.go
+++ b/cmd/maesh/maesh.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/containous/maesh/cmd"
+	"github.com/containous/maesh/cmd/cleanup"
 	"github.com/containous/maesh/cmd/prepare"
 	"github.com/containous/maesh/cmd/proxy"
 	"github.com/containous/maesh/cmd/version"
@@ -33,6 +34,12 @@ func main() {
 
 	pConfig := cmd.NewPrepareConfiguration()
 	if err := cmdMaesh.AddCommand(prepare.NewCmd(pConfig, loaders)); err != nil {
+		stdlog.Println(err)
+		os.Exit(1)
+	}
+
+	cConfig := cmd.NewCleanupConfiguration()
+	if err := cmdMaesh.AddCommand(cleanup.NewCmd(cConfig, loaders)); err != nil {
 		stdlog.Println(err)
 		os.Exit(1)
 	}

--- a/helm/chart/maesh/templates/controller/controller-deployment.yaml
+++ b/helm/chart/maesh/templates/controller/controller-deployment.yaml
@@ -73,7 +73,7 @@ spec:
             {{- if .Values.acl }}
             - "--acl"
             {{- end }}
-            - "--namespace=$(POD_NAMESPACE)"
+            - "--namespace={{ .Release.Namespace }}"
             {{- if .Values.controller.ignoreNamespaces }}
             - {{ include "maesh.controllerIgnoreNamespaces" . | quote }}
             {{- end }}
@@ -86,11 +86,6 @@ spec:
             {{- if .Values.limits.udp }}
             - "--limitUDPPort={{ .Values.limits.udp }}"
             {{- end }}
-          env:
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
           resources:
             requests:
               memory: {{ .Values.controller.resources.request.mem }}
@@ -121,12 +116,7 @@ spec:
             {{- end }}
             - "--clusterdomain"
             - {{ default "cluster.local" .Values.clusterDomain | quote }}
-            - "--namespace=$(POD_NAMESPACE)"
-          env:
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+            - "--namespace={{ .Release.Namespace }}"
           securityContext:
             capabilities:
               drop:

--- a/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
+++ b/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
@@ -1,4 +1,70 @@
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: maesh-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name | quote}}
+    chart: {{ include "maesh.chartLabel" . | quote}}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+    
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: maesh-cleanup-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name | quote}}
+    chart: {{ include "maesh.chartLabel" . | quote}}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: maesh-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name | quote}}
+    chart: {{ include "maesh.chartLabel" . | quote}}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "15"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: maesh-cleanup-role
+subjects:
+- kind: ServiceAccount
+  name: maesh-cleanup
+  namespace: {{ .Release.Namespace }}
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -10,7 +76,8 @@ metadata:
     release: {{ .Release.Name | quote}}
     heritage: {{ .Release.Service | quote}}
   annotations:
-    "helm.sh/hook": "pre-delete"
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "20"
     "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
 spec:
   backoffLimit: 0
@@ -22,7 +89,7 @@ spec:
         component: cleanup
         release: {{ .Release.Name | quote}}
     spec:
-      serviceAccountName: maesh-controller
+      serviceAccountName: maesh-cleanup
       restartPolicy: Never
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:

--- a/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
+++ b/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
@@ -101,8 +101,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           args:
             - "cleanup"
-            {{- if .Values.controller.logging.debug }}
-            - "--debug"
+            {{- if .Values.controller.logLevel }}
+            - "--logLevel={{ .Values.controller.logLevel }}"
             {{- end }}
             - "--namespace={{ .Release.Namespace }}"
           securityContext:

--- a/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
+++ b/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
@@ -37,12 +37,7 @@ spec:
             {{- if .Values.controller.logging.debug }}
             - "--debug"
             {{- end }}
-            - "--namespace=$(POD_NAMESPACE)"
-          env:
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+            - "--namespace={{ .Release.Namespace }}"
           securityContext:
             capabilities:
               drop:

--- a/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
+++ b/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
@@ -44,4 +44,3 @@ spec:
                 - ALL
               add:
                 - NET_BIND_SERVICE
-  

--- a/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
+++ b/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: maesh-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name | quote}}
+    chart: {{ include "maesh.chartLabel" . | quote }}
+    release: {{ .Release.Name | quote}}
+    heritage: {{ .Release.Service | quote}}
+  annotations:
+    "helm.sh/hook": "pre-delete"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 30
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name | quote}}
+        component: cleanup
+        release: {{ .Release.Name | quote}}
+    spec:
+      serviceAccountName: maesh-controller
+      restartPolicy: Never
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+      {{- end }}
+      containers:
+        - name: maesh-cleanup
+          image: {{ include "maesh.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          args:
+            - "cleanup"
+            {{- if .Values.controller.logging.debug }}
+            - "--debug"
+            {{- end }}
+            - "--namespace=$(POD_NAMESPACE)"
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+  

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -1,0 +1,52 @@
+package cleanup
+
+import (
+	"github.com/containous/maesh/pkg/k8s"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Cleaner is an interface for the cleanup methods.
+type Cleaner interface {
+	CleanShadowServices() error
+}
+
+// Ensure the Prepare fits the Preparer interface
+var _ Cleaner = (*Cleanup)(nil)
+
+// Cleanup holds the clients for the various resource controllers.
+type Cleanup struct {
+	client k8s.Client
+	log    logrus.FieldLogger
+}
+
+// NewCleanup returns an initialized cleanup object.
+func NewCleanup(log logrus.FieldLogger, client k8s.Client) Cleaner {
+	return &Cleanup{
+		client: client,
+		log:    log,
+	}
+}
+
+// CleanShadowServices deletes all shadow services from the cluster.
+func (c *Cleanup) CleanShadowServices() error {
+	serviceList, err := c.client.GetKubernetesClient().CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{
+		LabelSelector: "app=maesh",
+	})
+	if len(serviceList.Items) == 0 {
+		// No services found, return without error.
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	for _, s := range serviceList.Items {
+		if err := c.client.GetKubernetesClient().CoreV1().Services(s.Namespace).Delete(s.Name, &metav1.DeleteOptions{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -6,14 +6,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Cleaner is an interface for the cleanup methods.
-type Cleaner interface {
-	CleanShadowServices() error
-}
-
-// Ensure the Prepare fits the Preparer interface
-var _ Cleaner = (*Cleanup)(nil)
-
 // Cleanup holds the clients for the various resource controllers.
 type Cleanup struct {
 	client k8s.Client
@@ -21,7 +13,7 @@ type Cleanup struct {
 }
 
 // NewCleanup returns an initialized cleanup object.
-func NewCleanup(log logrus.FieldLogger, client k8s.Client) Cleaner {
+func NewCleanup(log logrus.FieldLogger, client k8s.Client) *Cleanup {
 	return &Cleanup{
 		client: client,
 		log:    log,
@@ -33,11 +25,6 @@ func (c *Cleanup) CleanShadowServices() error {
 	serviceList, err := c.client.GetKubernetesClient().CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{
 		LabelSelector: "app=maesh",
 	})
-	if len(serviceList.Items) == 0 {
-		// No services found, return without error.
-		return nil
-	}
-
 	if err != nil {
 		return err
 	}

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -8,21 +8,23 @@ import (
 
 // Cleanup holds the clients for the various resource controllers.
 type Cleanup struct {
-	client k8s.Client
-	log    logrus.FieldLogger
+	client    k8s.Client
+	log       logrus.FieldLogger
+	namespace string
 }
 
 // NewCleanup returns an initialized cleanup object.
-func NewCleanup(log logrus.FieldLogger, client k8s.Client) *Cleanup {
+func NewCleanup(log logrus.FieldLogger, client k8s.Client, namespace string) *Cleanup {
 	return &Cleanup{
-		client: client,
-		log:    log,
+		client:    client,
+		log:       log,
+		namespace: namespace,
 	}
 }
 
 // CleanShadowServices deletes all shadow services from the cluster.
-func (c *Cleanup) CleanShadowServices(namespace string) error {
-	serviceList, err := c.client.GetKubernetesClient().CoreV1().Services(namespace).List(metav1.ListOptions{
+func (c *Cleanup) CleanShadowServices() error {
+	serviceList, err := c.client.GetKubernetesClient().CoreV1().Services(c.namespace).List(metav1.ListOptions{
 		LabelSelector: "app=maesh,type=shadow",
 	})
 	if err != nil {

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -21,9 +21,9 @@ func NewCleanup(log logrus.FieldLogger, client k8s.Client) *Cleanup {
 }
 
 // CleanShadowServices deletes all shadow services from the cluster.
-func (c *Cleanup) CleanShadowServices() error {
-	serviceList, err := c.client.GetKubernetesClient().CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{
-		LabelSelector: "app=maesh",
+func (c *Cleanup) CleanShadowServices(namespace string) error {
+	serviceList, err := c.client.GetKubernetesClient().CoreV1().Services(namespace).List(metav1.ListOptions{
+		LabelSelector: "app=maesh,type=shadow",
 	})
 	if err != nil {
 		return err

--- a/pkg/cleanup/cleanup_test.go
+++ b/pkg/cleanup/cleanup_test.go
@@ -1,0 +1,54 @@
+package cleanup
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/containous/maesh/pkg/k8s"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewCleanup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clientMock := k8s.NewClientMock(ctx.Done(), "mock.yaml", false)
+	log := logrus.New()
+
+	log.SetOutput(os.Stdout)
+	log.SetLevel(logrus.DebugLevel)
+
+	cln := NewCleanup(log, clientMock)
+	assert.NotNil(t, cln)
+}
+
+func TestCleanShadowServices(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clientMock := k8s.NewClientMock(ctx.Done(), "mock.yaml", false)
+	log := logrus.New()
+
+	log.SetOutput(os.Stdout)
+	log.SetLevel(logrus.DebugLevel)
+
+	cln := NewCleanup(log, clientMock)
+	assert.NotNil(t, cln)
+
+	err := cln.CleanShadowServices()
+	assert.NoError(t, err)
+
+	sl, err := clientMock.GetKubernetesClient().CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{
+		LabelSelector: "app=maesh",
+	})
+	assert.NoError(t, err)
+	assert.Len(t, sl.Items, 0)
+
+	srv, err := clientMock.GetKubernetesClient().CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Len(t, srv.Items, 1)
+
+}

--- a/pkg/cleanup/cleanup_test.go
+++ b/pkg/cleanup/cleanup_test.go
@@ -38,16 +38,16 @@ func TestCleanShadowServices(t *testing.T) {
 	cln := NewCleanup(log, clientMock)
 	assert.NotNil(t, cln)
 
-	err := cln.CleanShadowServices()
+	err := cln.CleanShadowServices("maesh")
 	assert.NoError(t, err)
 
 	sl, err := clientMock.GetKubernetesClient().CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{
-		LabelSelector: "app=maesh",
+		LabelSelector: "app=maesh,type=shadow",
 	})
 	assert.NoError(t, err)
 	assert.Len(t, sl.Items, 0)
 
 	srv, err := clientMock.GetKubernetesClient().CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{})
 	assert.NoError(t, err)
-	assert.Len(t, srv.Items, 1)
+	assert.Len(t, srv.Items, 2)
 }

--- a/pkg/cleanup/cleanup_test.go
+++ b/pkg/cleanup/cleanup_test.go
@@ -50,5 +50,4 @@ func TestCleanShadowServices(t *testing.T) {
 	srv, err := clientMock.GetKubernetesClient().CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{})
 	assert.NoError(t, err)
 	assert.Len(t, srv.Items, 1)
-
 }

--- a/pkg/cleanup/cleanup_test.go
+++ b/pkg/cleanup/cleanup_test.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestNewCleanup(t *testing.T) {
+func TestCleanup_New(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -21,11 +21,11 @@ func TestNewCleanup(t *testing.T) {
 	log.SetOutput(os.Stdout)
 	log.SetLevel(logrus.DebugLevel)
 
-	cln := NewCleanup(log, clientMock)
+	cln := NewCleanup(log, clientMock, metav1.NamespaceDefault)
 	assert.NotNil(t, cln)
 }
 
-func TestCleanShadowServices(t *testing.T) {
+func TestCleanup_CleanShadowServices(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -35,10 +35,10 @@ func TestCleanShadowServices(t *testing.T) {
 	log.SetOutput(os.Stdout)
 	log.SetLevel(logrus.DebugLevel)
 
-	cln := NewCleanup(log, clientMock)
+	cln := NewCleanup(log, clientMock, "maesh")
 	assert.NotNil(t, cln)
 
-	err := cln.CleanShadowServices("maesh")
+	err := cln.CleanShadowServices()
 	assert.NoError(t, err)
 
 	sl, err := clientMock.GetKubernetesClient().CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{

--- a/pkg/cleanup/fixtures/mock.yaml
+++ b/pkg/cleanup/fixtures/mock.yaml
@@ -3,8 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test1
+  namespace: maesh
   labels:
     app: maesh
+    type: shadow
 spec:
   selector:
     app: test
@@ -18,8 +20,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test2
+  namespace: maesh
   labels:
     app: maesh
+    type: shadow
 spec:
   selector:
     app: test
@@ -33,6 +37,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test3
+  namespace: maesh
 spec:
   selector:
     app: test
@@ -40,3 +45,17 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: 8080
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test4
+  namespace: default
+spec:
+  selector:
+    app: test
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080      

--- a/pkg/cleanup/fixtures/mock.yaml
+++ b/pkg/cleanup/fixtures/mock.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test1
+  labels:
+    app: maesh
+spec:
+  selector:
+    app: test
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test2
+  labels:
+    app: maesh
+spec:
+  selector:
+    app: test
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test3
+spec:
+  selector:
+    app: test
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -70,7 +70,8 @@ func (s *ShadowServiceManager) Create(userSvc *corev1.Service) error {
 			Name:      name,
 			Namespace: s.namespace,
 			Labels: map[string]string{
-				"app": "maesh",
+				"app":  "maesh",
+				"type": "shadow",
 			},
 		},
 		Spec: corev1.ServiceSpec{

--- a/pkg/controller/service_test.go
+++ b/pkg/controller/service_test.go
@@ -64,6 +64,7 @@ func TestShadowServiceManager_Create(t *testing.T) {
 					Namespace: "maesh",
 					Labels: map[string]string{
 						"app":               "maesh",
+						"type":              "shadow",
 						"test-alreadyexist": "true",
 					},
 				},
@@ -91,7 +92,8 @@ func TestShadowServiceManager_Create(t *testing.T) {
 					Name:      "maesh-http-default-6d61657368-namespace",
 					Namespace: "maesh",
 					Labels: map[string]string{
-						"app": "maesh",
+						"app":  "maesh",
+						"type": "shadow",
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -134,7 +136,8 @@ func TestShadowServiceManager_Create(t *testing.T) {
 					Name:      "maesh-http-6d61657368-namespace",
 					Namespace: "maesh",
 					Labels: map[string]string{
-						"app": "maesh",
+						"app":  "maesh",
+						"type": "shadow",
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -177,7 +180,8 @@ func TestShadowServiceManager_Create(t *testing.T) {
 					Name:      "maesh-udp-reuse-6d61657368-namespace",
 					Namespace: "maesh",
 					Labels: map[string]string{
-						"app": "maesh",
+						"app":  "maesh",
+						"type": "shadow",
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -221,7 +225,8 @@ func TestShadowServiceManager_Create(t *testing.T) {
 					Name:      "maesh-udp-6d61657368-namespace",
 					Namespace: "maesh",
 					Labels: map[string]string{
-						"app": "maesh",
+						"app":  "maesh",
+						"type": "shadow",
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -249,6 +254,7 @@ func TestShadowServiceManager_Create(t *testing.T) {
 			Namespace: "maesh",
 			Labels: map[string]string{
 				"app":               "maesh",
+				"type":              "shadow",
 				"test-alreadyexist": "true",
 			},
 		},
@@ -369,7 +375,8 @@ func TestShadowServiceManager_Update(t *testing.T) {
 					Name:      "maesh-my-svc-6d61657368-my-ns",
 					Namespace: "maesh",
 					Labels: map[string]string{
-						"app": "maesh",
+						"app":  "maesh",
+						"type": "shadow",
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -441,7 +448,8 @@ func TestShadowServiceManager_Update(t *testing.T) {
 					Name:      "maesh-my-svc-6d61657368-my-ns",
 					Namespace: "maesh",
 					Labels: map[string]string{
-						"app": "maesh",
+						"app":  "maesh",
+						"type": "shadow",
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -537,7 +545,8 @@ func TestShadowServiceManager_Delete(t *testing.T) {
 					Name:      "maesh-my-svc-6d61657368-my-ns",
 					Namespace: "maesh",
 					Labels: map[string]string{
-						"app": "maesh",
+						"app":  "maesh",
+						"type": "shadow",
 					},
 				},
 				Spec: corev1.ServiceSpec{


### PR DESCRIPTION
## What does this PR do?

This PR:

- Adds a cleanup command
- Adds cleanup functionality to purge created shadow services from the cluster on helm delete

Fixes #487 
<!-- A brief description of the change being made with this pull request. -->
