### PR TITLE
Rework controller loop to use a work queue

### DIFF
--- a/cmd/maesh/maesh.go
+++ b/cmd/maesh/maesh.go
@@ -131,9 +131,7 @@ func maeshCommand(iConfig *cmd.MaeshConfiguration) error {
 	}
 
 	// run the ctr loop to process items
-	if err = ctr.Run(stopCh); err != nil {
-		log.Fatalf("Error running ctr: %v", err)
-	}
+	ctr.Run(stopCh)
 
 	return nil
 }

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -1,9 +1,8 @@
-package annotations_test
+package annotations
 
 import (
 	"testing"
 
-	"github.com/containous/maesh/pkg/annotations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,34 +24,34 @@ func TestGetTrafficType(t *testing.T) {
 		{
 			desc:        "returns the default traffic-type if not set",
 			annotations: map[string]string{},
-			want:        annotations.ServiceTypeHTTP,
+			want:        ServiceTypeHTTP,
 		},
 		{
 			desc: "http",
 			annotations: map[string]string{
 				"maesh.containo.us/traffic-type": "http",
 			},
-			want: annotations.ServiceTypeHTTP,
+			want: ServiceTypeHTTP,
 		},
 		{
 			desc: "tcp",
 			annotations: map[string]string{
 				"maesh.containo.us/traffic-type": "tcp",
 			},
-			want: annotations.ServiceTypeTCP,
+			want: ServiceTypeTCP,
 		},
 		{
 			desc: "udp",
 			annotations: map[string]string{
 				"maesh.containo.us/traffic-type": "udp",
 			},
-			want: annotations.ServiceTypeUDP,
+			want: ServiceTypeUDP,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			tt, err := annotations.GetTrafficType(annotations.ServiceTypeHTTP, test.annotations)
+			tt, err := GetTrafficType(ServiceTypeHTTP, test.annotations)
 			if test.err {
 				assert.Error(t, err)
 			} else {
@@ -80,34 +79,34 @@ func TestGetScheme(t *testing.T) {
 		{
 			desc:        "returns the default scheme if not set",
 			annotations: map[string]string{},
-			want:        annotations.SchemeHTTP,
+			want:        SchemeHTTP,
 		},
 		{
 			desc: "http",
 			annotations: map[string]string{
 				"maesh.containo.us/scheme": "http",
 			},
-			want: annotations.SchemeHTTP,
+			want: SchemeHTTP,
 		},
 		{
 			desc: "https",
 			annotations: map[string]string{
 				"maesh.containo.us/scheme": "https",
 			},
-			want: annotations.SchemeHTTPS,
+			want: SchemeHTTPS,
 		},
 		{
 			desc: "h2c",
 			annotations: map[string]string{
 				"maesh.containo.us/scheme": "h2c",
 			},
-			want: annotations.SchemeH2C,
+			want: SchemeH2C,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			tt, err := annotations.GetScheme(test.annotations)
+			tt, err := GetScheme(test.annotations)
 			if test.err {
 				assert.Error(t, err)
 			} else {
@@ -119,7 +118,7 @@ func TestGetScheme(t *testing.T) {
 }
 
 func TestGetRetryAttempts_Valid(t *testing.T) {
-	attempts, err := annotations.GetRetryAttempts(map[string]string{
+	attempts, err := GetRetryAttempts(map[string]string{
 		"maesh.containo.us/retry-attempts": "2",
 	})
 
@@ -128,13 +127,13 @@ func TestGetRetryAttempts_Valid(t *testing.T) {
 }
 
 func TestGetRetryAttempts_NotSet(t *testing.T) {
-	_, err := annotations.GetRetryAttempts(map[string]string{})
+	_, err := GetRetryAttempts(map[string]string{})
 
-	assert.Equal(t, annotations.ErrNotFound, err)
+	assert.Equal(t, ErrNotFound, err)
 }
 
 func TestGetRetryAttempts_Invalid(t *testing.T) {
-	_, err := annotations.GetRetryAttempts(map[string]string{
+	_, err := GetRetryAttempts(map[string]string{
 		"maesh.containo.us/retry-attempts": "hello",
 	})
 
@@ -142,7 +141,7 @@ func TestGetRetryAttempts_Invalid(t *testing.T) {
 }
 
 func TestGetCircuitBreakerExpression_Valid(t *testing.T) {
-	expression, err := annotations.GetCircuitBreakerExpression(map[string]string{
+	expression, err := GetCircuitBreakerExpression(map[string]string{
 		"maesh.containo.us/circuit-breaker-expression": "LatencyAtQuantileMS(50.0) > 100",
 	})
 
@@ -151,13 +150,13 @@ func TestGetCircuitBreakerExpression_Valid(t *testing.T) {
 }
 
 func TestGetCircuitBreakerExpression_NotSet(t *testing.T) {
-	_, err := annotations.GetCircuitBreakerExpression(map[string]string{})
+	_, err := GetCircuitBreakerExpression(map[string]string{})
 
-	assert.Equal(t, annotations.ErrNotFound, err)
+	assert.Equal(t, ErrNotFound, err)
 }
 
 func TestGetRateLimitBurst_Valid(t *testing.T) {
-	attempts, err := annotations.GetRateLimitBurst(map[string]string{
+	attempts, err := GetRateLimitBurst(map[string]string{
 		"maesh.containo.us/ratelimit-burst": "200",
 	})
 
@@ -166,13 +165,13 @@ func TestGetRateLimitBurst_Valid(t *testing.T) {
 }
 
 func TestGetRateLimitBurst_NotSet(t *testing.T) {
-	_, err := annotations.GetRateLimitBurst(map[string]string{})
+	_, err := GetRateLimitBurst(map[string]string{})
 
-	assert.Equal(t, annotations.ErrNotFound, err)
+	assert.Equal(t, ErrNotFound, err)
 }
 
 func TestGetRateLimitBurst_Invalid(t *testing.T) {
-	_, err := annotations.GetRateLimitBurst(map[string]string{
+	_, err := GetRateLimitBurst(map[string]string{
 		"maesh.containo.us/ratelimit-burst": "hello",
 	})
 
@@ -180,7 +179,7 @@ func TestGetRateLimitBurst_Invalid(t *testing.T) {
 }
 
 func TestGetRateLimitAverage_Valid(t *testing.T) {
-	attempts, err := annotations.GetRateLimitAverage(map[string]string{
+	attempts, err := GetRateLimitAverage(map[string]string{
 		"maesh.containo.us/ratelimit-average": "100",
 	})
 
@@ -189,13 +188,13 @@ func TestGetRateLimitAverage_Valid(t *testing.T) {
 }
 
 func TestGetRateLimitAverage_NotSet(t *testing.T) {
-	_, err := annotations.GetRateLimitAverage(map[string]string{})
+	_, err := GetRateLimitAverage(map[string]string{})
 
-	assert.Equal(t, annotations.ErrNotFound, err)
+	assert.Equal(t, ErrNotFound, err)
 }
 
 func TestGetRateLimitAverage_Invalid(t *testing.T) {
-	_, err := annotations.GetRateLimitAverage(map[string]string{
+	_, err := GetRateLimitAverage(map[string]string{
 		"maesh.containo.us/ratelimit-average": "hello",
 	})
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"reflect"
 	"time"
 
 	"github.com/containous/maesh/pkg/annotations"
@@ -18,13 +17,25 @@ import (
 	splitinformer "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/informers/externalversions"
 	splitlister "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/listers/split/v1alpha2"
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	// configRefreshKey is the work queue key used to indicate that config has to be refreshed.
+	configRefreshKey = "refresh"
+
+	// maxRetries is the number of times a work task will be retried before it is dropped out of the queue.
+	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the times a
+	// work task is going to be re-queued: 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s
+	maxRetries = 12
 )
 
 // PortMapper is capable of storing and retrieving a port mapping for a given service.
@@ -37,13 +48,6 @@ type PortMapper interface {
 // TopologyBuilder builds Topologies.
 type TopologyBuilder interface {
 	Build(ignoredResources k8s.IgnoreWrapper) (*topology.Topology, error)
-}
-
-// ServiceManager is capable of managing kubernetes services.
-type ServiceManager interface {
-	Create(userSvc *corev1.Service) error
-	Update(oldUserSvc, newUserSvc *corev1.Service) (*corev1.Service, error)
-	Delete(userSvc *corev1.Service) error
 }
 
 // Config holds the configuration of the controller.
@@ -66,8 +70,8 @@ type Config struct {
 type Controller struct {
 	cfg                  Config
 	handler              cache.ResourceEventHandler
-	serviceManager       ServiceManager
-	configRefreshChan    chan struct{}
+	workQueue            workqueue.RateLimitingInterface
+	shadowServiceManager *ShadowServiceManager
 	provider             *provider.Provider
 	ignoredResources     k8s.IgnoreWrapper
 	tcpStateTable        PortMapper
@@ -91,8 +95,8 @@ type Controller struct {
 	trafficSplitLister   splitlister.TrafficSplitLister
 }
 
-// NewMeshController is used to build the informers and other required components of the mesh controller,
-// and return an initialized mesh controller object.
+// NewMeshController builds the informers and other required components of the mesh controller, and returns an
+// initialized mesh controller object.
 func NewMeshController(clients k8s.Client, cfg Config, logger logrus.FieldLogger) (*Controller, error) {
 	ignoredResources := k8s.NewIgnored()
 
@@ -134,13 +138,13 @@ func (c *Controller) init() {
 	c.splitFactory = splitinformer.NewSharedInformerFactoryWithOptions(c.clients.SplitClient(), k8s.ResyncPeriod)
 
 	c.serviceLister = c.kubernetesFactory.Core().V1().Services().Lister()
-	c.serviceManager = NewShadowServiceManager(c.logger, c.serviceLister, c.cfg.Namespace, c.tcpStateTable, c.udpStateTable, c.cfg.DefaultMode, c.cfg.MinHTTPPort, c.cfg.MaxHTTPPort, c.clients.KubernetesClient())
+	c.shadowServiceManager = NewShadowServiceManager(c.logger, c.serviceLister, c.cfg.Namespace, c.tcpStateTable, c.udpStateTable, c.cfg.DefaultMode, c.cfg.MinHTTPPort, c.cfg.MaxHTTPPort, c.clients.KubernetesClient())
 
-	// configRefreshChan is used to trigger configuration refreshes.
-	c.configRefreshChan = make(chan struct{})
+	// Create the work queue and the enqueue handler.
+	c.workQueue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	c.handler = cache.FilteringResourceEventHandler{
 		FilterFunc: c.isWatchedResource,
-		Handler:    NewHandler(c.logger, c.serviceManager, c.configRefreshChan),
+		Handler:    &enqueueWorkHandler{logger: c.logger, workQueue: c.workQueue},
 	}
 
 	// Create listers and register the event handler to informers that are not ACL related.
@@ -198,6 +202,9 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 	// Handle a panic with logging and exiting.
 	defer utilruntime.HandleCrash()
 
+	// Tell processNextWorkItem to exit when the control loop ends.
+	defer c.workQueue.ShutDown()
+
 	c.logger.Debug("Initializing mesh controller")
 
 	// Start the api.
@@ -209,27 +216,13 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 	// Enable API readiness endpoint, informers are started and default conf is available.
 	c.api.EnableReadiness()
 
-	for {
-		select {
-		case <-stopCh:
-			c.logger.Info("Shutting down workers")
-			return nil
+	// Start to poll work from the queue.
+	go wait.Until(c.runWorker, time.Second, stopCh)
 
-		case <-c.configRefreshChan:
-			// Reload the configuration.
-			topo, err := c.topologyBuilder.Build(c.ignoredResources)
-			if err != nil {
-				c.logger.Errorf("Unable to build dynamic configuration: %v", err)
-				continue
-			}
+	<-stopCh
+	c.logger.Info("Shutting down workers")
 
-			conf := c.provider.BuildConfig(topo)
-
-			if !reflect.DeepEqual(c.currentConfiguration.Get(), conf) {
-				c.currentConfiguration.Set(conf)
-			}
-		}
-	}
+	return nil
 }
 
 // startInformers starts the controller informers.
@@ -292,4 +285,77 @@ func (c *Controller) isWatchedResource(obj interface{}) bool {
 	pMeta := meta.AsPartialObjectMetadata(accessor)
 
 	return !c.ignoredResources.IsIgnored(pMeta.ObjectMeta)
+}
+
+// runWorker is a long-running function that will continually call the processNextWorkItem function in order to read and
+// process a message on the work queue.
+func (c *Controller) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+// processNextWorkItem will read a single work item off the work queue and attempt to process it.
+func (c *Controller) processNextWorkItem() bool {
+	key, quit := c.workQueue.Get()
+	if quit {
+		return false
+	}
+
+	defer c.workQueue.Done(key)
+
+	if key != configRefreshKey {
+		if err := c.syncShadowService(key.(string)); err != nil {
+			c.handleErr(key, err)
+			return true
+		}
+	}
+
+	// Build and store config.
+	topo, err := c.topologyBuilder.Build(c.ignoredResources)
+	if err != nil {
+		c.handleErr(key, err)
+		return true
+	}
+
+	conf := c.provider.BuildConfig(topo)
+	c.currentConfiguration.Set(conf)
+
+	c.workQueue.Forget(key)
+
+	return true
+}
+
+// syncShadowService calls the shadow service manager to keep the shadow service state in sync with the service events received.
+func (c *Controller) syncShadowService(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	svc, err := c.serviceLister.Services(namespace).Get(name)
+	if errors.IsNotFound(err) {
+		return c.shadowServiceManager.Delete(namespace, name)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	_, err = c.shadowServiceManager.CreateOrUpdate(svc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// handleErr re-queues the given work key only if the maximum number of attempts is not exceeded.
+func (c *Controller) handleErr(key interface{}, err error) {
+	if c.workQueue.NumRequeues(key) < maxRetries {
+		c.workQueue.AddRateLimited(key)
+		return
+	}
+
+	c.logger.Errorf("Unable to complete work for key %q: %v", key, err)
+	c.workQueue.Forget(key)
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containous/maesh/pkg/k8s"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -20,7 +21,7 @@ const (
 	maxUDPPort           = int32(15005)
 )
 
-func TestNewController(t *testing.T) {
+func TestController_NewMeshController(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -44,11 +45,12 @@ func TestNewController(t *testing.T) {
 		MinUDPPort:       minUDPPort,
 		MaxUDPPort:       maxUDPPort,
 	}, log)
-	assert.NoError(t, err)
+
+	require.NoError(t, err)
 	assert.NotNil(t, controller)
 }
 
-func TestNewControllerWithSMI(t *testing.T) {
+func TestController_NewMeshControllerWithSMI(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -72,6 +74,7 @@ func TestNewControllerWithSMI(t *testing.T) {
 		MinUDPPort:       minUDPPort,
 		MaxUDPPort:       maxUDPPort,
 	}, log)
-	assert.NoError(t, err)
+
+	require.NoError(t, err)
 	assert.NotNil(t, controller)
 }

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -3,71 +3,50 @@ package controller
 import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 )
 
-// Handler is an implementation of a ResourceEventHandler.
-type Handler struct {
-	log               logrus.FieldLogger
-	configRefreshChan chan struct{}
-	serviceManager    ServiceManager
+type enqueueWorkHandler struct {
+	logger    logrus.FieldLogger
+	workQueue workqueue.RateLimitingInterface
 }
 
-// NewHandler creates a handler.
-func NewHandler(log logrus.FieldLogger, serviceManager ServiceManager, configRefreshChan chan struct{}) *Handler {
-	return &Handler{
-		log:               log,
-		configRefreshChan: configRefreshChan,
-		serviceManager:    serviceManager,
-	}
+// OnAdd is called when an object is added to the informers cache.
+func (h *enqueueWorkHandler) OnAdd(obj interface{}) {
+	h.enqueueWork(obj)
 }
 
-// OnAdd is called when an object is added.
-func (h *Handler) OnAdd(obj interface{}) {
-	// If the created object is a service we have to create a corresponding shadow service.
-	if obj, isService := obj.(*corev1.Service); isService {
-		h.log.Debugf("MeshControllerHandler ObjectAdded with type: *corev1.Service: %s/%s", obj.Namespace, obj.Name)
+// OnUpdate is called when an object is updated in the informers cache.
+func (h *enqueueWorkHandler) OnUpdate(oldObj interface{}, newObj interface{}) {
+	oldObjMeta, okOld := oldObj.(metav1.Object)
+	newObjMeta, okNew := newObj.(metav1.Object)
 
-		if err := h.serviceManager.Create(obj); err != nil {
-			h.log.Errorf("Could not create mesh service: %v", err)
-		}
+	// This is a resync event, no extra work is needed.
+	if okOld && okNew && oldObjMeta.GetResourceVersion() == newObjMeta.GetResourceVersion() {
+		return
 	}
 
-	// Trigger a configuration rebuild.
-	h.configRefreshChan <- struct{}{}
+	h.enqueueWork(newObj)
 }
 
-// OnUpdate is called when an object is updated.
-func (h *Handler) OnUpdate(oldObj, newObj interface{}) {
-	// If the updated object is a service we have to update the corresponding shadow service.
-	if obj, isService := newObj.(*corev1.Service); isService {
-		oldSvc, ok := oldObj.(*corev1.Service)
-		if !ok {
-			h.log.Errorf("Old object is not a kubernetes Service")
-			return
-		}
-
-		if _, err := h.serviceManager.Update(oldSvc, obj); err != nil {
-			h.log.Errorf("Could not update mesh service: %v", err)
-		}
-
-		h.log.Debugf("MeshControllerHandler ObjectUpdated with type: *corev1.Service: %s/%s", obj.Namespace, obj.Name)
-	}
-
-	// Trigger a configuration rebuild.
-	h.configRefreshChan <- struct{}{}
+// OnDelete is called when an object is removed from the informers cache.
+func (h *enqueueWorkHandler) OnDelete(obj interface{}) {
+	h.enqueueWork(obj)
 }
 
-// OnDelete is called when an object is deleted.
-func (h *Handler) OnDelete(obj interface{}) {
-	// If the deleted object is a service we have to delete the corresponding shadow service.
-	if obj, isService := obj.(*corev1.Service); isService {
-		h.log.Debugf("MeshControllerHandler ObjectDeleted with type: *corev1.Service: %s/%s", obj.Namespace, obj.Name)
-
-		if err := h.serviceManager.Delete(obj); err != nil {
-			h.log.Errorf("Could not delete mesh service: %v", err)
-		}
+func (h *enqueueWorkHandler) enqueueWork(obj interface{}) {
+	if _, isService := obj.(*corev1.Service); !isService {
+		h.workQueue.Add(configRefreshKey)
+		return
 	}
 
-	// Trigger a configuration rebuild.
-	h.configRefreshChan <- struct{}{}
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		h.logger.Errorf("Unable to create a work key for resource %#v", obj)
+		return
+	}
+
+	h.workQueue.Add(key)
 }

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -1,0 +1,144 @@
+package controller
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+)
+
+func TestEnqueueWorkHandler_OnAdd(t *testing.T) {
+	log := logrus.New()
+
+	log.SetOutput(os.Stdout)
+	log.SetLevel(logrus.DebugLevel)
+
+	workQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	handler := &enqueueWorkHandler{logger: log, workQueue: workQueue}
+	handler.OnAdd(&corev1.Pod{})
+
+	assert.Equal(t, 1, workQueue.Len())
+
+	currentKey, _ := workQueue.Get()
+
+	assert.Equal(t, configRefreshKey, currentKey)
+}
+
+func TestEnqueueWorkHandler_OnDelete(t *testing.T) {
+	log := logrus.New()
+
+	log.SetOutput(os.Stdout)
+	log.SetLevel(logrus.DebugLevel)
+
+	workQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	handler := &enqueueWorkHandler{logger: log, workQueue: workQueue}
+	handler.OnDelete(&corev1.Pod{})
+
+	assert.Equal(t, 1, workQueue.Len())
+
+	currentKey, _ := workQueue.Get()
+
+	assert.Equal(t, configRefreshKey, currentKey)
+}
+
+func TestEnqueueWorkHandler_OnUpdate(t *testing.T) {
+	tests := []struct {
+		desc        string
+		oldObj      interface{}
+		newObj      interface{}
+		expectedLen int
+	}{
+		{
+			desc: "should enqueue if this is not a re-sync event",
+			oldObj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "foo"},
+			},
+			newObj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "foo"},
+			},
+			expectedLen: 0,
+		},
+		{
+			desc: "should enqueue if this is a re-sync event",
+			oldObj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "foo"},
+			},
+			newObj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "bar"},
+			},
+			expectedLen: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			log := logrus.New()
+
+			log.SetOutput(os.Stdout)
+			log.SetLevel(logrus.DebugLevel)
+
+			workQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+			handler := &enqueueWorkHandler{logger: log, workQueue: workQueue}
+			handler.OnUpdate(test.oldObj, test.newObj)
+
+			assert.Equal(t, test.expectedLen, workQueue.Len())
+		})
+	}
+}
+
+func TestEnqueueWorkHandler_enqueueWork(t *testing.T) {
+	tests := []struct {
+		desc        string
+		obj         interface{}
+		expectedLen int
+		expectedKey string
+	}{
+		{
+			desc:        "should enqueue a refresh key if obj is not a service",
+			obj:         &corev1.Endpoints{},
+			expectedLen: 1,
+			expectedKey: configRefreshKey,
+		},
+		{
+			desc: "should enqueue a meta namespace key if the obj is a service",
+			obj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			},
+			expectedLen: 1,
+			expectedKey: "bar/foo",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			log := logrus.New()
+
+			log.SetOutput(os.Stdout)
+			log.SetLevel(logrus.DebugLevel)
+
+			workQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+			handler := &enqueueWorkHandler{logger: log, workQueue: workQueue}
+			handler.enqueueWork(test.obj)
+
+			assert.Equal(t, test.expectedLen, workQueue.Len())
+
+			currentKey, _ := workQueue.Get()
+
+			fmt.Println(currentKey)
+
+			assert.Equal(t, test.expectedKey, currentKey)
+		})
+	}
+}

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -56,7 +55,7 @@ func TestEnqueueWorkHandler_OnUpdate(t *testing.T) {
 		expectedLen int
 	}{
 		{
-			desc: "should enqueue if this is not a re-sync event",
+			desc: "should not enqueue if this is a re-sync event",
 			oldObj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "foo"},
 			},
@@ -66,7 +65,7 @@ func TestEnqueueWorkHandler_OnUpdate(t *testing.T) {
 			expectedLen: 0,
 		},
 		{
-			desc: "should enqueue if this is a re-sync event",
+			desc: "should enqueue if this is not a re-sync event",
 			oldObj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "foo"},
 			},
@@ -135,8 +134,6 @@ func TestEnqueueWorkHandler_enqueueWork(t *testing.T) {
 			assert.Equal(t, test.expectedLen, workQueue.Len())
 
 			currentKey, _ := workQueue.Get()
-
-			fmt.Println(currentKey)
 
 			assert.Equal(t, test.expectedKey, currentKey)
 		})

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -170,7 +170,7 @@ func (s *ShadowServiceManager) removeServicePortMapping(namespace, name string, 
 
 	case corev1.ProtocolUDP:
 		if _, err := s.udpStateTable.Remove(svcWithPort); err != nil {
-			s.logger.Warnf("Unable to remove TCP port mapping for %s/%s on port %d", namespace, name, svcPort.Port)
+			s.logger.Warnf("Unable to remove UDP port mapping for %s/%s on port %d", namespace, name, svcPort.Port)
 		}
 	}
 }

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -14,13 +14,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/util/retry"
 )
 
 // ShadowServiceManager manages shadow services.
 type ShadowServiceManager struct {
-	log                logrus.FieldLogger
-	lister             listers.ServiceLister
+	logger             logrus.FieldLogger
+	serviceLister      listers.ServiceLister
 	namespace          string
 	tcpStateTable      PortMapper
 	udpStateTable      PortMapper
@@ -31,10 +30,10 @@ type ShadowServiceManager struct {
 }
 
 // NewShadowServiceManager returns new shadow service manager.
-func NewShadowServiceManager(log logrus.FieldLogger, lister listers.ServiceLister, namespace string, tcpStateTable PortMapper, udpStateTable PortMapper, defaultTrafficType string, minHTTPPort, maxHTTPPort int32, kubeClient kubernetes.Interface) *ShadowServiceManager {
+func NewShadowServiceManager(logger logrus.FieldLogger, serviceLister listers.ServiceLister, namespace string, tcpStateTable, udpStateTable PortMapper, defaultTrafficType string, minHTTPPort, maxHTTPPort int32, kubeClient kubernetes.Interface) *ShadowServiceManager {
 	return &ShadowServiceManager{
-		log:                log,
-		lister:             lister,
+		logger:             logger,
+		serviceLister:      serviceLister,
 		namespace:          namespace,
 		tcpStateTable:      tcpStateTable,
 		udpStateTable:      udpStateTable,
@@ -45,29 +44,28 @@ func NewShadowServiceManager(log logrus.FieldLogger, lister listers.ServiceListe
 	}
 }
 
-// Create creates a new shadow service based on the given service.
-func (s *ShadowServiceManager) Create(userSvc *corev1.Service) error {
-	name := s.getShadowServiceName(userSvc.Name, userSvc.Namespace)
+// CreateOrUpdate creates or updates the shadow service corresponding to the given service.
+func (s *ShadowServiceManager) CreateOrUpdate(svc *corev1.Service) (*corev1.Service, error) {
+	shadowSvcName := s.getShadowServiceName(svc.Namespace, svc.Name)
 
-	s.log.Debugf("Creating mesh service: %s", name)
-
-	_, err := s.lister.Services(s.namespace).Get(name)
-	if err == nil {
-		return nil
+	shadowSvc, err := s.serviceLister.Services(s.namespace).Get(shadowSvcName)
+	if err != nil && !kerrors.IsNotFound(err) {
+		return nil, fmt.Errorf("unable to get shadow service %q: %w", shadowSvcName, err)
 	}
 
-	if !kerrors.IsNotFound(err) {
-		return fmt.Errorf("unable to get shadow service %q: %w", name, err)
-	}
+	// Removes the current mappings for the ports that are not present in the new service version.
+	// Current shadow service ports are equal to the ports mapped for the previous service version.
+	// This step is required to free up some ports before allocation.
+	s.removeUnusedPortMappings(shadowSvc, svc)
 
-	ports, err := s.getShadowServicePorts(userSvc)
+	ports, err := s.getShadowServicePorts(svc)
 	if err != nil {
-		return fmt.Errorf("unable to get ports for service %s/%s: %w", userSvc.Namespace, userSvc.Name, err)
+		return nil, fmt.Errorf("unable to get shadow service ports for service %s/%s: %w", svc.Namespace, svc.Name, err)
 	}
 
-	svc := &corev1.Service{
+	newShadowSvc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      shadowSvcName,
 			Namespace: s.namespace,
 			Labels: map[string]string{
 				"app":  "maesh",
@@ -82,11 +80,9 @@ func (s *ShadowServiceManager) Create(userSvc *corev1.Service) error {
 		},
 	}
 
-	major, minor := parseKubernetesServerVersion(s.kubeClient)
-
 	// If the kubernetes server version is 1.17+, then use the topology key.
-	if major == 1 && minor >= 17 {
-		svc.Spec.TopologyKeys = []string{
+	if major, minor := parseKubernetesServerVersion(s.kubeClient); major == 1 && minor >= 17 {
+		newShadowSvc.Spec.TopologyKeys = []string{
 			"kubernetes.io/hostname",
 			"topology.kubernetes.io/zone",
 			"topology.kubernetes.io/region",
@@ -94,107 +90,94 @@ func (s *ShadowServiceManager) Create(userSvc *corev1.Service) error {
 		}
 	}
 
-	if _, err = s.kubeClient.CoreV1().Services(s.namespace).Create(svc); err != nil {
-		return fmt.Errorf("unable to create kubernetes service: %w", err)
+	if shadowSvc == nil {
+		return s.kubeClient.CoreV1().Services(s.namespace).Create(newShadowSvc)
 	}
 
-	return nil
+	// Ensure that we are not leaking some port mappings if the traffic type of the new service version has been updated.
+	// If the traffic has been updated, some ports may be missing if they are not suitable, and some target port values may not match.
+	s.cleanupPortMappings(svc.Namespace, svc.Name, shadowSvc, newShadowSvc)
+
+	shadowSvc = shadowSvc.DeepCopy()
+	shadowSvc.Spec.Ports = newShadowSvc.Spec.Ports
+
+	return s.kubeClient.CoreV1().Services(s.namespace).Update(shadowSvc)
 }
 
-// Update updates the shadow service associated with the old user service following the content of the new user service.
-func (s *ShadowServiceManager) Update(oldUserSvc *corev1.Service, newUserSvc *corev1.Service) (*corev1.Service, error) {
-	name := s.getShadowServiceName(newUserSvc.Name, newUserSvc.Namespace)
+// Delete deletes the shadow service associated with the given service.
+func (s *ShadowServiceManager) Delete(namespace, name string) error {
+	shadowSvcName := s.getShadowServiceName(namespace, name)
 
-	if err := s.cleanupPortMapping(oldUserSvc, newUserSvc); err != nil {
-		return nil, fmt.Errorf("unable to cleanup port mapping for service %s/%s: %w", oldUserSvc.Namespace, oldUserSvc.Name, err)
-	}
-
-	ports, err := s.getShadowServicePorts(newUserSvc)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get ports for service %s/%s: %w", newUserSvc.Namespace, newUserSvc.Name, err)
-	}
-
-	var updatedSvc *corev1.Service
-
-	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		svc, err := s.lister.Services(s.namespace).Get(name)
-		if err != nil {
-			return fmt.Errorf("unable to get shadow service %q: %w", name, err)
-		}
-
-		newSvc := svc.DeepCopy()
-		newSvc.Spec.Ports = ports
-
-		if updatedSvc, err = s.kubeClient.CoreV1().Services(s.namespace).Update(newSvc); err != nil {
-			return fmt.Errorf("unable to update kubernetes service: %w", err)
-		}
-
+	shadowSvc, err := s.serviceLister.Services(s.namespace).Get(shadowSvcName)
+	if kerrors.IsNotFound(err) {
 		return nil
-	})
-
-	if retryErr != nil {
-		return nil, fmt.Errorf("unable to update service %q: %v", name, retryErr)
 	}
 
-	s.log.Debugf("Updated service: %s/%s", s.namespace, name)
-
-	return updatedSvc, nil
-}
-
-// Delete deletes a shadow service associated with the given user service.
-func (s *ShadowServiceManager) Delete(userSvc *corev1.Service) error {
-	name := s.getShadowServiceName(userSvc.Name, userSvc.Namespace)
-
-	if err := s.cleanupPortMapping(userSvc, nil); err != nil {
-		return fmt.Errorf("unable to cleanup port mapping for service %s/%s: %w", userSvc.Namespace, userSvc.Name, err)
-	}
-
-	_, err := s.lister.Services(s.namespace).Get(name)
 	if err != nil {
 		return err
 	}
 
-	if err := s.kubeClient.CoreV1().Services(s.namespace).Delete(name, &metav1.DeleteOptions{}); err != nil {
-		return err
+	// Removes all port mappings for the deleted service.
+	// Current shadow service ports are equal to the deleted service ports.
+	for _, svcPort := range shadowSvc.Spec.Ports {
+		s.removeServicePortMapping(namespace, name, svcPort)
 	}
 
-	s.log.Debugf("Deleted service: %s/%s", s.namespace, name)
-
-	return nil
+	return s.kubeClient.CoreV1().Services(s.namespace).Delete(shadowSvcName, &metav1.DeleteOptions{})
 }
 
-func (s *ShadowServiceManager) cleanupPortMapping(oldUserSvc *corev1.Service, newUserSvc *corev1.Service) error {
-	var stateTable PortMapper
+func (s *ShadowServiceManager) cleanupPortMappings(namespace, name string, oldShadowSvc, newShadowSvc *corev1.Service) {
+	for _, oldPort := range oldShadowSvc.Spec.Ports {
+		if !needsCleanup(newShadowSvc.Spec.Ports, oldPort) {
+			continue
+		}
 
-	trafficType, err := annotations.GetTrafficType(s.defaultTrafficType, oldUserSvc.Annotations)
-	if err != nil {
-		return fmt.Errorf("unable to get service traffic type: %w", err)
+		s.removeServicePortMapping(namespace, name, oldPort)
+	}
+}
+
+func (s *ShadowServiceManager) removeUnusedPortMappings(shadowSvc, svc *corev1.Service) {
+	if svc == nil || shadowSvc == nil {
+		return
 	}
 
-	switch trafficType {
-	case annotations.ServiceTypeTCP:
-		stateTable = s.tcpStateTable
-	case annotations.ServiceTypeUDP:
-		stateTable = s.udpStateTable
-	default:
-		return nil
+	for _, shadowSvcPort := range shadowSvc.Spec.Ports {
+		if containsPort(svc.Spec.Ports, shadowSvcPort) {
+			continue
+		}
+
+		s.removeServicePortMapping(svc.Namespace, svc.Name, shadowSvcPort)
+	}
+}
+
+func (s *ShadowServiceManager) removeServicePortMapping(namespace, name string, svcPort corev1.ServicePort) {
+	// Nothing to do here as there is no port table for HTTP ports.
+	if svcPort.TargetPort.IntVal < s.maxHTTPPort {
+		return
 	}
 
-	for _, old := range oldUserSvc.Spec.Ports {
-		if found := matchPort(old.Port, newUserSvc); !found {
-			_, err := stateTable.Remove(k8s.ServiceWithPort{
-				Namespace: oldUserSvc.Namespace,
-				Name:      oldUserSvc.Name,
-				Port:      old.Port,
-			})
+	svcWithPort := k8s.ServiceWithPort{
+		Namespace: namespace,
+		Name:      name,
+		Port:      svcPort.Port,
+	}
 
-			if err != nil {
-				s.log.Warnf("Unable to remove port mapping for %s/%s on port %d", oldUserSvc.Namespace, oldUserSvc.Name, old.Port)
-			}
+	switch svcPort.Protocol {
+	case corev1.ProtocolTCP:
+		if _, err := s.tcpStateTable.Remove(svcWithPort); err != nil {
+			s.logger.Warnf("Unable to remove TCP port mapping for %s/%s on port %d", namespace, name, svcPort.Port)
+		}
+
+	case corev1.ProtocolUDP:
+		if _, err := s.udpStateTable.Remove(svcWithPort); err != nil {
+			s.logger.Warnf("Unable to remove TCP port mapping for %s/%s on port %d", namespace, name, svcPort.Port)
 		}
 	}
+}
 
-	return nil
+// getShadowServiceName returns the shadow service name corresponding to the given service name and namespace.
+func (s *ShadowServiceManager) getShadowServiceName(namespace, name string) string {
+	return fmt.Sprintf("%s-%s-6d61657368-%s", s.namespace, name, namespace)
 }
 
 func (s *ShadowServiceManager) getShadowServicePorts(svc *corev1.Service) ([]corev1.ServicePort, error) {
@@ -207,12 +190,13 @@ func (s *ShadowServiceManager) getShadowServicePorts(svc *corev1.Service) ([]cor
 
 	for i, sp := range svc.Spec.Ports {
 		if !isPortSuitable(trafficType, sp) {
-			s.log.Warnf("Unsupported port type %q on %q service %s/%s, skipping port %q", sp.Protocol, trafficType, svc.Namespace, svc.Name, sp.Name)
+			s.logger.Warnf("Unsupported port type %q on %q service %s/%s, skipping port %q", sp.Protocol, trafficType, svc.Namespace, svc.Name, sp.Name)
+			continue
 		}
 
 		targetPort, err := s.getTargetPort(trafficType, i, svc.Name, svc.Namespace, sp.Port)
 		if err != nil {
-			s.log.Errorf("Unable to find available %s port: %v, skipping port %s on service %s/%s", sp.Name, err, sp.Name, svc.Namespace, svc.Name)
+			s.logger.Errorf("Unable to find available %s port: %v, skipping port %s on service %s/%s", sp.Name, err, sp.Name, svc.Namespace, svc.Name)
 			continue
 		}
 
@@ -225,11 +209,6 @@ func (s *ShadowServiceManager) getShadowServicePorts(svc *corev1.Service) ([]cor
 	}
 
 	return ports, nil
-}
-
-// getShadowServiceName converts a User service with a namespace to a mesh service name.
-func (s *ShadowServiceManager) getShadowServiceName(name string, namespace string) string {
-	return fmt.Sprintf("%s-%s-6d61657368-%s", s.namespace, name, namespace)
 }
 
 func (s *ShadowServiceManager) getTargetPort(trafficType string, portID int, name, namespace string, port int32) (int32, error) {
@@ -265,14 +244,14 @@ func (s *ShadowServiceManager) getMappedPort(stateTable PortMapper, svcName, svc
 		return port, nil
 	}
 
-	s.log.Debugf("No match found for %s/%s %d - Add a new port", svcName, svcNamespace, svcPort)
+	s.logger.Debugf("No match found for %s/%s %d - Add a new port", svcName, svcNamespace, svcPort)
 
 	port, err := stateTable.Add(&svc)
 	if err != nil {
 		return 0, fmt.Errorf("unable to add service to the TCP state table: %w", err)
 	}
 
-	s.log.Debugf("Service %s/%s %d as been assigned port %d", svcName, svcNamespace, svcPort, port)
+	s.logger.Debugf("Service %s/%s %d as been assigned port %d", svcName, svcNamespace, svcPort, port)
 
 	return port, nil
 }
@@ -308,16 +287,24 @@ func parseKubernetesServerVersion(kubeClient kubernetes.Interface) (major, minor
 	return major, minor
 }
 
-func matchPort(oldPort int32, newUserSvc *corev1.Service) bool {
-	if newUserSvc == nil {
-		return false
-	}
-
-	for _, new := range newUserSvc.Spec.Ports {
-		if oldPort == new.Port {
+// containsPort returns true if a service port with the same port and protocol value exist in the given port list, false otherwise.
+func containsPort(ports []corev1.ServicePort, port corev1.ServicePort) bool {
+	for _, onePort := range ports {
+		if onePort.Port == port.Port && onePort.Protocol == port.Protocol {
 			return true
 		}
 	}
 
 	return false
+}
+
+// needsCleanup returns true if the given shadow service port have to be cleaned up, false otherwise.
+func needsCleanup(ports []corev1.ServicePort, port corev1.ServicePort) bool {
+	for _, onePort := range ports {
+		if onePort.Port == port.Port && onePort.Protocol == port.Protocol && onePort.TargetPort == port.TargetPort {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/k8s/portmapping.go
+++ b/pkg/k8s/portmapping.go
@@ -58,14 +58,6 @@ func (m *PortMapping) Find(svc ServiceWithPort) (int32, bool) {
 	return 0, false
 }
 
-// Get returns the ServiceWithPort associated to the given port.
-func (m *PortMapping) Get(srcPort int32) *ServiceWithPort {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	return m.table[srcPort]
-}
-
 // Add adds a new mapping between the given ServiceWithPort and the first port available in the range defined
 // within minPort and maxPort. If there's no port left, an error will be returned.
 func (m *PortMapping) Add(svc *ServiceWithPort) (int32, error) {

--- a/pkg/k8s/portmapping_test.go
+++ b/pkg/k8s/portmapping_test.go
@@ -22,7 +22,7 @@ func TestPortMapping_GetEmptyState(t *testing.T) {
 	m, err := NewPortMapping(client, "maesh", "tcp-state-table", 10000, 10200)
 	require.NoError(t, err)
 
-	svc := m.Get(8080)
+	svc := m.table[8080]
 	assert.Nil(t, svc)
 }
 
@@ -42,13 +42,13 @@ func TestPortMapping_GetWithState(t *testing.T) {
 	m, err := NewPortMapping(client, "maesh", "tcp-state-table", 10000, 10200)
 	require.NoError(t, err)
 
-	svc := m.Get(10000)
+	svc := m.table[10000]
 	require.NotNil(t, svc)
 	assert.Equal(t, "my-ns", svc.Namespace)
 	assert.Equal(t, "my-app", svc.Name)
 	assert.Equal(t, int32(9090), svc.Port)
 
-	svc = m.Get(10001)
+	svc = m.table[10001]
 	require.NotNil(t, svc)
 	assert.Equal(t, "my-ns", svc.Namespace)
 	assert.Equal(t, "my-app2", svc.Name)
@@ -76,7 +76,7 @@ func TestPortMapping_AddEmptyState(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(10000), port)
 
-	gotSvc := m.Get(10000)
+	gotSvc := m.table[10000]
 	require.NotNil(t, gotSvc)
 	assert.Equal(t, wantSvc, gotSvc)
 
@@ -115,15 +115,15 @@ func TestPortMapping_AddOverflow(t *testing.T) {
 	_, err = m.Add(wantSvc)
 	assert.Error(t, err)
 
-	gotSvc := m.Get(10000)
+	gotSvc := m.table[10000]
 	require.NotNil(t, gotSvc)
 	assert.Equal(t, wantSvc, gotSvc)
 
-	gotSvc = m.Get(10001)
+	gotSvc = m.table[10001]
 	require.NotNil(t, gotSvc)
 	assert.Equal(t, wantSvc, gotSvc)
 
-	gotSvc = m.Get(10002)
+	gotSvc = m.table[10002]
 	assert.Nil(t, gotSvc)
 
 	cfgMap, err = client.CoreV1().ConfigMaps("maesh").Get("tcp-state-table", metav1.GetOptions{})

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -6,11 +6,6 @@ type Service struct {
 	Name      string
 }
 
-// State holds service state for TCP.
-type State struct {
-	Table map[int]*ServiceWithPort
-}
-
 // ServiceWithPort holds a combination of service name and namespace and port.
 type ServiceWithPort struct {
 	Namespace string

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,4 +1,4 @@
-package provider_test
+package provider
 
 import (
 	"encoding/json"
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	mk8s "github.com/containous/maesh/pkg/k8s"
-	"github.com/containous/maesh/pkg/provider"
 	"github.com/containous/maesh/pkg/topology"
 	"github.com/containous/traefik/v2/pkg/config/dynamic"
 	"github.com/sirupsen/logrus"
@@ -120,7 +119,7 @@ func TestProvider_BuildConfig(t *testing.T) {
 				defaultTrafficType = test.defaultTrafficType
 			}
 
-			cfg := provider.Config{
+			cfg := Config{
 				IgnoredResources:   mk8s.NewIgnored(),
 				MinHTTPPort:        10000,
 				MaxHTTPPort:        10010,
@@ -148,7 +147,7 @@ func TestProvider_BuildConfig(t *testing.T) {
 				return nil, nil
 			}
 
-			p := provider.New(stateTableMock(tcpStateTable), stateTableMock(udpStateTable), middlewareBuilder, cfg, logger)
+			p := New(stateTableMock(tcpStateTable), stateTableMock(udpStateTable), middlewareBuilder, cfg, logger)
 
 			topo, err := loadTopology(test.topology)
 			require.NoError(t, err)


### PR DESCRIPTION
## What does this PR do?

This PR:

- Removes unused code.
- Renames some test packages for consistency.
- Reworks the controller loop to use a work queue.
- Reworks the `ShadowServiceManager` to make it `idempotent`.

Fixes #562.

## Additional Notes

To fix #514, the TCP tables must be built from the `informers` cache which requires some synchronisation before starting the events processing. As discussed, to prepare the work on #514, I've reworked the controller loop to use a work queue which allows enqueueing before processing events.

By design, work queue keys are unique. So, if we receive a lot of events with the same work key, only one will be present in the queue at a time. This would avoid us some unnecessary work if we received a lot of events which require to rebuild the configuration, for example.

Something to keep in mind is that we are building the desired state of the configuration and the shadow services from the last know state of the cluster, the informers `cache`. The controller work is to update the configuration and the shadow services to match this state. So, if a service is updated `10000` times and is deleted, it's not necessary to process all events, our job is to remove the shadow service.

As we should not rely on an expected cluster state, I've also modified the `ShadowServiceManager` to make it `idempotent`. I'm pretty sure that it could be simplified and I will try to address that in my following work on #514.