### PR TITLE
Add destination namespace check in indexer

### DIFF
--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -141,7 +141,6 @@ By default, all traffic is denied so we need to grant access to clients to our a
 
 !!! Note "TrafficTarget Source & Destination"
     Please note that TrafficTarget is a namespaced resource.
-    It is important to ensure that the destination namespace is populated, as kubernetes will not autopopulate this field for you.
     If the destination namespace is not populated, the TrafficTarget namespace will be used as the destination namespace. 
 
 ```yaml

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -141,7 +141,8 @@ By default, all traffic is denied so we need to grant access to clients to our a
 
 !!! Note "TrafficTarget Source & Destination"
     Please note that TrafficTarget is a namespaced resource.
-    If the destination namespace is not populated, the TrafficTarget namespace will be used as the destination namespace. 
+    If the destination namespace is not populated, the TrafficTarget namespace will be used as the destination namespace.
+    The source namespace must be populated, as it cannot be inferred.
 
 ```yaml
 ---

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -139,9 +139,10 @@ Other types of route groups and detailed information are available [in the speci
 
 By default, all traffic is denied so we need to grant access to clients to our application. This is done by defining a `TrafficTarget`.
 
-??? Note "TrafficTarget Source & Destination"
-    Please note that TrafficTarget is a namespaced resource. Therefore, the source and the destination namespace needs to be explicitly defined.
-    If you do not define a destination namespace, the TrafficTarget namespace will be used as the destination namespace.
+!!! Note "TrafficTarget Source & Destination"
+    Please note that TrafficTarget is a namespaced resource.
+    It is important to ensure that the destination namespace is populated, as kubernetes will not autopopulate this field for you.
+    If the destination namespace is not populated, the TrafficTarget namespace will be used as the destination namespace. 
 
 ```yaml
 ---

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -141,6 +141,7 @@ By default, all traffic is denied so we need to grant access to clients to our a
 
 ??? Note "TrafficTarget Source & Destination"
     Please note that TrafficTarget is a namespaced resource. Therefore, the source and the destination namespace needs to be explicitly defined.
+    If you do not define a destination namespace, the TrafficTarget namespace will be used as the destination namespace.
 
 ```yaml
 ---

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -35,7 +35,7 @@ type Builder struct {
 func (b *Builder) Build(ignoredResources mk8s.IgnoreWrapper) (*Topology, error) {
 	topology := NewTopology()
 
-	res, err := b.LoadResources(ignoredResources)
+	res, err := b.loadResources(ignoredResources)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load resources: %w", err)
 	}
@@ -564,8 +564,6 @@ func getOrCreatePod(topology *Topology, pod *corev1.Pod) Key {
 
 	return podKey
 }
-
-// LoadResources uses listers to populate a resource object.
 
 func (b *Builder) loadResources(ignoredResources mk8s.IgnoreWrapper) (*resources, error) {
 	res := &resources{

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -13,7 +13,6 @@ import (
 	splitlister "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/listers/split/v1alpha2"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	listers "k8s.io/client-go/listers/core/v1"
 )
@@ -723,9 +722,9 @@ func (r *resources) indexSMIResources(ignoredResources mk8s.IgnoreWrapper, tts [
 			continue
 		}
 
-		// If the destination namepace is empty or blank, set it to default.
-		if trafficTarget.Destination.Namespace == "" {
-			trafficTarget.Destination.Namespace = metav1.NamespaceDefault
+		// If the destination namepace is empty or blank, set it to the trafficTarget namespace.
+		if len(trafficTarget.Destination.Namespace) == 0 {
+			trafficTarget.Destination.Namespace = trafficTarget.Namespace
 		}
 
 		key := Key{trafficTarget.Name, trafficTarget.Namespace}

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -13,6 +13,7 @@ import (
 	splitlister "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/listers/split/v1alpha2"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	listers "k8s.io/client-go/listers/core/v1"
 )
@@ -720,6 +721,11 @@ func (r *resources) indexSMIResources(ignoredResources mk8s.IgnoreWrapper, tts [
 	for _, trafficTarget := range tts {
 		if ignoredResources.IsIgnored(trafficTarget.ObjectMeta) {
 			continue
+		}
+
+		// If the destination namepace is empty or blank, set it to default.
+		if trafficTarget.Destination.Namespace == "" {
+			trafficTarget.Destination.Namespace = metav1.NamespaceDefault
 		}
 
 		key := Key{trafficTarget.Name, trafficTarget.Namespace}

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -723,7 +723,7 @@ func (r *resources) indexSMIResources(ignoredResources mk8s.IgnoreWrapper, tts [
 		}
 
 		// If the destination namepace is empty or blank, set it to the trafficTarget namespace.
-		if len(trafficTarget.Destination.Namespace) == 0 {
+		if trafficTarget.Destination.Namespace == "" {
 			trafficTarget.Destination.Namespace = trafficTarget.Namespace
 		}
 

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -35,7 +35,7 @@ type Builder struct {
 func (b *Builder) Build(ignoredResources mk8s.IgnoreWrapper) (*Topology, error) {
 	topology := NewTopology()
 
-	res, err := b.loadResources(ignoredResources)
+	res, err := b.LoadResources(ignoredResources)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load resources: %w", err)
 	}
@@ -564,6 +564,8 @@ func getOrCreatePod(topology *Topology, pod *corev1.Pod) Key {
 
 	return podKey
 }
+
+// LoadResources uses listers to populate a resource object.
 
 func (b *Builder) loadResources(ignoredResources mk8s.IgnoreWrapper) (*resources, error) {
 	res := &resources{

--- a/pkg/topology/builder_test.go
+++ b/pkg/topology/builder_test.go
@@ -473,6 +473,40 @@ func TestTopologyBuilder_BuildTrafficTargetMultipleSourcesAndDestinations(t *tes
 	assertTopology(t, "testdata/topology-multi-sources-destinations.json", got)
 }
 
+func TestTopologyBuilder_EmptyTrafficTargetDestination(t *testing.T) {
+	tt := &access.TrafficTarget{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "TrafficTarget",
+			APIVersion: "access.smi-spec.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+			Name:      "test",
+		},
+		Destination: access.IdentityBindingSubject{
+			Kind: "ServiceAccount",
+			Name: "test",
+			Port: "80",
+		},
+	}
+
+	k8sClient := fake.NewSimpleClientset()
+	smiAccessClient := accessfake.NewSimpleClientset(tt)
+	smiSplitClient := splitfake.NewSimpleClientset()
+	smiSpecClient := specfake.NewSimpleClientset()
+
+	builder, err := createBuilder(k8sClient, smiAccessClient, smiSpecClient, smiSplitClient)
+	require.NoError(t, err)
+
+	ignoredResources := mk8s.NewIgnored()
+	res, err := builder.LoadResources(ignoredResources)
+	require.NoError(t, err)
+
+	actual, exists := res.TrafficTargets[topology.Key{Name: "test", Namespace: metav1.NamespaceDefault}]
+	assert.Equal(t, true, exists)
+	assert.Equal(t, metav1.NamespaceDefault, actual.Destination.Namespace)
+}
+
 // createBuilder initializes the different k8s factories and start them, initializes listers and create
 // a new topology.Builder.
 func createBuilder(k8sClient k8s.Interface, smiAccessClient accessclient.Interface, smiSpecClient specsclient.Interface, smiSplitClient splitclient.Interface) (*topology.Builder, error) {

--- a/pkg/topology/builder_test.go
+++ b/pkg/topology/builder_test.go
@@ -472,14 +472,15 @@ func TestTopologyBuilder_BuildTrafficTargetMultipleSourcesAndDestinations(t *tes
 	assertTopology(t, "testdata/topology-multi-sources-destinations.json", got)
 }
 
-func TestTopologyBuilder_EmptyTrafficTargetDestination(t *testing.T) {
+func TestTopologyBuilder_EmptyTrafficTargetDestinationNamespace(t *testing.T) {
+	namespace := "foo"
 	tt := &access.TrafficTarget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "TrafficTarget",
 			APIVersion: "access.smi-spec.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: metav1.NamespaceDefault,
+			Namespace: namespace,
 			Name:      "test",
 		},
 		Destination: access.IdentityBindingSubject{
@@ -501,9 +502,9 @@ func TestTopologyBuilder_EmptyTrafficTargetDestination(t *testing.T) {
 	res, err := builder.loadResources(ignoredResources)
 	require.NoError(t, err)
 
-	actual, exists := res.TrafficTargets[Key{Name: "test", Namespace: metav1.NamespaceDefault}]
+	actual, exists := res.TrafficTargets[Key{Name: "test", Namespace: namespace}]
 	assert.Equal(t, true, exists)
-	assert.Equal(t, metav1.NamespaceDefault, actual.Destination.Namespace)
+	assert.Equal(t, namespace, actual.Destination.Namespace)
 }
 
 // createBuilder initializes the different k8s factories and start them, initializes listers and create


### PR DESCRIPTION
## What does this PR do?

This PR:

- Adds a check for an empty destination namespace in traffictargets during load
- Adds test to ensure empty destination namespaces are filled with the namespace of the traffictarget.

Fixes #546
<!-- A brief description of the change being made with this pull request. -->


## Additional Notes

We may want to look at a "validate resource" method in the future, but I think for now it can be avoided as there is not a lot of validation required.