### PR TITLE
Add default config values for pollInterval and pollTimeout

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -82,6 +82,8 @@ type ProxyConfiguration struct {
 // NewProxyConfiguration creates a ProxyConfiguration with default values.
 func NewProxyConfiguration() *ProxyConfiguration {
 	return &ProxyConfiguration{
+		PollInterval: 1 * time.Second,
+		PollTimeout:  1 * time.Second,
 		Configuration: static.Configuration{
 			Global: &static.Global{
 				CheckNewVersion: false,

--- a/helm/chart/maesh/Guidelines.md
+++ b/helm/chart/maesh/Guidelines.md
@@ -4,7 +4,7 @@ This document outlines the guidelines for developing, managing and extending the
 
 ## Optionality
 
-All non-critical features (features not mandatory to starting a cluster) in the Helm Chart must be optional.
+All non-critical features (features not mandatory to start Maesh) in the Helm Chart must be optional.
 All non-critical features should be disabled (commented out) in the `values.yaml` file.
 All optional non-critical features should be disabled (commented out) in the `values.yaml` file, and have a comment `# (Optional)` in the line above.
 This allows minimal configuration, and ease of extension.

--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -77,8 +77,12 @@ spec:
             - {{ printf "\"--entryPoints.udp-%d.address=:%d/udp\"" $port $port }}
             {{- end }}
             - {{ printf "--endpoint=http://maesh-controller.%s.svc.%s:9000/api/configuration/current" .Release.Namespace (default "cluster.local" .Values.clusterDomain) | quote }}
+            {{- if .Values.mesh.pollInterval }}
             - "--pollInterval={{ .Values.mesh.pollInterval }}"
+            {{- end }}
+            {{- if .Values.mesh.pollTimeout }}
             - "--pollTimeout={{ .Values.mesh.pollTimeout }}"
+            {{- end }}
             {{- if .Values.tracing.jaeger.enabled }}
               {{- if .Values.tracing.jaeger.localagenthostport }}
             - "--tracing.jaeger.localagenthostport={{ .Values.tracing.jaeger.localagenthostport }}"

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -38,10 +38,10 @@ controller:
   affinity: {}
 
 mesh:
-  pollInterval: 1s
-  pollTimeout: 1s
   # defaultMode: http
   # logLevel: error
+  # pollInterval: 1s
+  # pollTimeout: 1s
   # forwardingTimeouts:
   #   dialTimeout: 30s
   #   (Optional)

--- a/pkg/proxy/provider/http/http.go
+++ b/pkg/proxy/provider/http/http.go
@@ -40,16 +40,16 @@ func New(endpoint string, pollInterval time.Duration, pollTimeout time.Duration)
 
 // Init the provider.
 func (p *Provider) Init() error {
-	if len(p.Endpoint) == 0 {
+	if p.Endpoint == "" {
 		return fmt.Errorf("a non-empty endpoint is required")
 	}
 
 	if p.PollInterval == 0 {
-		p.PollInterval = 15 * time.Second
+		p.PollInterval = 1 * time.Second
 	}
 
 	if p.PollTimeout == 0 {
-		p.PollTimeout = 15 * time.Second
+		p.PollTimeout = 1 * time.Second
 	}
 
 	p.httpClient = &http.Client{Timeout: p.PollTimeout}
@@ -59,7 +59,7 @@ func (p *Provider) Init() error {
 
 // Provide allows the provider to provide configurations to traefik
 // using the given configuration channel.
-//nolint:gocognit // This requires a refactor that will come in its own PR.
+// nolint:gocognit // This requires a refactor that will come in its own PR.
 func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.Pool) error {
 	pool.GoCtx(func(routineCtx context.Context) {
 		ctxLog := log.With(routineCtx, log.Str(log.ProviderName, providerName))


### PR DESCRIPTION
## What does this PR do?

This PR:

- Adds default values for the `pollInterval` and `pollTimeout` configuration properties.

Fixes #597.