### PR TITLE
Increase goreleaser build timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_deploy:
 deploy:
   - provider: script
     skip_cleanup: true
-    script: curl -sL https://git.io/goreleaser | bash
+    script: curl -sL https://git.io/goreleaser | bash -s -- --timeout="60m"
     on:
       tags: true
       condition: $STABLE = true


### PR DESCRIPTION
## What does this PR do?

This PR:

- Backports the fix to increase the goreleaser timeout on branch `v1.2`