### PR TITLE
Add log level configuration property to commands

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -14,7 +14,8 @@ type MaeshConfiguration struct {
 	ConfigFile       string   `description:"Configuration file to use. If specified all other flags are ignored." export:"true"`
 	KubeConfig       string   `description:"Path to a kubeconfig. Only required if out-of-cluster." export:"true"`
 	MasterURL        string   `description:"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster." export:"true"`
-	Debug            bool     `description:"Debug mode." export:"true"`
+	LogLevel         string   `description:"The log level." export:"true"`
+	Debug            bool     `description:"Debug mode, deprecated, use --loglevel=debug instead." export:"true"`
 	ACL              bool     `description:"Enable ACL mode." export:"true"`
 	SMI              bool     `description:"Enable SMI operation, deprecated, use --acl instead." export:"true"`
 	DefaultMode      string   `description:"Default mode for mesh services." export:"true"`
@@ -32,6 +33,7 @@ func NewMaeshConfiguration() *MaeshConfiguration {
 	return &MaeshConfiguration{
 		ConfigFile:    "",
 		KubeConfig:    os.Getenv("KUBECONFIG"),
+		LogLevel:      "error",
 		Debug:         false,
 		ACL:           false,
 		SMI:           false,
@@ -49,7 +51,8 @@ func NewMaeshConfiguration() *MaeshConfiguration {
 type PrepareConfiguration struct {
 	KubeConfig    string `description:"Path to a kubeconfig. Only required if out-of-cluster." export:"true"`
 	MasterURL     string `description:"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster." export:"true"`
-	Debug         bool   `description:"Debug mode." export:"true"`
+	LogLevel      string `description:"The log level." export:"true"`
+	Debug         bool   `description:"Debug mode, deprecated, use --loglevel=debug instead." export:"true"`
 	Namespace     string `description:"The namespace that maesh is installed in." export:"true"`
 	ClusterDomain string `description:"Your internal K8s cluster domain." export:"true"`
 	SMI           bool   `description:"Enable SMI operation, deprecated, use --acl instead." export:"true"`
@@ -60,6 +63,7 @@ type PrepareConfiguration struct {
 func NewPrepareConfiguration() *PrepareConfiguration {
 	return &PrepareConfiguration{
 		KubeConfig:    os.Getenv("KUBECONFIG"),
+		LogLevel:      "error",
 		Debug:         false,
 		Namespace:     "maesh",
 		ClusterDomain: "cluster.local",

--- a/cmd/maesh/maesh.go
+++ b/cmd/maesh/maesh.go
@@ -59,11 +59,20 @@ func maeshCommand(iConfig *cmd.MaeshConfiguration) error {
 	log := logrus.New()
 
 	log.SetOutput(os.Stdout)
-	log.SetLevel(logrus.InfoLevel)
 
+	logLevelStr := iConfig.LogLevel
 	if iConfig.Debug {
-		log.SetLevel(logrus.DebugLevel)
+		logLevelStr = "debug"
+
+		log.Warnf("debug flag is deprecated, please consider using --loglevel=DEBUG instead")
 	}
+
+	logLevel, err := logrus.ParseLevel(logLevelStr)
+	if err != nil {
+		return err
+	}
+
+	log.SetLevel(logLevel)
 
 	log.Debugln("Starting maesh prepare...")
 	log.Debugf("Using masterURL: %q", iConfig.MasterURL)

--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -28,11 +28,20 @@ func prepareCommand(pConfig *cmd.PrepareConfiguration) error {
 	log := logrus.New()
 
 	log.SetOutput(os.Stdout)
-	log.SetLevel(logrus.InfoLevel)
 
+	logLevelStr := pConfig.LogLevel
 	if pConfig.Debug {
-		log.SetLevel(logrus.DebugLevel)
+		logLevelStr = "debug"
+
+		log.Warnf("debug flag is deprecated, please consider using --loglevel=DEBUG instead")
 	}
+
+	logLevel, err := logrus.ParseLevel(logLevelStr)
+	if err != nil {
+		return err
+	}
+
+	log.SetLevel(logLevel)
 
 	log.Debugln("Starting maesh prepare...")
 	log.Debugf("Using masterURL: %q", pConfig.MasterURL)

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -64,7 +64,7 @@ func runCmd(proxyConfiguration *cmd.ProxyConfiguration) error {
 
 	log.WithoutContext().Infof("Maesh proxy version %s built on %s", version.Version, version.Date)
 
-	if proxyConfiguration.Configuration.Log.Level == "DEBUG" {
+	if proxyConfiguration.Configuration.Log != nil && proxyConfiguration.Configuration.Log.Level == "DEBUG" {
 		jsonConf, err := json.Marshal(proxyConfiguration.Configuration)
 		if err != nil {
 			log.WithoutContext().Errorf("Could not marshal static configuration: %v", err)

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -7,17 +7,17 @@ The static configuration is configured when the service mesh is installed and is
 
 - The Maesh image version can be manually defined if needed.
 
-- Debug logging can be globally enabled.
+- Logging level for controller and proxies can be defined.
 
 - The default mesh mode can be configured. If this is not set, the default mode will be HTTP.
-    This means that new mesh services that are not specified will default to operate in HTTP mode.
+  This means that new mesh services that are not specified will default to operate in HTTP mode.
 
 - Tracing can be enabled.
 
 - Access-Control List (ACL) mode can be enabled.
-    This configures Maesh to run in ACL mode, where all traffic is forbidden unless explicitly allowed via 
-    an SMI [TrafficTarget](https://github.com/servicemeshinterface/smi-spec/blob/master/traffic-access-control.md).
-    Please see the [SMI Specification](https://github.com/servicemeshinterface/smi-spec/blob/master/traffic-access-control.md) for more information.
+  This configures Maesh to run in ACL mode, where all traffic is forbidden unless explicitly allowed via an SMI 
+  [TrafficTarget](https://github.com/servicemeshinterface/smi-spec/blob/master/traffic-access-control.md). Please see 
+  the [SMI Specification](https://github.com/servicemeshinterface/smi-spec/blob/master/traffic-access-control.md) for more information.
 
 ## Dynamic configuration
 

--- a/docs/content/migration/helm-chart.md
+++ b/docs/content/migration/helm-chart.md
@@ -5,13 +5,18 @@ Helm Chart
 
 ## v1.x to v2.0
 
-### SMI Mode
-
-The `smi.enable` Helm option has been deprecated and removed. You should use the new and backward compatible ACL mode 
-option as described in the [documentation](../install.md#access-control-list). 
-
-### Docker image version
+### Image version
 
 Since version `v1.2`, Maesh uses [Traefik](https://github.com/containous/traefik/) as a library and does not rely on its 
-Docker image anymore. Therefore, the `controller.image` and `mesh.image` Helm options have been removed. You should use 
-the new `image` option as described in the [documentation](../install.md#deploy-helm-chart).    
+Docker image anymore. Therefore, the `controller.image` and `mesh.image` options have been removed. You should use the 
+new `image` option as described in the [documentation](../install.md#deploy-helm-chart).    
+
+### Log Level
+
+The `controller.logging.debug` and `mesh.logging` options have been removed. You should use the new `controller.logLevel` 
+and `mesh.logLevel` options to configure the logging level for the controller and proxies.
+
+### SMI Mode
+
+The `smi.enable` option has been deprecated and removed. You should use the new and backward compatible ACL mode 
+option as described in the [documentation](../install.md#access-control-list). 

--- a/docs/content/migration/maesh-v1.md
+++ b/docs/content/migration/maesh-v1.md
@@ -5,6 +5,11 @@ Maesh v1
 
 ## v1.1 to v1.2
 
+### Debug
+
+The `--debug` CLI flag is deprecated and will be removed in a futur Major release. Instead, you should use the new 
+`--logLevel` flag with `debug` as value.
+
 ### SMI Mode
 
 The `--smi` CLI flag is deprecated and will be removed in a future Major release. Instead, you should use the new and 

--- a/helm/chart/maesh/templates/controller/controller-deployment.yaml
+++ b/helm/chart/maesh/templates/controller/controller-deployment.yaml
@@ -64,8 +64,8 @@ spec:
           image: {{ include "maesh.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           args:
-            {{- if .Values.controller.logging.debug }}
-            - "--debug"
+            {{- if .Values.controller.logLevel }}
+            - "--logLevel={{ .Values.controller.logLevel }}"
             {{- end }}
             {{- if .Values.mesh }}
             - "--defaultMode={{ .Values.mesh.defaultMode }}"
@@ -113,8 +113,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent"}}
           args:
             - "prepare"
-            {{- if .Values.controller.logging.debug }}
-            - "--debug"
+            {{- if .Values.controller.logLevel }}
+            - "--logLevel={{ .Values.controller.logLevel }}"
             {{- end }}
             {{- if .Values.acl }}
             - "--acl"

--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -156,7 +156,9 @@ spec:
             - "--api.dashboard=false"
             - "--api.insecure"
             - "--ping"
-            - "--log.level={{ .Values.mesh.logging }}"
+            {{- if .Values.mesh.logLevel }}
+            - "--log.level={{ .Values.mesh.logLevel }}"
+            {{- end }}
             {{- if .Values.metrics.prometheus.enabled }}
             - "--metrics.prometheus"
             {{- end }}

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -16,8 +16,7 @@ controller:
     request:
       mem: "50Mi"
       cpu: "100m"
-  logging:
-    debug: true
+  logLevel: error
   ignoreNamespaces:
   # Added so we can launch on nodes with restrictions
   nodeSelector: {}
@@ -35,10 +34,10 @@ mesh:
     request:
       mem: "50Mi"
       cpu: "100m"
-  logging: INFO
   defaultMode: http
   pollInterval: "1s"
   pollTimeout: "1s"
+  logLevel: error
   # Added so we can launch on nodes with restrictions
   nodeSelector: {}
   tolerations: []

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -107,7 +107,7 @@ func (s *BaseSuite) maeshStartControllerWithArgsCmd(args ...string) *exec.Cmd {
 	controllerArgSlice := []string{
 		fmt.Sprintf("--masterurl=%s", masterURL),
 		fmt.Sprintf("--kubeconfig=%s", os.Getenv("KUBECONFIG")),
-		"--debug",
+		"--logLevel=debug",
 		fmt.Sprintf("--namespace=%s", maeshNamespace),
 		"--apihost=127.0.0.1",
 	}
@@ -117,7 +117,7 @@ func (s *BaseSuite) maeshStartControllerWithArgsCmd(args ...string) *exec.Cmd {
 }
 
 func (s *BaseSuite) maeshPrepareWithArgs(args ...string) *exec.Cmd {
-	prepareArgSlice := []string{"prepare", fmt.Sprintf("--masterurl=%s", masterURL), fmt.Sprintf("--kubeconfig=%s", os.Getenv("KUBECONFIG")), "--debug", "--clusterdomain=cluster.local", fmt.Sprintf("--namespace=%s", maeshNamespace)}
+	prepareArgSlice := []string{"prepare", fmt.Sprintf("--masterurl=%s", masterURL), fmt.Sprintf("--kubeconfig=%s", os.Getenv("KUBECONFIG")), "--loglevel=debug", "--clusterdomain=cluster.local", fmt.Sprintf("--namespace=%s", maeshNamespace)}
 	args = append(prepareArgSlice, args...)
 
 	return exec.Command(maeshBinary, args...)


### PR DESCRIPTION
## What does this PR do?

This PR:

- Fixes a panic issue if the log level is not defined in the `proxy` cmd configuration.
- Adds a new `logLevel` configuration property to the `maesh` and `prepare` cmds.
- Adds a new `logLevel` property to the Helm chart and removed the older ones for consistency.

Fixes #520.

### How to test it

* Helm install with a custom log level for the `controller`:

```
helm install maesh helm/chart/maesh --set controller.logLevel=debug
```

* Helm install with a custom log level for the `proxies`:

```
helm install maesh helm/chart/maesh --set mesh.logLevel=debug
```

## Additional Notes

To be consistent the `logLevel` configuration should also be added to the new `cleanup` command in #538.

Maybe we could also add a global Helm `logLevel` option to configure the `controller` and `proxies` log level globally?
