### PR TITLE
Cleanup log messages

### DIFF
--- a/cmd/maesh/maesh.go
+++ b/cmd/maesh/maesh.go
@@ -71,7 +71,7 @@ func maeshCommand(iConfig *cmd.MaeshConfiguration) error {
 	if iConfig.Debug {
 		logLevelStr = "debug"
 
-		log.Warnf("debug flag is deprecated, please consider using --loglevel=DEBUG instead")
+		log.Warnf("Debug flag is deprecated, please consider using --loglevel=DEBUG instead")
 	}
 
 	logLevel, err := logrus.ParseLevel(logLevelStr)

--- a/cmd/prepare/prepare.go
+++ b/cmd/prepare/prepare.go
@@ -33,7 +33,7 @@ func prepareCommand(pConfig *cmd.PrepareConfiguration) error {
 	if pConfig.Debug {
 		logLevelStr = "debug"
 
-		log.Warnf("debug flag is deprecated, please consider using --loglevel=DEBUG instead")
+		log.Warnf("Debug flag is deprecated, please consider using --loglevel=DEBUG instead")
 	}
 
 	logLevel, err := logrus.ParseLevel(logLevelStr)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -50,7 +50,7 @@ var (
 
 func Test(t *testing.T) {
 	if !*integration {
-		log.Println("Integration tests disabled.")
+		log.Println("Integration tests disabled")
 		return
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -206,7 +206,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 	c.logger.Info("Creating initial mesh services")
 
 	if err := c.createMeshServices(); err != nil {
-		c.logger.Errorf("could not create mesh services: %v", err)
+		c.logger.Errorf("Could not create mesh services: %v", err)
 	}
 
 	// Start the api, and enable the readiness endpoint.
@@ -256,7 +256,7 @@ func (c *Controller) startInformers(stopCh <-chan struct{}, syncTimeout time.Dur
 
 	for t, ok := range c.kubernetesFactory.WaitForCacheSync(ctx.Done()) {
 		if !ok {
-			c.logger.Errorf("timed out waiting for controller caches to sync: %s", t.String())
+			c.logger.Errorf("Timed out waiting for controller caches to sync: %s", t)
 		}
 	}
 
@@ -264,7 +264,7 @@ func (c *Controller) startInformers(stopCh <-chan struct{}, syncTimeout time.Dur
 
 	for t, ok := range c.splitFactory.WaitForCacheSync(ctx.Done()) {
 		if !ok {
-			c.logger.Errorf("timed out waiting for controller caches to sync: %s", t.String())
+			c.logger.Errorf("Timed out waiting for controller caches to sync: %s", t)
 		}
 	}
 
@@ -273,7 +273,7 @@ func (c *Controller) startInformers(stopCh <-chan struct{}, syncTimeout time.Dur
 
 		for t, ok := range c.accessFactory.WaitForCacheSync(ctx.Done()) {
 			if !ok {
-				c.logger.Errorf("timed out waiting for controller caches to sync: %s", t.String())
+				c.logger.Errorf("Timed out waiting for controller caches to sync: %s", t)
 			}
 		}
 
@@ -281,7 +281,7 @@ func (c *Controller) startInformers(stopCh <-chan struct{}, syncTimeout time.Dur
 
 		for t, ok := range c.specsFactory.WaitForCacheSync(ctx.Done()) {
 			if !ok {
-				c.logger.Errorf("timed out waiting for controller caches to sync: %s", t.String())
+				c.logger.Errorf("Timed out waiting for controller caches to sync: %s", t)
 			}
 		}
 	}

--- a/pkg/proxy/provider/http/http.go
+++ b/pkg/proxy/provider/http/http.go
@@ -77,7 +77,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 					case <-ticker.C:
 						data, err := p.getDataFromEndpoint(ctxLog)
 						if err != nil {
-							logger.Errorf("Failed to get config from endpoint: %w", err)
+							logger.Errorf("Failed to get config from endpoint: %v", err)
 							errChan <- err
 							return
 						}
@@ -85,7 +85,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 						configuration := &dynamic.Configuration{}
 
 						if err := json.Unmarshal(data, configuration); err != nil {
-							log.FromContext(ctx).Errorf("Error parsing configuration %w", err)
+							log.FromContext(ctx).Errorf("Error parsing configuration: %v", err)
 							return
 						}
 
@@ -110,11 +110,11 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 		}
 
 		notify := func(err error, time time.Duration) {
-			logger.Errorf("Provider connection error %w, retrying in %s", err, time)
+			logger.Errorf("Provider connection error, retrying in %s: %v", time, err)
 		}
 		err := backoff.RetryNotify(safe.OperationWithRecover(operation), backoff.WithContext(job.NewBackOff(backoff.NewExponentialBackOff()), ctxLog), notify)
 		if err != nil {
-			logger.Errorf("Cannot connect to HTTP server %w", err)
+			logger.Errorf("Cannot connect to HTTP server: %v", err)
 		}
 	})
 


### PR DESCRIPTION
## What does this PR do?

This PR:

- Capitalizes some log messages for consistency.
- Replaces `%w` in some error log messages which cause ugly log messages:

```
Failed to get config from endpoint: %!w(*fmt.wrapError=&{unable to get data from...
```