### PR TITLE
Refine the controller readiness status

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -213,7 +213,6 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 	c.api.Start()
 
 	for {
-		timer := time.NewTimer(10 * time.Second)
 		select {
 		case <-stopCh:
 			c.logger.Info("Shutting down workers")
@@ -234,13 +233,6 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 				// Configuration successfully created, enable readiness in the api.
 				c.api.EnableReadiness()
 			}
-		case <-timer.C:
-			if rawCfg := c.lastConfiguration.Get(); rawCfg == nil {
-				break
-			}
-
-			// Configuration successfully created, enable readiness in the api.
-			c.api.EnableReadiness()
 		}
 	}
 }


### PR DESCRIPTION
## What does this PR do?

This PR:

- Removes the unnecessary `timer` in the controller loop.
- Enables the controller readiness endpoint as soon as the informers are started and synced.

Fixes #565.

As described, the `controller` is now marked as ready when the informers are started. Therefore, the mesh proxies will be able to fetch a default config even if no events are received because of an empty cluster. This default config enables the proxy readiness endpoint, which indicates that the link between the controller and the proxy is ready.

### How to test it

* Create an empty cluster with kind for example.
* Install Maesh with Helm. If you're using kind, you should ignore the `local-path-storage` ns.
* Maesh controller and proxy pods should be marked as ready.