### PR TITLE
Remove unused env variable POD_IP in Helm chart

### DIFF
--- a/helm/chart/maesh/templates/controller/controller-deployment.yaml
+++ b/helm/chart/maesh/templates/controller/controller-deployment.yaml
@@ -87,10 +87,6 @@ spec:
             - "--limitUDPPort={{ .Values.limits.udp }}"
             {{- end }}
           env:
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## What does this PR do?

This PR:

- Removes the unused env variable named `POD_IP` in the Helm chart