### PR TITLE
Fix incomplete topology when destination port is not found

### DIFF
--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -126,6 +126,7 @@ func (b *Builder) evaluateTrafficTarget(res *resources, topology *Topology, tt *
 
 			continue
 		}
+
 		stt.Specs = specs
 
 		// Find out which are the destination pods.
@@ -146,6 +147,7 @@ func (b *Builder) evaluateTrafficTarget(res *resources, topology *Topology, tt *
 
 			continue
 		}
+
 		stt.Destination.Ports = destPorts
 
 		svc.TrafficTargets = append(svc.TrafficTargets, svcTTKey)

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -90,31 +90,43 @@ func (b *Builder) evaluateTrafficTarget(res *resources, topology *Topology, tt *
 
 	sources := b.buildTrafficTargetSources(res, topology, tt)
 
-	specs, err := b.buildTrafficTargetSpecs(res, tt)
-	if err != nil {
-		err = fmt.Errorf("unable to build spec: %v", err)
-		setTrafficTargetWithErr(topology, tt, sources, err)
-		b.Logger.Errorf("Error building topology for TrafficTarget %q: %v", Key{tt.Name, tt.Namespace}, err)
-
-		return
-	}
-
 	for svcKey, pods := range res.PodsBySvcBySa[destSaKey] {
+		stt := &ServiceTrafficTarget{
+			Name:      tt.Name,
+			Namespace: tt.Namespace,
+			Service:   svcKey,
+			Sources:   sources,
+			Destination: ServiceTrafficTargetDestination{
+				ServiceAccount: tt.Destination.Name,
+				Namespace:      tt.Destination.Namespace,
+			},
+		}
+
 		svcTTKey := ServiceTrafficTargetKey{
 			Service:       svcKey,
 			TrafficTarget: Key{tt.Name, tt.Namespace},
 		}
+		topology.ServiceTrafficTargets[svcTTKey] = stt
 
 		svc, ok := topology.Services[svcKey]
 		if !ok {
-			err = fmt.Errorf("unable to find Service %q", svcKey)
-			setTrafficTargetWithErr(topology, tt, sources, err)
+			err := fmt.Errorf("unable to find Service %q", svcKey)
+			stt.AddError(err)
 			b.Logger.Errorf("Error building topology for TrafficTarget %q: %v", Key{tt.Name, tt.Namespace}, err)
 
 			continue
 		}
 
-		var destPods []Key
+		// Build the TrafficTarget Specs.
+		specs, err := b.buildTrafficTargetSpecs(res, tt)
+		if err != nil {
+			err = fmt.Errorf("unable to build spec: %v", err)
+			stt.AddError(err)
+			b.Logger.Errorf("Error building topology for TrafficTarget %q: %v", Key{tt.Name, tt.Namespace}, err)
+
+			continue
+		}
+		stt.Specs = specs
 
 		// Find out which are the destination pods.
 		for _, pod := range pods {
@@ -122,33 +134,19 @@ func (b *Builder) evaluateTrafficTarget(res *resources, topology *Topology, tt *
 				continue
 			}
 
-			destPods = append(destPods, getOrCreatePod(topology, pod))
+			stt.Destination.Pods = append(stt.Destination.Pods, getOrCreatePod(topology, pod))
 		}
 
 		// Find out which ports can be used on the destination service.
 		destPorts, err := b.getTrafficTargetDestinationPorts(svc, tt)
 		if err != nil {
 			err = fmt.Errorf("unable to find destination ports on Service %q: %w", svcKey, err)
-			setTrafficTargetWithErr(topology, tt, sources, err)
+			stt.AddError(err)
 			b.Logger.Errorf("Error building topology for TrafficTarget %q: %v", Key{tt.Name, tt.Namespace}, err)
 
 			continue
 		}
-
-		// Create the ServiceTrafficTarget for the given service.
-		topology.ServiceTrafficTargets[svcTTKey] = &ServiceTrafficTarget{
-			Service:   svcKey,
-			Name:      tt.Name,
-			Namespace: tt.Namespace,
-			Sources:   sources,
-			Destination: ServiceTrafficTargetDestination{
-				ServiceAccount: tt.Destination.Name,
-				Namespace:      tt.Destination.Namespace,
-				Ports:          destPorts,
-				Pods:           destPods,
-			},
-			Specs: specs,
-		}
+		stt.Destination.Ports = destPorts
 
 		svc.TrafficTargets = append(svc.TrafficTargets, svcTTKey)
 
@@ -179,46 +177,35 @@ func addSourceAndDestinationToPods(topology *Topology, sources []ServiceTrafficT
 	}
 }
 
-func setTrafficTargetWithErr(topology *Topology, tt *access.TrafficTarget, sources []ServiceTrafficTargetSource, err error) {
-	stt := &ServiceTrafficTarget{
-		Name:      tt.Name,
-		Namespace: tt.Namespace,
-		Sources:   sources,
-		Destination: ServiceTrafficTargetDestination{
-			ServiceAccount: tt.Destination.Name,
-			Namespace:      tt.Destination.Namespace,
-		},
-	}
-	stt.AddError(err)
-
-	svcTTKey := ServiceTrafficTargetKey{TrafficTarget: Key{tt.Name, tt.Namespace}}
-	topology.ServiceTrafficTargets[svcTTKey] = stt
-}
-
 // evaluateTrafficSplit evaluates the given traffic-split. If the traffic-split targets a known Service, a new TrafficSplit
 // will be added to it. The TrafficSplit will be added only if all its backends expose the ports required by the Service.
 func (b *Builder) evaluateTrafficSplit(topology *Topology, trafficSplit *split.TrafficSplit) {
 	svcKey := Key{trafficSplit.Spec.Service, trafficSplit.Namespace}
+	ts := &TrafficSplit{
+		Name:      trafficSplit.Name,
+		Namespace: trafficSplit.Namespace,
+		Service:   svcKey,
+	}
+
 	tsKey := Key{trafficSplit.Name, trafficSplit.Namespace}
+	topology.TrafficSplits[tsKey] = ts
 
 	svc, ok := topology.Services[svcKey]
 	if !ok {
 		err := fmt.Errorf("unable to find root Service %q", svcKey)
-		setTrafficSplitWithErr(topology, trafficSplit, svcKey, err)
+		ts.AddError(err)
 		b.Logger.Errorf("Error building topology for TrafficSplit %q: %v", tsKey, err)
 
 		return
 	}
 
-	backends := make([]TrafficSplitBackend, len(trafficSplit.Spec.Backends))
-
-	for i, backend := range trafficSplit.Spec.Backends {
+	for _, backend := range trafficSplit.Spec.Backends {
 		backendSvcKey := Key{backend.Service, trafficSplit.Namespace}
 
 		backendSvc, ok := topology.Services[backendSvcKey]
 		if !ok {
 			err := fmt.Errorf("unable to find backend Service %q", backendSvcKey)
-			setTrafficSplitWithErr(topology, trafficSplit, svcKey, err)
+			ts.AddError(err)
 			b.Logger.Errorf("Error building topology for TrafficSplit %q: %v", tsKey, err)
 
 			continue
@@ -227,25 +214,18 @@ func (b *Builder) evaluateTrafficSplit(topology *Topology, trafficSplit *split.T
 		// As required by the SMI specification, backends must expose at least the same ports as the Service on
 		// which the TrafficSplit is.
 		if err := b.validateServiceAndBackendPorts(svc.Ports, backendSvc.Ports); err != nil {
-			setTrafficSplitWithErr(topology, trafficSplit, svcKey, err)
-			b.Logger.Errorf("Error building topology for TrafficSplit %q: %v", tsKey, err)
+			ts.AddError(err)
+			b.Logger.Errorf("Error building topology for TrafficSplit %q: backend %q and service %q ports mismatch: %v", tsKey, backendSvcKey, svcKey, err)
 
 			continue
 		}
 
-		backends[i] = TrafficSplitBackend{
+		ts.Backends = append(ts.Backends, TrafficSplitBackend{
 			Weight:  backend.Weight,
 			Service: backendSvcKey,
-		}
+		})
 
 		backendSvc.BackendOf = append(backendSvc.BackendOf, tsKey)
-	}
-
-	topology.TrafficSplits[tsKey] = &TrafficSplit{
-		Name:      trafficSplit.Name,
-		Namespace: trafficSplit.Namespace,
-		Service:   svcKey,
-		Backends:  backends,
 	}
 
 	svc.TrafficSplits = append(svc.TrafficSplits, tsKey)
@@ -268,18 +248,6 @@ func (b *Builder) validateServiceAndBackendPorts(svcPorts []corev1.ServicePort, 
 	}
 
 	return nil
-}
-
-func setTrafficSplitWithErr(topology *Topology, trafficSplit *split.TrafficSplit, svcKey Key, err error) {
-	ts := &TrafficSplit{
-		Name:      trafficSplit.Name,
-		Namespace: trafficSplit.Namespace,
-		Service:   svcKey,
-	}
-	ts.AddError(err)
-
-	tsKey := Key{trafficSplit.Name, trafficSplit.Namespace}
-	topology.TrafficSplits[tsKey] = ts
 }
 
 // populateTrafficSplitsAuthorizedIncomingTraffic computes the list of pods allowed to access a traffic-split. As

--- a/pkg/topology/testdata/topology-traffic-target-service-port-mismatch.json
+++ b/pkg/topology/testdata/topology-traffic-target-service-port-mismatch.json
@@ -1,0 +1,130 @@
+{
+  "services": {
+    "svc-b1@my-ns": {
+      "name": "svc-b1",
+      "namespace": "my-ns",
+      "selector": {
+        "app": "app-b1"
+      },
+      "annotations": {},
+      "ports": [
+        {
+          "name": "port-8080",
+          "protocol": "TCP",
+          "port": 8080,
+          "targetPort": 8080
+        }
+      ],
+      "clusterIp": "10.10.1.16",
+      "pods": [
+        "app-b1@my-ns"
+      ]
+    },
+    "svc-b2@my-ns": {
+      "name": "svc-b2",
+      "namespace": "my-ns",
+      "selector": {
+        "app": "app-b2"
+      },
+      "annotations": {},
+      "ports": [
+        {
+          "name": "port-80",
+          "protocol": "TCP",
+          "port": 80,
+          "targetPort": 80
+        }
+      ],
+      "clusterIp": "10.10.1.17",
+      "pods": [
+        "app-b2@my-ns"
+      ],
+      "trafficTargets": [
+        "svc-b2@my-ns:tt@my-ns"
+      ]
+    }
+  },
+  "pods": {
+    "app-a@my-ns": {
+      "name": "app-a",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-a",
+      "ip": "10.10.1.1",
+      "sourceOf": [
+        "svc-b2@my-ns:tt@my-ns"
+      ]
+    },
+    "app-b1@my-ns": {
+      "name": "app-b1",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-b",
+      "ip": "10.10.1.2"
+    },
+    "app-b2@my-ns": {
+      "name": "app-b2",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-b",
+      "ip": "10.10.1.3",
+      "destinationOf": [
+        "svc-b2@my-ns:tt@my-ns"
+      ]
+    }
+  },
+  "serviceTrafficTargets": {
+    "svc-b1@my-ns:tt@my-ns": {
+      "service": "svc-b1@my-ns",
+      "name": "tt",
+      "namespace": "my-ns",
+      "sources": [
+        {
+          "serviceAccount": "service-account-a",
+          "namespace": "my-ns",
+          "pods": [
+            "app-a@my-ns"
+          ]
+        }
+      ],
+      "destination": {
+        "serviceAccount": "service-account-b",
+        "namespace": "my-ns",
+        "ports": [],
+        "pods": [
+          "app-b1@my-ns"
+        ]
+      },
+      "errors": [
+        "unable to find destination ports on Service \"svc-b1@my-ns\": destination port 80 of TrafficTarget \"tt@my-ns\" is not exposed by the service"
+      ]
+    },
+    "svc-b2@my-ns:tt@my-ns": {
+      "service": "svc-b2@my-ns",
+      "name": "tt",
+      "namespace": "my-ns",
+      "sources": [
+        {
+          "serviceAccount": "service-account-a",
+          "namespace": "my-ns",
+          "pods": [
+            "app-a@my-ns"
+          ]
+        }
+      ],
+      "destination": {
+        "serviceAccount": "service-account-b",
+        "namespace": "my-ns",
+        "ports": [
+          {
+            "name": "port-80",
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 80
+          }
+        ],
+        "pods": [
+          "app-b2@my-ns"
+        ]
+      }
+    }
+  },
+  "trafficSplits": {}
+}

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -95,6 +95,19 @@ func (k *ServiceTrafficTargetKey) UnmarshalText(data []byte) error {
 	return nil
 }
 
+// UnmarshalJSON implements the `json.Unmarshaler` interface.
+// This is a temporary workaround for the bug described in this
+// issue: https://github.com/golang/go/issues/38771.
+func (k *ServiceTrafficTargetKey) UnmarshalJSON(data []byte) error {
+	if len(data) < 2 {
+		return nil
+	}
+
+	data = data[1 : len(data)-1]
+
+	return k.UnmarshalText(data)
+}
+
 // Topology holds the graph. Each Pods and services are nodes of the graph.
 type Topology struct {
 	Services              map[Key]*Service                                  `json:"services"`


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug that happen when a TrafficTarget is applied on more than one Service and one of them is causing an error: If the `TrafficTarget.destination.port` is not present on the targeted service an error gets logged and it won't process next services.

Fixes #581 

In order to fix this behavior, instead of exiting the function on the first error, we just skip the Service.

## How to test it:

- Deploy 2 Service:
  - One which expose port 80
  - One which expose port 8080
- Define a TrafficTarget with a destination port = 80
- Update the TrafficTarget to trigger update (such as modifying the spec of a HTTPRouteGroup)

You should see one router for the traffic target in the dynamic config.