### PR TITLE
Cleanup port mapping before getting a new port

### DIFF
--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -104,14 +104,13 @@ func (s *ShadowServiceManager) Create(userSvc *corev1.Service) error {
 func (s *ShadowServiceManager) Update(oldUserSvc *corev1.Service, newUserSvc *corev1.Service) (*corev1.Service, error) {
 	name := s.getShadowServiceName(newUserSvc.Name, newUserSvc.Namespace)
 
+	if err := s.cleanupPortMapping(oldUserSvc, newUserSvc); err != nil {
+		return nil, fmt.Errorf("unable to cleanup port mapping for service %s/%s: %w", oldUserSvc.Namespace, oldUserSvc.Name, err)
+	}
+
 	ports, err := s.getShadowServicePorts(newUserSvc)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get ports for service %s/%s: %w", newUserSvc.Namespace, newUserSvc.Name, err)
-	}
-
-	err = s.cleanupPortMapping(oldUserSvc, newUserSvc)
-	if err != nil {
-		return nil, fmt.Errorf("unable to cleanup port mapping for service %s/%s: %w", oldUserSvc.Namespace, oldUserSvc.Name, err)
 	}
 
 	var updatedSvc *corev1.Service


### PR DESCRIPTION
## What does this PR do?

This PR fixes a regression on the `ShadowServiceManager.Update`. The new port gets allocated before we clean up the port mapping.

### How to test it

* Deploy maesh with a limited set of TCP port (like 1)
* Deploy a service which exposes a port (`8080`)
* Update the service and replace the exposed port by another one (`8081`)
* Check the tcp-state-table configMap and make sure there's a single port allocated on port (`10000` and not `10001`)

## Additional Notes

This regression happened in https://github.com/containous/maesh/pull/531