### PR TITLE
Add testing to client mock

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -137,7 +137,7 @@ func TestGetMeshNodes(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			clientMock := k8s.NewClientMock(ctx.Done(), test.mockFile, false)
+			clientMock := k8s.NewClientMock(t, ctx.Done(), test.mockFile, false)
 			api := NewAPI(log, 9000, localhost, &config, clientMock.PodLister, "foo")
 			res := httptest.NewRecorder()
 			req := testhelpers.MustNewRequest(http.MethodGet, "/api/status/nodes", nil)
@@ -185,7 +185,7 @@ func TestGetMeshNodeConfiguration(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		clientMock := k8s.NewClientMock(ctx.Done(), test.mockFile, false)
+		clientMock := k8s.NewClientMock(t, ctx.Done(), test.mockFile, false)
 		api := NewAPI(log, 9000, localhost, &config, clientMock.PodLister, "foo")
 		res := httptest.NewRecorder()
 		req := testhelpers.MustNewRequest(http.MethodGet, "/api/status/node/mesh-pod-1/configuration", nil)

--- a/pkg/cleanup/cleanup_test.go
+++ b/pkg/cleanup/cleanup_test.go
@@ -15,7 +15,7 @@ func TestCleanup_New(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clientMock := k8s.NewClientMock(ctx.Done(), "mock.yaml", false)
+	clientMock := k8s.NewClientMock(t, ctx.Done(), "mock.yaml", false)
 	log := logrus.New()
 
 	log.SetOutput(os.Stdout)
@@ -29,7 +29,7 @@ func TestCleanup_CleanShadowServices(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clientMock := k8s.NewClientMock(ctx.Done(), "mock.yaml", false)
+	clientMock := k8s.NewClientMock(t, ctx.Done(), "mock.yaml", false)
 	log := logrus.New()
 
 	log.SetOutput(os.Stdout)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -24,7 +24,7 @@ func TestNewController(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clientMock := k8s.NewClientMock(ctx.Done(), "mock.yaml", false)
+	clientMock := k8s.NewClientMock(t, ctx.Done(), "mock.yaml", false)
 	log := logrus.New()
 
 	log.SetOutput(os.Stdout)
@@ -52,7 +52,7 @@ func TestNewControllerWithSMI(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clientMock := k8s.NewClientMock(ctx.Done(), "mock.yaml", true)
+	clientMock := k8s.NewClientMock(t, ctx.Done(), "mock.yaml", true)
 	log := logrus.New()
 
 	log.SetOutput(os.Stdout)

--- a/pkg/k8s/client_mock.go
+++ b/pkg/k8s/client_mock.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"testing"
 
 	"github.com/containous/traefik/v2/pkg/provider/kubernetes/crd/traefik/v1alpha1"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha1"
@@ -60,6 +61,8 @@ func init() {
 
 // ClientMock holds mock client.
 type ClientMock struct {
+	testingT *testing.T
+
 	kubeClient   *fakekubeclient.Clientset
 	accessClient *fakeaccessclient.Clientset
 	specsClient  *fakespecsclient.Clientset
@@ -81,14 +84,14 @@ type ClientMock struct {
 }
 
 // NewClientMock create a new client mock.
-func NewClientMock(stopCh <-chan struct{}, path string, smi bool) *ClientMock {
+func NewClientMock(testingT *testing.T, stopCh <-chan struct{}, path string, smi bool) *ClientMock {
 	yamlContent, err := ioutil.ReadFile(filepath.FromSlash("./testdata/" + path))
 	if err != nil {
 		panic(err)
 	}
 
 	k8sObjects := MustParseYaml(yamlContent)
-	c := &ClientMock{}
+	c := &ClientMock{testingT: testingT}
 
 	c.kubeClient = fakekubeclient.NewSimpleClientset(filterObjectsByKind(k8sObjects, CoreObjectKinds)...)
 
@@ -114,7 +117,7 @@ func NewClientMock(stopCh <-chan struct{}, path string, smi bool) *ClientMock {
 
 	for t, ok := range c.informerFactory.WaitForCacheSync(stopCh) {
 		if !ok {
-			fmt.Printf("timed out waiting for controller caches to sync: %s", t.String())
+			c.testingT.Logf("timed out waiting for controller caches to sync: %s", t.String())
 		}
 	}
 
@@ -149,19 +152,19 @@ func NewClientMock(stopCh <-chan struct{}, path string, smi bool) *ClientMock {
 
 		for t, ok := range c.accessInformerFactory.WaitForCacheSync(stopCh) {
 			if !ok {
-				fmt.Printf("timed out waiting for controller caches to sync: %s", t.String())
+				c.testingT.Logf("timed out waiting for controller caches to sync: %s", t.String())
 			}
 		}
 
 		for t, ok := range c.specsInformerFactory.WaitForCacheSync(stopCh) {
 			if !ok {
-				fmt.Printf("timed out waiting for controller caches to sync: %s", t.String())
+				c.testingT.Logf("timed out waiting for controller caches to sync: %s", t.String())
 			}
 		}
 
 		for t, ok := range c.splitInformerFactory.WaitForCacheSync(stopCh) {
 			if !ok {
-				fmt.Printf("timed out waiting for controller caches to sync: %s", t.String())
+				c.testingT.Logf("timed out waiting for controller caches to sync: %s", t.String())
 			}
 		}
 	}

--- a/pkg/k8s/client_mock.go
+++ b/pkg/k8s/client_mock.go
@@ -117,7 +117,7 @@ func NewClientMock(testingT *testing.T, stopCh <-chan struct{}, path string, smi
 
 	for t, ok := range c.informerFactory.WaitForCacheSync(stopCh) {
 		if !ok {
-			c.testingT.Logf("timed out waiting for controller caches to sync: %s", t.String())
+			c.testingT.Logf("timed out waiting for controller caches to sync: %s", t)
 		}
 	}
 
@@ -152,19 +152,19 @@ func NewClientMock(testingT *testing.T, stopCh <-chan struct{}, path string, smi
 
 		for t, ok := range c.accessInformerFactory.WaitForCacheSync(stopCh) {
 			if !ok {
-				c.testingT.Logf("timed out waiting for controller caches to sync: %s", t.String())
+				c.testingT.Logf("timed out waiting for controller caches to sync: %s", t)
 			}
 		}
 
 		for t, ok := range c.specsInformerFactory.WaitForCacheSync(stopCh) {
 			if !ok {
-				c.testingT.Logf("timed out waiting for controller caches to sync: %s", t.String())
+				c.testingT.Logf("timed out waiting for controller caches to sync: %s", t)
 			}
 		}
 
 		for t, ok := range c.splitInformerFactory.WaitForCacheSync(stopCh) {
 			if !ok {
-				c.testingT.Logf("timed out waiting for controller caches to sync: %s", t.String())
+				c.testingT.Logf("timed out waiting for controller caches to sync: %s", t)
 			}
 		}
 	}

--- a/pkg/prepare/prepare_test.go
+++ b/pkg/prepare/prepare_test.go
@@ -60,7 +60,7 @@ func TestCheckDNSProvider(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			clt := k8s.NewClientMock(ctx.Done(), test.mockFile, false)
+			clt := k8s.NewClientMock(t, ctx.Done(), test.mockFile, false)
 
 			prep := prepare.NewPrepare(logrus.New(), clt)
 			provider, err := prep.CheckDNSProvider()
@@ -122,7 +122,7 @@ func TestConfigureCoreDNS(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			clt := k8s.NewClientMock(ctx.Done(), test.mockFile, false)
+			clt := k8s.NewClientMock(t, ctx.Done(), test.mockFile, false)
 
 			prep := prepare.NewPrepare(logrus.New(), clt)
 			err := prep.ConfigureCoreDNS("titi", "toto")
@@ -179,7 +179,7 @@ func TestConfigureKubeDNS(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			clt := k8s.NewClientMock(ctx.Done(), test.mockFile, false)
+			clt := k8s.NewClientMock(t, ctx.Done(), test.mockFile, false)
 
 			prep := prepare.NewPrepare(logrus.New(), clt)
 			err := prep.ConfigureKubeDNS()


### PR DESCRIPTION
## What does this PR do?

This PR:

- Adds `t *testing.T` to clientmock for logging

Fixes #578

<!-- A brief description of the change being made with this pull request. -->
