### PR TITLE
Rebuild dynamic configuration on pod events

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -182,7 +182,6 @@ func (c *Controller) init() {
 		MaxHTTPPort:        c.cfg.MaxHTTPPort,
 		ACL:                c.cfg.ACLEnabled,
 		DefaultTrafficType: c.cfg.DefaultMode,
-		MaeshNamespace:     c.cfg.Namespace,
 	}
 
 	c.provider = provider.New(c.tcpStateTable, c.udpStateTable, annotations.BuildMiddlewares, providerCfg, c.logger)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -309,8 +309,3 @@ func (c *Controller) createMeshServices() error {
 
 	return nil
 }
-
-// isMeshPod checks if the pod is a mesh pod. Can be modified to use multiple metrics if needed.
-func isMeshPod(pod *corev1.Pod) bool {
-	return pod.Labels["component"] == "maesh-mesh"
-}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -146,7 +146,6 @@ func (c *Controller) init() {
 
 	c.kubernetesFactory.Core().V1().Services().Informer().AddEventHandler(c.handler)
 	c.kubernetesFactory.Core().V1().Endpoints().Informer().AddEventHandler(c.handler)
-	c.kubernetesFactory.Core().V1().Pods().Informer().AddEventHandler(c.handler)
 	c.splitFactory.Split().V1alpha2().TrafficSplits().Informer().AddEventHandler(c.handler)
 
 	// Create SharedInformers, listers and register the event handler for ACL related resources.
@@ -159,6 +158,7 @@ func (c *Controller) init() {
 		c.TCPRouteLister = c.specsFactory.Specs().V1alpha1().TCPRoutes().Lister()
 
 		c.accessFactory.Access().V1alpha1().TrafficTargets().Informer().AddEventHandler(c.handler)
+		c.kubernetesFactory.Core().V1().Pods().Informer().AddEventHandler(c.handler)
 		c.specsFactory.Specs().V1alpha1().HTTPRouteGroups().Informer().AddEventHandler(c.handler)
 		c.specsFactory.Specs().V1alpha1().TCPRoutes().Informer().AddEventHandler(c.handler)
 	}

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -16,25 +16,12 @@ type Handler struct {
 
 // NewHandler creates a handler.
 func NewHandler(log logrus.FieldLogger, ignored k8s.IgnoreWrapper, serviceManager ServiceManager, configRefreshChan chan string) *Handler {
-	h := &Handler{
+	return &Handler{
 		log:               log,
 		ignored:           ignored,
 		configRefreshChan: configRefreshChan,
 		serviceManager:    serviceManager,
 	}
-
-	if err := h.Init(); err != nil {
-		log.Errorln("Could not initialize MeshControllerHandler")
-	}
-
-	return h
-}
-
-// Init handles any handler initialization.
-func (h *Handler) Init() error {
-	h.log.Debugln("MeshControllerHandler.Init")
-
-	return nil
 }
 
 // OnAdd executed when an object is added.

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -1,28 +1,24 @@
 package controller
 
 import (
-	"github.com/containous/maesh/pkg/k8s"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 )
 
 // configMessageChanRebuild rebuild.
-const configMessageChanRebuild = "rebuild"
+var configMessageChanRebuild = struct{}{}
 
 // Handler is an implementation of a ResourceEventHandler.
 type Handler struct {
 	log               logrus.FieldLogger
-	ignoredResources  k8s.IgnoreWrapper
-	configRefreshChan chan string
+	configRefreshChan chan struct{}
 	serviceManager    ServiceManager
 }
 
 // NewHandler creates a handler.
-func NewHandler(log logrus.FieldLogger, ignored k8s.IgnoreWrapper, serviceManager ServiceManager, configRefreshChan chan string) *Handler {
+func NewHandler(log logrus.FieldLogger, serviceManager ServiceManager, configRefreshChan chan struct{}) *Handler {
 	return &Handler{
 		log:               log,
-		ignoredResources:  ignored,
 		configRefreshChan: configRefreshChan,
 		serviceManager:    serviceManager,
 	}
@@ -30,11 +26,7 @@ func NewHandler(log logrus.FieldLogger, ignored k8s.IgnoreWrapper, serviceManage
 
 // OnAdd is called when an object is added.
 func (h *Handler) OnAdd(obj interface{}) {
-	if h.isIgnoredResource(obj) {
-		return
-	}
-
-	// If the created object is a service we should create a corresponding shadow service.
+	// If the created object is a service we have to create a corresponding shadow service.
 	if obj, isService := obj.(*corev1.Service); isService {
 		if err := h.serviceManager.Create(obj); err != nil {
 			h.log.Errorf("Could not create mesh service: %v", err)
@@ -47,26 +39,7 @@ func (h *Handler) OnAdd(obj interface{}) {
 
 // OnUpdate is called when an object is updated and ensures that the proper handler is called depending on the filter matches.
 func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
-	isOldIgnored := h.isIgnoredResource(oldObj)
-	isNewIgnored := h.isIgnoredResource(newObj)
-
-	switch {
-	case isOldIgnored && isNewIgnored:
-		return
-
-	// Old object is not ignored anymore, so we can treat this as an add event.
-	case isOldIgnored && !isNewIgnored:
-		h.OnAdd(newObj)
-		return
-
-	// Old object is now ignored, so we can treat this as a delete event.
-	case !isOldIgnored && isNewIgnored:
-		h.OnDelete(oldObj)
-		return
-	}
-
-	// Old and new object are not ignored so this is a real update.
-	// If the updated object is a service we should update the corresponding shadow service.
+	// If the updated object is a service we have to update the corresponding shadow service.
 	if obj, isService := newObj.(*corev1.Service); isService {
 		oldSvc, ok := oldObj.(*corev1.Service)
 		if !ok {
@@ -87,11 +60,7 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 
 // OnDelete is called when an object is deleted.
 func (h *Handler) OnDelete(obj interface{}) {
-	if h.isIgnoredResource(obj) {
-		return
-	}
-
-	// If the deleted object is a service we should delete the corresponding shadow service.
+	// If the deleted object is a service we have to delete the corresponding shadow service.
 	if obj, isService := obj.(*corev1.Service); isService {
 		h.log.Debugf("MeshControllerHandler ObjectDeleted with type: *corev1.Service: %s/%s", obj.Namespace, obj.Name)
 
@@ -102,16 +71,4 @@ func (h *Handler) OnDelete(obj interface{}) {
 
 	// Trigger a configuration rebuild.
 	h.configRefreshChan <- configMessageChanRebuild
-}
-
-// isIgnoredResource returns true if the given resource should be ignored, false otherwise.
-func (h *Handler) isIgnoredResource(obj interface{}) bool {
-	accessor, err := meta.Accessor(obj)
-	if err != nil {
-		return true
-	}
-
-	pMeta := meta.AsPartialObjectMetadata(accessor)
-
-	return h.ignoredResources.IsIgnored(pMeta.ObjectMeta)
 }

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -5,9 +5,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// configMessageChanRebuild rebuild.
-var configMessageChanRebuild = struct{}{}
-
 // Handler is an implementation of a ResourceEventHandler.
 type Handler struct {
 	log               logrus.FieldLogger
@@ -34,10 +31,10 @@ func (h *Handler) OnAdd(obj interface{}) {
 	}
 
 	// Trigger a configuration rebuild.
-	h.configRefreshChan <- configMessageChanRebuild
+	h.configRefreshChan <- struct{}{}
 }
 
-// OnUpdate is called when an object is updated and ensures that the proper handler is called depending on the filter matches.
+// OnUpdate is called when an object is updated.
 func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 	// If the updated object is a service we have to update the corresponding shadow service.
 	if obj, isService := newObj.(*corev1.Service); isService {
@@ -55,7 +52,7 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 	}
 
 	// Trigger a configuration rebuild.
-	h.configRefreshChan <- configMessageChanRebuild
+	h.configRefreshChan <- struct{}{}
 }
 
 // OnDelete is called when an object is deleted.
@@ -70,5 +67,5 @@ func (h *Handler) OnDelete(obj interface{}) {
 	}
 
 	// Trigger a configuration rebuild.
-	h.configRefreshChan <- configMessageChanRebuild
+	h.configRefreshChan <- struct{}{}
 }

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -6,6 +6,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// configMessageChanRebuild rebuild.
+const configMessageChanRebuild = "rebuild"
+
 // Handler is an implementation of a ResourceEventHandler.
 type Handler struct {
 	log               logrus.FieldLogger
@@ -45,7 +48,7 @@ func (h *Handler) OnAdd(obj interface{}) {
 	}
 
 	// Trigger a configuration rebuild.
-	h.configRefreshChan <- k8s.ConfigMessageChanRebuild
+	h.configRefreshChan <- configMessageChanRebuild
 }
 
 // OnUpdate executed when an object is updated.
@@ -82,14 +85,10 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 		}
 
 		h.log.Debugf("MeshControllerHandler ObjectUpdated with type: *corev1.Pod: %s/%s", obj.Namespace, obj.Name)
-		// Since this is a mesh pod update, trigger a force deploy.
-		h.configRefreshChan <- k8s.ConfigMessageChanForce
-
-		return
 	}
 
 	// Trigger a configuration rebuild.
-	h.configRefreshChan <- k8s.ConfigMessageChanRebuild
+	h.configRefreshChan <- configMessageChanRebuild
 }
 
 // OnDelete executed when an object is deleted.
@@ -118,5 +117,5 @@ func (h *Handler) OnDelete(obj interface{}) {
 	}
 
 	// Trigger a configuration rebuild.
-	h.configRefreshChan <- k8s.ConfigMessageChanRebuild
+	h.configRefreshChan <- configMessageChanRebuild
 }

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -4,6 +4,7 @@ import (
 	"github.com/containous/maesh/pkg/k8s"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 )
 
 // configMessageChanRebuild rebuild.
@@ -12,7 +13,7 @@ const configMessageChanRebuild = "rebuild"
 // Handler is an implementation of a ResourceEventHandler.
 type Handler struct {
 	log               logrus.FieldLogger
-	ignored           k8s.IgnoreWrapper
+	ignoredResources  k8s.IgnoreWrapper
 	configRefreshChan chan string
 	serviceManager    ServiceManager
 }
@@ -21,29 +22,22 @@ type Handler struct {
 func NewHandler(log logrus.FieldLogger, ignored k8s.IgnoreWrapper, serviceManager ServiceManager, configRefreshChan chan string) *Handler {
 	return &Handler{
 		log:               log,
-		ignored:           ignored,
+		ignoredResources:  ignored,
 		configRefreshChan: configRefreshChan,
 		serviceManager:    serviceManager,
 	}
 }
 
-// OnAdd executed when an object is added.
+// OnAdd is called when an object is added.
 func (h *Handler) OnAdd(obj interface{}) {
-	// assert the type to an object to pull out relevant data
-	switch obj := obj.(type) {
-	case *corev1.Service:
-		if h.ignored.IsIgnored(obj.ObjectMeta) {
-			return
-		}
+	if h.isIgnoredResource(obj) {
+		return
+	}
 
+	// If the created object is a service we should create a corresponding shadow service.
+	if obj, isService := obj.(*corev1.Service); isService {
 		if err := h.serviceManager.Create(obj); err != nil {
 			h.log.Errorf("Could not create mesh service: %v", err)
-		}
-	case *corev1.Endpoints:
-		return
-	case *corev1.Pod:
-		if !isMeshPod(obj) {
-			return
 		}
 	}
 
@@ -51,15 +45,29 @@ func (h *Handler) OnAdd(obj interface{}) {
 	h.configRefreshChan <- configMessageChanRebuild
 }
 
-// OnUpdate executed when an object is updated.
+// OnUpdate is called when an object is updated and ensures that the proper handler is called depending on the filter matches.
 func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
-	// Assert the type to an object to pull out relevant data.
-	switch obj := newObj.(type) {
-	case *corev1.Service:
-		if h.ignored.IsIgnored(obj.ObjectMeta) {
-			return
-		}
+	isOldIgnored := h.isIgnoredResource(oldObj)
+	isNewIgnored := h.isIgnoredResource(newObj)
 
+	switch {
+	case isOldIgnored && isNewIgnored:
+		return
+
+	// Old object is not ignored anymore, so we can treat this as an add event.
+	case isOldIgnored && !isNewIgnored:
+		h.OnAdd(newObj)
+		return
+
+	// Old object is now ignored, so we can treat this as a delete event.
+	case !isOldIgnored && isNewIgnored:
+		h.OnDelete(oldObj)
+		return
+	}
+
+	// Old and new object are not ignored so this is a real update.
+	// If the updated object is a service we should update the corresponding shadow service.
+	if obj, isService := newObj.(*corev1.Service); isService {
 		oldSvc, ok := oldObj.(*corev1.Service)
 		if !ok {
 			h.log.Errorf("Old object is not a kubernetes Service")
@@ -71,51 +79,39 @@ func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
 		}
 
 		h.log.Debugf("MeshControllerHandler ObjectUpdated with type: *corev1.Service: %s/%s", obj.Namespace, obj.Name)
-	case *corev1.Endpoints:
-		// We can use the same ignore for services and endpoints.
-		if h.ignored.IsIgnored(obj.ObjectMeta) {
-			return
-		}
-
-		h.log.Debugf("MeshControllerHandler ObjectUpdated with type: *corev1.Endpoints: %s/%s", obj.Namespace, obj.Name)
-	case *corev1.Pod:
-		if !isMeshPod(obj) {
-			// We don't track updates of user pods, updates are done through endpoints.
-			return
-		}
-
-		h.log.Debugf("MeshControllerHandler ObjectUpdated with type: *corev1.Pod: %s/%s", obj.Namespace, obj.Name)
 	}
 
 	// Trigger a configuration rebuild.
 	h.configRefreshChan <- configMessageChanRebuild
 }
 
-// OnDelete executed when an object is deleted.
+// OnDelete is called when an object is deleted.
 func (h *Handler) OnDelete(obj interface{}) {
-	// Assert the type to an object to pull out relevant data.
-	switch obj := obj.(type) {
-	case *corev1.Service:
-		if h.ignored.IsIgnored(obj.ObjectMeta) {
-			return
-		}
+	if h.isIgnoredResource(obj) {
+		return
+	}
 
+	// If the deleted object is a service we should delete the corresponding shadow service.
+	if obj, isService := obj.(*corev1.Service); isService {
 		h.log.Debugf("MeshControllerHandler ObjectDeleted with type: *corev1.Service: %s/%s", obj.Namespace, obj.Name)
 
 		if err := h.serviceManager.Delete(obj); err != nil {
 			h.log.Errorf("Could not delete mesh service: %v", err)
 		}
-	case *corev1.Endpoints:
-		// We can use the same ignore for services and endpoints.
-		if h.ignored.IsIgnored(obj.ObjectMeta) {
-			return
-		}
-
-		h.log.Debugf("MeshController ObjectDeleted with type: *corev1.Endpoints: %s/%s", obj.Namespace, obj.Name)
-	case *corev1.Pod:
-		return
 	}
 
 	// Trigger a configuration rebuild.
 	h.configRefreshChan <- configMessageChanRebuild
+}
+
+// isIgnoredResource returns true if the given resource should be ignored, false otherwise.
+func (h *Handler) isIgnoredResource(obj interface{}) bool {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return true
+	}
+
+	pMeta := meta.AsPartialObjectMetadata(accessor)
+
+	return h.ignoredResources.IsIgnored(pMeta.ObjectMeta)
 }

--- a/pkg/k8s/constants.go
+++ b/pkg/k8s/constants.go
@@ -21,9 +21,4 @@ const (
 	TCPStateConfigMapName string = "tcp-state-table"
 	// UDPStateConfigMapName UDP config map name.
 	UDPStateConfigMapName string = "udp-state-table"
-
-	// ConfigMessageChanRebuild rebuild.
-	ConfigMessageChanRebuild string = "rebuild"
-	// ConfigMessageChanForce force.
-	ConfigMessageChanForce string = "force"
 )

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -44,7 +44,6 @@ type Config struct {
 	MaxHTTPPort        int32
 	ACL                bool
 	DefaultTrafficType string
-	MaeshNamespace     string
 }
 
 // Provider holds the configuration for generating dynamic configuration from a kubernetes cluster state.

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -126,7 +126,6 @@ func TestProvider_BuildConfig(t *testing.T) {
 				MaxHTTPPort:        10010,
 				ACL:                test.acl,
 				DefaultTrafficType: defaultTrafficType,
-				MaeshNamespace:     "maesh",
 			}
 
 			tcpStateTable := func(port mk8s.ServiceWithPort) (int32, bool) {


### PR DESCRIPTION
## What does this PR do?

This PR:

- Removes some unused properties and methods.
- Removes the forced configuration rebuild on `mesh` pods events.
- Triggers a configuration rebuild when pod events are received in ACL mode.

Fixes #513.

## How to test it

- Build and install Maesh with ACL mode enabled.
- Deploy the attached [resources](https://github.com/containous/maesh/files/4586145/issue-513.zip).
- Remove/Add the client resource to trigger dynamic config updates (which does not work well on master).

## Additional Notes

I've added a check to the `onAdd`, `onUpdate` and `onDelete` handler methods to make sure that we're not rebuilding the dynamic conf if the event should be ignored. Previously, only the service or endpoint events were filtered but we should do the same for `TrafficTarget` and so on.

As `proxy` nodes are now pulling the configuration from the `controller`, I've removed the unnecessary configuration rebuild when a `mesh` pod is added or deleted. `mesh` pod events are now filtered by the new `isIgnoredResource` method because we're ignoring the `maesh` app by default.

Last but not least, the `Handler` does not ignore pod events anymore in ACL mode. If I'm not wrong it's unnecessary to listen for pod events in non ACL mode.
