### PR TITLE
Remove unneeded createMeshServices method in controller

### DIFF
--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -25,6 +25,8 @@ func NewHandler(log logrus.FieldLogger, serviceManager ServiceManager, configRef
 func (h *Handler) OnAdd(obj interface{}) {
 	// If the created object is a service we have to create a corresponding shadow service.
 	if obj, isService := obj.(*corev1.Service); isService {
+		h.log.Debugf("MeshControllerHandler ObjectAdded with type: *corev1.Service: %s/%s", obj.Namespace, obj.Name)
+
 		if err := h.serviceManager.Create(obj); err != nil {
 			h.log.Errorf("Could not create mesh service: %v", err)
 		}


### PR DESCRIPTION
## What does this PR do?

This PR:

- Removes the unneeded `createMeshServices` method in the controller.

## Additional Notes

When informers are started, they will emit an `Add` event for every watched resource added to the cache. So, we will receive an event for every `service` created by the user and create the corresponding `shadow service` if needed. Therefore, the `createMeshServices` method in the controller is not needed.


