### PR TITLE
Build kubernetes clients separately

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -275,12 +275,12 @@ func (s *BaseSuite) deleteShadowServices(c *check.C) {
 	opts := metav1.ListOptions{
 		LabelSelector: "app=maesh",
 	}
-	svcs, err := s.client.GetKubernetesClient().CoreV1().Services(maeshNamespace).List(opts)
+	svcs, err := s.client.KubernetesClient().CoreV1().Services(maeshNamespace).List(opts)
 	c.Assert(err, checker.IsNil)
 
 	for _, svc := range svcs.Items {
 		c.Logf("Deleting shadow service %s.", svc.Name)
-		err = s.client.GetKubernetesClient().CoreV1().Services(maeshNamespace).Delete(svc.Name, &metav1.DeleteOptions{})
+		err = s.client.KubernetesClient().CoreV1().Services(maeshNamespace).Delete(svc.Name, &metav1.DeleteOptions{})
 		c.Assert(err, checker.IsNil)
 	}
 }
@@ -371,7 +371,7 @@ func (s *BaseSuite) setCoreDNSVersion(c *check.C, version string) {
 
 	err := backoff.Retry(safe.OperationWithRecover(func() error {
 		// Get current coreDNS deployment.
-		deployment, err := s.client.GetKubernetesClient().AppsV1().Deployments(metav1.NamespaceSystem).Get("coredns", metav1.GetOptions{})
+		deployment, err := s.client.KubernetesClient().AppsV1().Deployments(metav1.NamespaceSystem).Get("coredns", metav1.GetOptions{})
 		c.Assert(err, checker.IsNil)
 
 		newDeployment := deployment.DeepCopy()
@@ -396,7 +396,7 @@ func (s *BaseSuite) installTinyToolsMaesh(c *check.C) {
 }
 
 func (s *BaseSuite) getToolsPodMaesh(c *check.C) *corev1.Pod {
-	podList, err := s.client.GetKubernetesClient().CoreV1().Pods(testNamespace).List(metav1.ListOptions{
+	podList, err := s.client.KubernetesClient().CoreV1().Pods(testNamespace).List(metav1.ListOptions{
 		LabelSelector: "app=tiny-tools",
 	})
 	c.Assert(err, checker.IsNil)
@@ -527,28 +527,28 @@ func (s *BaseSuite) digHost(c *check.C, source, namespace, destination string) {
 }
 
 func (s *BaseSuite) getPod(c *check.C, name string) *corev1.Pod {
-	pod, err := s.client.GetKubernetesClient().CoreV1().Pods(testNamespace).Get(name, metav1.GetOptions{})
+	pod, err := s.client.KubernetesClient().CoreV1().Pods(testNamespace).Get(name, metav1.GetOptions{})
 	c.Assert(err, checker.IsNil)
 
 	return pod
 }
 
 func (s *BaseSuite) getService(c *check.C, name string) *corev1.Service {
-	svc, err := s.client.GetKubernetesClient().CoreV1().Services(testNamespace).Get(name, metav1.GetOptions{})
+	svc, err := s.client.KubernetesClient().CoreV1().Services(testNamespace).Get(name, metav1.GetOptions{})
 	c.Assert(err, checker.IsNil)
 
 	return svc
 }
 
 func (s *BaseSuite) getTrafficTarget(c *check.C, name string) *access.TrafficTarget {
-	tt, err := s.client.GetAccessClient().AccessV1alpha1().TrafficTargets(testNamespace).Get(name, metav1.GetOptions{})
+	tt, err := s.client.AccessClient().AccessV1alpha1().TrafficTargets(testNamespace).Get(name, metav1.GetOptions{})
 	c.Assert(err, checker.IsNil)
 
 	return tt
 }
 
 func (s *BaseSuite) getTrafficSplit(c *check.C, name string) *split.TrafficSplit {
-	ts, err := s.client.GetSplitClient().SplitV1alpha2().TrafficSplits(testNamespace).Get(name, metav1.GetOptions{})
+	ts, err := s.client.SplitClient().SplitV1alpha2().TrafficSplits(testNamespace).Get(name, metav1.GetOptions{})
 	c.Assert(err, checker.IsNil)
 
 	return ts

--- a/integration/try/try.go
+++ b/integration/try/try.go
@@ -51,7 +51,7 @@ func (t *Try) WaitReadyDeployment(name string, namespace string, timeout time.Du
 	ebo.MaxElapsedTime = applyCIMultiplier(timeout)
 
 	if err := backoff.Retry(safe.OperationWithRecover(func() error {
-		d, err := t.client.GetKubernetesClient().AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
+		d, err := t.client.KubernetesClient().AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			if kubeerror.IsNotFound(err) {
 				return fmt.Errorf("deployment %q has not been yet created", name)
@@ -80,7 +80,7 @@ func (t *Try) WaitReadyDaemonset(name string, namespace string, timeout time.Dur
 	ebo.MaxElapsedTime = applyCIMultiplier(timeout)
 
 	if err := backoff.Retry(safe.OperationWithRecover(func() error {
-		d, err := t.client.GetKubernetesClient().AppsV1().DaemonSets(namespace).Get(name, metav1.GetOptions{})
+		d, err := t.client.KubernetesClient().AppsV1().DaemonSets(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			if kubeerror.IsNotFound(err) {
 				return fmt.Errorf("daemonset %q has not been yet created", name)
@@ -102,7 +102,7 @@ func (t *Try) WaitReadyDaemonset(name string, namespace string, timeout time.Dur
 // WaitUpdateDeployment waits until the deployment is successfully updated and ready.
 func (t *Try) WaitUpdateDeployment(deployment *appsv1.Deployment, timeout time.Duration) error {
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		_, err := t.client.GetKubernetesClient().AppsV1().Deployments(deployment.Namespace).Update(deployment)
+		_, err := t.client.KubernetesClient().AppsV1().Deployments(deployment.Namespace).Update(deployment)
 		return err
 	})
 
@@ -119,7 +119,7 @@ func (t *Try) WaitDeleteDeployment(name string, namespace string, timeout time.D
 	ebo.MaxElapsedTime = applyCIMultiplier(timeout)
 
 	if err := backoff.Retry(safe.OperationWithRecover(func() error {
-		_, err := t.client.GetKubernetesClient().AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
+		_, err := t.client.KubernetesClient().AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			if kubeerror.IsNotFound(err) {
 				return nil
@@ -142,7 +142,7 @@ func (t *Try) WaitPodIPAssigned(name string, namespace string, timeout time.Dura
 	ebo.MaxElapsedTime = applyCIMultiplier(timeout)
 
 	if err := backoff.Retry(safe.OperationWithRecover(func() error {
-		pod, err := t.client.GetKubernetesClient().CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+		pod, err := t.client.KubernetesClient().CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("unable get the pod %q in namespace %q: %v", name, namespace, err)
 		}
@@ -232,7 +232,7 @@ func (t *Try) WaitDeleteNamespace(name string, timeout time.Duration) error {
 	ebo.MaxElapsedTime = applyCIMultiplier(timeout)
 
 	if err := backoff.Retry(safe.OperationWithRecover(func() error {
-		_, err := t.client.GetKubernetesClient().CoreV1().Namespaces().Get(name, metav1.GetOptions{})
+		_, err := t.client.KubernetesClient().CoreV1().Namespaces().Get(name, metav1.GetOptions{})
 		if err != nil {
 			if kubeerror.IsNotFound(err) {
 				return nil
@@ -270,7 +270,7 @@ func (t *Try) WaitClientCreated(url string, kubeConfigPath string, timeout time.
 			return fmt.Errorf("unable to create clients: %v", err)
 		}
 
-		if _, err = clients.GetKubernetesClient().Discovery().ServerVersion(); err != nil {
+		if _, err = clients.KubernetesClient().Discovery().ServerVersion(); err != nil {
 			return fmt.Errorf("unable to get server version: %v", err)
 		}
 

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -24,7 +24,7 @@ func NewCleanup(log logrus.FieldLogger, client k8s.Client, namespace string) *Cl
 
 // CleanShadowServices deletes all shadow services from the cluster.
 func (c *Cleanup) CleanShadowServices() error {
-	serviceList, err := c.client.GetKubernetesClient().CoreV1().Services(c.namespace).List(metav1.ListOptions{
+	serviceList, err := c.client.KubernetesClient().CoreV1().Services(c.namespace).List(metav1.ListOptions{
 		LabelSelector: "app=maesh,type=shadow",
 	})
 	if err != nil {
@@ -32,7 +32,7 @@ func (c *Cleanup) CleanShadowServices() error {
 	}
 
 	for _, s := range serviceList.Items {
-		if err := c.client.GetKubernetesClient().CoreV1().Services(s.Namespace).Delete(s.Name, &metav1.DeleteOptions{}); err != nil {
+		if err := c.client.KubernetesClient().CoreV1().Services(s.Namespace).Delete(s.Name, &metav1.DeleteOptions{}); err != nil {
 			return err
 		}
 	}

--- a/pkg/cleanup/cleanup_test.go
+++ b/pkg/cleanup/cleanup_test.go
@@ -41,13 +41,13 @@ func TestCleanup_CleanShadowServices(t *testing.T) {
 	err := cln.CleanShadowServices()
 	assert.NoError(t, err)
 
-	sl, err := clientMock.GetKubernetesClient().CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{
+	sl, err := clientMock.KubernetesClient().CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{
 		LabelSelector: "app=maesh,type=shadow",
 	})
 	assert.NoError(t, err)
 	assert.Len(t, sl.Items, 0)
 
-	srv, err := clientMock.GetKubernetesClient().CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{})
+	srv, err := clientMock.KubernetesClient().CoreV1().Services(metav1.NamespaceAll).List(metav1.ListOptions{})
 	assert.NoError(t, err)
 	assert.Len(t, srv.Items, 2)
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -2,19 +2,20 @@ package k8s
 
 import (
 	"fmt"
+	"os"
 
 	accessclient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/clientset/versioned"
 	specsclient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/specs/clientset/versioned"
 	splitclient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/clientset/versioned"
 	"github.com/sirupsen/logrus"
-	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Client is an interface for the various resource controllers.
 type Client interface {
-	GetKubernetesClient() kubeclient.Interface
+	GetKubernetesClient() kubernetes.Interface
 	GetAccessClient() accessclient.Interface
 	GetSpecsClient() specsclient.Interface
 	GetSplitClient() splitclient.Interface
@@ -25,7 +26,7 @@ var _ Client = (*ClientWrapper)(nil)
 
 // ClientWrapper holds the clients for the various resource controllers.
 type ClientWrapper struct {
-	kubeClient   *kubeclient.Clientset
+	kubeClient   *kubernetes.Clientset
 	accessClient *accessclient.Clientset
 	specsClient  *specsclient.Clientset
 	splitClient  *splitclient.Clientset
@@ -33,7 +34,7 @@ type ClientWrapper struct {
 
 // NewClient creates and returns a ClientWrapper that satisfies the Client interface.
 func NewClient(log logrus.FieldLogger, url string, kubeConfig string) (Client, error) {
-	config, err := clientcmd.BuildConfigFromFlags(url, kubeConfig)
+	config, err := buildConfig(log, url, kubeConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +67,24 @@ func NewClient(log logrus.FieldLogger, url string, kubeConfig string) (Client, e
 	}, nil
 }
 
+// buildConfig takes the url and kubeconfig, and returns an external or internal config.
+func buildConfig(log logrus.FieldLogger, url string, kubeConfig string) (*rest.Config, error) {
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" && os.Getenv("KUBERNETES_SERVICE_PORT") != "" {
+		// If these env vars are set, we can build an in-cluster config.
+		log.Infoln("Creating in-cluster client")
+		return rest.InClusterConfig()
+	}
+
+	if url != "" && kubeConfig != "" {
+		log.Infoln("Creating cluster-external client from masterURL and kubeconfig")
+		return clientcmd.BuildConfigFromFlags(url, kubeConfig)
+	}
+
+	return nil, fmt.Errorf("Could not create client: Missing masterURL or kubeConfig")
+}
+
 // GetKubernetesClient is used to get the kubernetes clientset.
-func (w *ClientWrapper) GetKubernetesClient() kubeclient.Interface {
+func (w *ClientWrapper) GetKubernetesClient() kubernetes.Interface {
 	return w.kubeClient
 }
 
@@ -87,10 +104,10 @@ func (w *ClientWrapper) GetSplitClient() splitclient.Interface {
 }
 
 // buildClient returns a useable kubernetes client.
-func buildKubernetesClient(log logrus.FieldLogger, config *rest.Config) (*kubeclient.Clientset, error) {
+func buildKubernetesClient(log logrus.FieldLogger, config *rest.Config) (*kubernetes.Clientset, error) {
 	log.Debugln("Building Kubernetes Client...")
 
-	client, err := kubeclient.NewForConfig(config)
+	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create kubernetes client: %v", err)
 	}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -75,8 +75,8 @@ func buildConfig(log logrus.FieldLogger, masterURL, kubeConfig string) (*rest.Co
 		return rest.InClusterConfig()
 	}
 
-	if masterURL != "" && kubeConfig != "" {
-		log.Infoln("Creating cluster-external client from masterURL and kubeconfig")
+	if masterURL != "" || kubeConfig != "" {
+		log.Infoln("Creating cluster-external client from provided masterURL or kubeconfig")
 		return clientcmd.BuildConfigFromFlags(masterURL, kubeConfig)
 	}
 

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -80,7 +80,7 @@ func buildConfig(log logrus.FieldLogger, url string, kubeConfig string) (*rest.C
 		return clientcmd.BuildConfigFromFlags(url, kubeConfig)
 	}
 
-	return nil, fmt.Errorf("Could not create client: Missing masterURL or kubeConfig")
+	return nil, fmt.Errorf("could not create client: Missing masterURL or kubeConfig")
 }
 
 // GetKubernetesClient is used to get the kubernetes clientset.

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -15,10 +15,10 @@ import (
 
 // Client is an interface for the various resource controllers.
 type Client interface {
-	GetKubernetesClient() kubernetes.Interface
-	GetAccessClient() accessclient.Interface
-	GetSpecsClient() specsclient.Interface
-	GetSplitClient() splitclient.Interface
+	KubernetesClient() kubernetes.Interface
+	AccessClient() accessclient.Interface
+	SpecsClient() specsclient.Interface
+	SplitClient() splitclient.Interface
 }
 
 // Ensure the client wrapper fits the Client interface.
@@ -33,8 +33,8 @@ type ClientWrapper struct {
 }
 
 // NewClient creates and returns a ClientWrapper that satisfies the Client interface.
-func NewClient(log logrus.FieldLogger, url string, kubeConfig string) (Client, error) {
-	config, err := buildConfig(log, url, kubeConfig)
+func NewClient(log logrus.FieldLogger, masterURL, kubeConfig string) (Client, error) {
+	config, err := buildConfig(log, masterURL, kubeConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -67,39 +67,39 @@ func NewClient(log logrus.FieldLogger, url string, kubeConfig string) (Client, e
 	}, nil
 }
 
-// buildConfig takes the url and kubeconfig, and returns an external or internal config.
-func buildConfig(log logrus.FieldLogger, url string, kubeConfig string) (*rest.Config, error) {
+// buildConfig takes the master URL and kubeconfig, and returns an external or internal config.
+func buildConfig(log logrus.FieldLogger, masterURL, kubeConfig string) (*rest.Config, error) {
 	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" && os.Getenv("KUBERNETES_SERVICE_PORT") != "" {
 		// If these env vars are set, we can build an in-cluster config.
 		log.Infoln("Creating in-cluster client")
 		return rest.InClusterConfig()
 	}
 
-	if url != "" && kubeConfig != "" {
+	if masterURL != "" && kubeConfig != "" {
 		log.Infoln("Creating cluster-external client from masterURL and kubeconfig")
-		return clientcmd.BuildConfigFromFlags(url, kubeConfig)
+		return clientcmd.BuildConfigFromFlags(masterURL, kubeConfig)
 	}
 
-	return nil, fmt.Errorf("could not create client: Missing masterURL or kubeConfig")
+	return nil, fmt.Errorf("could not create client: missing masterURL or kubeConfig")
 }
 
-// GetKubernetesClient is used to get the kubernetes clientset.
-func (w *ClientWrapper) GetKubernetesClient() kubernetes.Interface {
+// KubernetesClient is used to get the kubernetes clientset.
+func (w *ClientWrapper) KubernetesClient() kubernetes.Interface {
 	return w.kubeClient
 }
 
-// GetAccessClient is used to get the SMI Access clientset.
-func (w *ClientWrapper) GetAccessClient() accessclient.Interface {
+// AccessClient is used to get the SMI Access clientset.
+func (w *ClientWrapper) AccessClient() accessclient.Interface {
 	return w.accessClient
 }
 
-// GetSpecsClient is used to get the SMI Specs clientset.
-func (w *ClientWrapper) GetSpecsClient() specsclient.Interface {
+// SpecsClient is used to get the SMI Specs clientset.
+func (w *ClientWrapper) SpecsClient() specsclient.Interface {
 	return w.specsClient
 }
 
-// GetSplitClient is used to get the SMI Split clientset.
-func (w *ClientWrapper) GetSplitClient() splitclient.Interface {
+// SplitClient is used to get the SMI Split clientset.
+func (w *ClientWrapper) SplitClient() splitclient.Interface {
 	return w.splitClient
 }
 

--- a/pkg/k8s/client_mock.go
+++ b/pkg/k8s/client_mock.go
@@ -183,23 +183,23 @@ func (c *ClientMock) startACLInformers(stopCh <-chan struct{}) {
 	}
 }
 
-// GetKubernetesClient is used to get the kubernetes clientset.
-func (c *ClientMock) GetKubernetesClient() kubeclient.Interface {
+// KubernetesClient is used to get the kubernetes clientset.
+func (c *ClientMock) KubernetesClient() kubeclient.Interface {
 	return c.kubeClient
 }
 
-// GetAccessClient is used to get the SMI Access clientset.
-func (c *ClientMock) GetAccessClient() accessclient.Interface {
+// AccessClient is used to get the SMI Access clientset.
+func (c *ClientMock) AccessClient() accessclient.Interface {
 	return c.accessClient
 }
 
-// GetSpecsClient is used to get the SMI Specs clientset.
-func (c *ClientMock) GetSpecsClient() specsclient.Interface {
+// SpecsClient is used to get the SMI Specs clientset.
+func (c *ClientMock) SpecsClient() specsclient.Interface {
 	return c.specsClient
 }
 
-// GetSplitClient is used to get the SMI Split clientset.
-func (c *ClientMock) GetSplitClient() splitclient.Interface {
+// SplitClient is used to get the SMI Split clientset.
+func (c *ClientMock) SplitClient() splitclient.Interface {
 	return c.splitClient
 }
 

--- a/pkg/prepare/prepare.go
+++ b/pkg/prepare/prepare.go
@@ -84,7 +84,7 @@ func (p *Prepare) CheckDNSProvider() (DNSProvider, error) {
 func (p *Prepare) coreDNSMatch() (bool, error) {
 	p.log.Info("Checking CoreDNS")
 
-	deployment, err := p.client.GetKubernetesClient().AppsV1().Deployments(metav1.NamespaceSystem).Get("coredns", metav1.GetOptions{})
+	deployment, err := p.client.KubernetesClient().AppsV1().Deployments(metav1.NamespaceSystem).Get("coredns", metav1.GetOptions{})
 	if kubeerror.IsNotFound(err) {
 		p.log.Debugf("CoreDNS does not exist in namespace %q", metav1.NamespaceSystem)
 		return false, nil
@@ -127,7 +127,7 @@ func isCoreDNSVersionSupported(versionLine string) bool {
 func (p *Prepare) kubeDNSMatch() (bool, error) {
 	p.log.Info("Checking KubeDNS")
 
-	_, err := p.client.GetKubernetesClient().AppsV1().Deployments(metav1.NamespaceSystem).Get("kube-dns", metav1.GetOptions{})
+	_, err := p.client.KubernetesClient().AppsV1().Deployments(metav1.NamespaceSystem).Get("kube-dns", metav1.GetOptions{})
 	if kubeerror.IsNotFound(err) {
 		p.log.Debugf("KubeDNS does not exist in namespace %q", metav1.NamespaceSystem)
 		return false, nil
@@ -146,7 +146,7 @@ func (p *Prepare) kubeDNSMatch() (bool, error) {
 func (p *Prepare) ConfigureCoreDNS(clusterDomain, maeshNamespace string) error {
 	p.log.Debug("Patching CoreDNS")
 
-	deployment, err := p.client.GetKubernetesClient().AppsV1().Deployments(metav1.NamespaceSystem).Get("coredns", metav1.GetOptions{})
+	deployment, err := p.client.KubernetesClient().AppsV1().Deployments(metav1.NamespaceSystem).Get("coredns", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ maesh:53 {
 
 	coreConfigMap.ObjectMeta.Labels["maesh-patched"] = "true"
 
-	if _, err := p.client.GetKubernetesClient().CoreV1().ConfigMaps(coreNamespace).Update(coreConfigMap); err != nil {
+	if _, err := p.client.KubernetesClient().CoreV1().ConfigMaps(coreNamespace).Update(coreConfigMap); err != nil {
 		return err
 	}
 
@@ -225,7 +225,7 @@ func (p *Prepare) getCorefileConfigMap(coreDeployment *appsv1.Deployment) (*core
 			continue
 		}
 
-		cfgMap, err := p.client.GetKubernetesClient().CoreV1().ConfigMaps(coreDeployment.Namespace).Get(volume.ConfigMap.Name, metav1.GetOptions{})
+		cfgMap, err := p.client.KubernetesClient().CoreV1().ConfigMaps(coreDeployment.Namespace).Get(volume.ConfigMap.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -248,7 +248,7 @@ func (p *Prepare) getCorefileConfigMap(coreDeployment *appsv1.Deployment) (*core
 func (p *Prepare) ConfigureKubeDNS() error {
 	p.log.Debug("Patching KubeDNS")
 
-	deployment, err := p.client.GetKubernetesClient().AppsV1().Deployments(metav1.NamespaceSystem).Get("kube-dns", metav1.GetOptions{})
+	deployment, err := p.client.KubernetesClient().AppsV1().Deployments(metav1.NamespaceSystem).Get("kube-dns", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -261,7 +261,7 @@ func (p *Prepare) ConfigureKubeDNS() error {
 	p.log.Debug("Getting CoreDNS service IP")
 
 	if err = backoff.Retry(safe.OperationWithRecover(func() error {
-		svc, errSvc := p.client.GetKubernetesClient().CoreV1().Services("maesh").Get("coredns", metav1.GetOptions{})
+		svc, errSvc := p.client.KubernetesClient().CoreV1().Services("maesh").Get("coredns", metav1.GetOptions{})
 		if errSvc != nil {
 			return fmt.Errorf("unable get the service %q in namespace %q: %w", "coredns", "maesh", errSvc)
 		}
@@ -305,7 +305,7 @@ func (p *Prepare) getKubeDNSConfigMap(kubeDeployment *appsv1.Deployment) (*corev
 			continue
 		}
 
-		cfgMap, err := p.client.GetKubernetesClient().CoreV1().ConfigMaps(kubeDeployment.Namespace).Get(volume.ConfigMap.Name, metav1.GetOptions{})
+		cfgMap, err := p.client.KubernetesClient().CoreV1().ConfigMaps(kubeDeployment.Namespace).Get(volume.ConfigMap.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -348,7 +348,7 @@ func (p *Prepare) patchKubeDNSConfigMap(kubeConfigMap *corev1.ConfigMap, namespa
 
 	kubeConfigMap.ObjectMeta.Labels["maesh-patched"] = "true"
 
-	if _, err := p.client.GetKubernetesClient().CoreV1().ConfigMaps(namespace).Update(kubeConfigMap); err != nil {
+	if _, err := p.client.KubernetesClient().CoreV1().ConfigMaps(namespace).Update(kubeConfigMap); err != nil {
 		return err
 	}
 
@@ -379,7 +379,7 @@ func (p *Prepare) StartInformers(acl bool) error {
 
 func (p *Prepare) startBaseInformers(ctx context.Context, stopCh <-chan struct{}) error {
 	// Create a new SharedInformerFactory, and register the event handler to informers.
-	kubeFactory := informers.NewSharedInformerFactoryWithOptions(p.client.GetKubernetesClient(), k8s.ResyncPeriod)
+	kubeFactory := informers.NewSharedInformerFactoryWithOptions(p.client.KubernetesClient(), k8s.ResyncPeriod)
 	kubeFactory.Core().V1().Services().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
 	kubeFactory.Core().V1().Endpoints().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
 	kubeFactory.Start(stopCh)
@@ -390,7 +390,7 @@ func (p *Prepare) startBaseInformers(ctx context.Context, stopCh <-chan struct{}
 		}
 	}
 
-	splitFactory := splitinformer.NewSharedInformerFactoryWithOptions(p.client.GetSplitClient(), k8s.ResyncPeriod)
+	splitFactory := splitinformer.NewSharedInformerFactoryWithOptions(p.client.SplitClient(), k8s.ResyncPeriod)
 	splitFactory.Split().V1alpha2().TrafficSplits().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
 	splitFactory.Start(stopCh)
 
@@ -405,7 +405,7 @@ func (p *Prepare) startBaseInformers(ctx context.Context, stopCh <-chan struct{}
 
 func (p *Prepare) startACLInformers(ctx context.Context, stopCh <-chan struct{}) error {
 	// Create new SharedInformerFactories, and register the event handler to informers.
-	accessFactory := accessinformer.NewSharedInformerFactoryWithOptions(p.client.GetAccessClient(), k8s.ResyncPeriod)
+	accessFactory := accessinformer.NewSharedInformerFactoryWithOptions(p.client.AccessClient(), k8s.ResyncPeriod)
 	accessFactory.Access().V1alpha1().TrafficTargets().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
 	accessFactory.Start(stopCh)
 
@@ -415,7 +415,7 @@ func (p *Prepare) startACLInformers(ctx context.Context, stopCh <-chan struct{})
 		}
 	}
 
-	specsFactory := specsinformer.NewSharedInformerFactoryWithOptions(p.client.GetSpecsClient(), k8s.ResyncPeriod)
+	specsFactory := specsinformer.NewSharedInformerFactoryWithOptions(p.client.SpecsClient(), k8s.ResyncPeriod)
 	specsFactory.Specs().V1alpha1().HTTPRouteGroups().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
 	specsFactory.Specs().V1alpha1().TCPRoutes().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
 	specsFactory.Start(stopCh)
@@ -427,7 +427,7 @@ func (p *Prepare) startACLInformers(ctx context.Context, stopCh <-chan struct{})
 	}
 
 	// Create a new SharedInformerFactory, and register the event handler to informers.
-	kubeFactory := informers.NewSharedInformerFactoryWithOptions(p.client.GetKubernetesClient(), k8s.ResyncPeriod)
+	kubeFactory := informers.NewSharedInformerFactoryWithOptions(p.client.KubernetesClient(), k8s.ResyncPeriod)
 	kubeFactory.Core().V1().Pods().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
 	kubeFactory.Start(stopCh)
 
@@ -462,7 +462,7 @@ func (p *Prepare) restartPods(deployment *appsv1.Deployment) error {
 
 	annotations["maesh-hash"] = uuid.New().String()
 	newDeployment.Spec.Template.Annotations = annotations
-	_, err := p.client.GetKubernetesClient().AppsV1().Deployments(newDeployment.Namespace).Update(newDeployment)
+	_, err := p.client.KubernetesClient().AppsV1().Deployments(newDeployment.Namespace).Update(newDeployment)
 
 	return err
 }

--- a/pkg/prepare/prepare_test.go
+++ b/pkg/prepare/prepare_test.go
@@ -133,7 +133,7 @@ func TestConfigureCoreDNS(t *testing.T) {
 
 			assert.NoError(t, err)
 
-			cfgMap, err := clt.GetKubernetesClient().CoreV1().ConfigMaps("kube-system").Get("coredns-cfgmap", metav1.GetOptions{})
+			cfgMap, err := clt.KubernetesClient().CoreV1().ConfigMaps("kube-system").Get("coredns-cfgmap", metav1.GetOptions{})
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expectedCorefile, cfgMap.Data["Corefile"])
@@ -190,7 +190,7 @@ func TestConfigureKubeDNS(t *testing.T) {
 
 			assert.NoError(t, err)
 
-			cfgMap, err := clt.GetKubernetesClient().CoreV1().ConfigMaps("kube-system").Get("kubedns-cfgmap", metav1.GetOptions{})
+			cfgMap, err := clt.KubernetesClient().CoreV1().ConfigMaps("kube-system").Get("kubedns-cfgmap", metav1.GetOptions{})
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expectedStubDomains, cfgMap.Data["stubDomains"])


### PR DESCRIPTION
## What does this PR do?

This PR:

- Adds checks to determine if an in-cluster or external-cluster config needs to be built
- Adds logging for what client is being built

Fixes #580

## Additional Notes

The warning comes from: https://github.com/kubernetes/client-go/blob/v0.17.4/tools/clientcmd/client_config.go#L543

Where an in-cluster config is built if the args are not present. We can do the check beforehand, and return the same client before calling this method, and skip that warning altogether.
