### PR TITLE
Add Helm option to configure logging level globally

### DIFF
--- a/helm/chart/maesh/Chart.yaml
+++ b/helm/chart/maesh/Chart.yaml
@@ -7,7 +7,10 @@ description: Maesh - Simpler Service Mesh
 keywords:
   - traefik
   - mesh
-home: https://containo.us/
+  - smi
+home: https://mae.sh/
+sources:
+  - https://github.com/containous/maesh/
 maintainers:
   - name: emilevauge
     email: emile@vauge.com

--- a/helm/chart/maesh/Chart.yaml
+++ b/helm/chart/maesh/Chart.yaml
@@ -5,16 +5,16 @@ version: 2.0.0
 appVersion: v1.2.0
 description: Maesh - Simpler Service Mesh
 keywords:
-- traefik
-- mesh
+  - traefik
+  - mesh
 home: https://containo.us/
 maintainers:
-- name: emilevauge
-  email: emile@vauge.com
-- name: dtomcej
-  email: daniel@containo.us
-- name: mmatur
-  email: michael@containo.us
+  - name: emilevauge
+    email: emile@vauge.com
+  - name: dtomcej
+    email: daniel@containo.us
+  - name: mmatur
+    email: michael@containo.us
 engine: gotpl
 icon: https://avatars0.githubusercontent.com/u/16349663?s=200&v=4
 dependencies:

--- a/helm/chart/maesh/templates/_helpers.tpl
+++ b/helm/chart/maesh/templates/_helpers.tpl
@@ -1,21 +1,21 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-Define the Chart version Label
+Define the Chart version Label.
 */}}
 {{- define "maesh.chartLabel" -}}
     {{- printf "%s-%s" .Chart.Name .Chart.Version -}}
 {{- end -}}
 
 {{/*
-Define the templated image with tag
+Define the templated image with tag.
 */}}
 {{- define "maesh.image" -}}
     {{- printf "%s:%s" .Values.image.name ( .Values.image.tag | default .Chart.AppVersion ) -}}
 {{- end -}}
 
 {{/*
-Define the ignoreNamespaces List
+Define the ignoreNamespaces List.
 */}}
 {{- define "maesh.controllerIgnoreNamespaces" -}}
     --ignoreNamespaces=

--- a/helm/chart/maesh/templates/controller/controller-deployment.yaml
+++ b/helm/chart/maesh/templates/controller/controller-deployment.yaml
@@ -64,8 +64,8 @@ spec:
           image: {{ include "maesh.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           args:
-            {{- if .Values.controller.logLevel }}
-            - "--logLevel={{ .Values.controller.logLevel }}"
+            {{- if or .Values.controller.logLevel .Values.logLevel }}
+            - "--logLevel={{ or .Values.controller.logLevel .Values.logLevel }}"
             {{- end }}
             {{- if .Values.mesh.defaultMode }}
             - "--defaultMode={{ .Values.mesh.defaultMode }}"
@@ -108,8 +108,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent"}}
           args:
             - "prepare"
-            {{- if .Values.controller.logLevel }}
-            - "--logLevel={{ .Values.controller.logLevel }}"
+            {{- if or .Values.controller.logLevel .Values.logLevel }}
+            - "--logLevel={{ or .Values.controller.logLevel .Values.logLevel }}"
             {{- end }}
             {{- if .Values.acl }}
             - "--acl"

--- a/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
+++ b/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
@@ -115,8 +115,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           args:
             - "cleanup"
-            {{- if .Values.controller.logLevel }}
-            - "--logLevel={{ .Values.controller.logLevel }}"
+            {{- if or .Values.controller.logLevel .Values.logLevel }}
+            - "--logLevel={{ or .Values.controller.logLevel .Values.logLevel }}"
             {{- end }}
             - "--namespace={{ .Release.Namespace }}"
           securityContext:

--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -171,8 +171,8 @@ spec:
             - "--serversTransport.forwardingTimeouts.idleConnTimeout={{ .Values.mesh.forwardingTimeouts.idleConnTimeout }}"
               {{- end }}
             {{- end }}
-            {{- if .Values.mesh.logLevel }}
-            - "--log.level={{ .Values.mesh.logLevel }}"
+            {{- if or .Values.mesh.logLevel .Values.logLevel }}
+            - "--log.level={{ or .Values.mesh.logLevel .Values.logLevel }}"
             {{- end }}
             {{- if .Values.metrics.prometheus.enabled }}
             - "--metrics.prometheus"

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -14,6 +14,8 @@ image:
 
 # clusterDomain: cluster.local
 
+# logLevel: error
+
 limits:
   http: 10
   tcp: 25


### PR DESCRIPTION
## What does this PR do?

This PR:

- Adds missing dots to Helm comments.
- Formats and adds properties to Helm `Chart.yaml`.
- Adds a Helm option to configure the `logLevel` globally (the `logLevel` defined for the controller or mesh component has precedence).

Fixes #560.