### PR TITLE
Add custom namespace to helm rewrite

### DIFF
--- a/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
@@ -36,7 +36,7 @@ data:
         kubernetes {{ default "cluster.local" .Values.clusterDomain }} in-addr.arpa ip6.arpa {
             pods insecure
             upstream
-        	fallthrough in-addr.arpa ip6.arpa
+        	  fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf
         cache 30

--- a/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
@@ -30,8 +30,8 @@ data:
     maesh:53 {
         errors
         rewrite continue {
-            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh maesh-{1}-6d61657368-{2}.maesh.svc.{{ default "cluster.local" .Values.clusterDomain }}
-            answer name maesh-([a-zA-Z0-9-_]*)-6d61657368-([a-zA-Z0-9-_]*)\.maesh\.svc\.{{ default "cluster.local" .Values.clusterDomain | replace "." "\\." }} {1}.{2}.maesh
+            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh {{{ .Release.Namespace }}}-{1}-6d61657368-{2}.{{{ .Release.Namespace }}}.svc.{{ default "cluster.local" .Values.clusterDomain }}
+            answer name {{{ .Release.Namespace }}}-([a-zA-Z0-9-_]*)-6d61657368-([a-zA-Z0-9-_]*)\.{{{ .Release.Namespace }}}\.svc\.{{ default "cluster.local" .Values.clusterDomain | replace "." "\\." }} {1}.{2}.maesh
         }
         kubernetes {{ default "cluster.local" .Values.clusterDomain }} in-addr.arpa ip6.arpa {
             pods insecure

--- a/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
@@ -30,8 +30,8 @@ data:
     maesh:53 {
         errors
         rewrite continue {
-            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh {{{ .Release.Namespace }}}-{1}-6d61657368-{2}.{{{ .Release.Namespace }}}.svc.{{ default "cluster.local" .Values.clusterDomain }}
-            answer name {{{ .Release.Namespace }}}-([a-zA-Z0-9-_]*)-6d61657368-([a-zA-Z0-9-_]*)\.{{{ .Release.Namespace }}}\.svc\.{{ default "cluster.local" .Values.clusterDomain | replace "." "\\." }} {1}.{2}.maesh
+            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh {{ .Release.Namespace }}-{1}-6d61657368-{2}.{{ .Release.Namespace }}.svc.{{ default "cluster.local" .Values.clusterDomain }}
+            answer name {{ .Release.Namespace }}-([a-zA-Z0-9-_]*)-6d61657368-([a-zA-Z0-9-_]*)\.{{ .Release.Namespace }}\.svc\.{{ default "cluster.local" .Values.clusterDomain | replace "." "\\." }} {1}.{2}.maesh
         }
         kubernetes {{ default "cluster.local" .Values.clusterDomain }} in-addr.arpa ip6.arpa {
             pods insecure

--- a/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
@@ -36,7 +36,7 @@ data:
         kubernetes {{ default "cluster.local" .Values.clusterDomain }} in-addr.arpa ip6.arpa {
             pods insecure
             upstream
-        	  fallthrough in-addr.arpa ip6.arpa
+            fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf
         cache 30


### PR DESCRIPTION
## What does this PR do?

This PR:

- Adds custom namespace to helm coreDNS rewrite template

Fixes #549

<!-- A brief description of the change being made with this pull request. -->

## Additional Notes

Part of me would want to have code de-duplication here, but I don't think that it is feasible given how golang parses multi-line strings, and how picky coreDNS is with indentation/whitespace.