### PR TITLE
Patch our CoreDNS implementation in kube-dns mode

### DIFF
--- a/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
@@ -26,22 +26,4 @@ data:
         reload
         loadbalance
     }
-
-    maesh:53 {
-        errors
-        rewrite continue {
-            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh {{ .Release.Namespace }}-{1}-6d61657368-{2}.{{ .Release.Namespace }}.svc.{{ default "cluster.local" .Values.clusterDomain }}
-            answer name {{ .Release.Namespace }}-([a-zA-Z0-9-_]*)-6d61657368-([a-zA-Z0-9-_]*)\.{{ .Release.Namespace }}\.svc\.{{ default "cluster.local" .Values.clusterDomain | replace "." "\\." }} {1}.{2}.maesh
-        }
-        kubernetes {{ default "cluster.local" .Values.clusterDomain }} in-addr.arpa ip6.arpa {
-            pods insecure
-            upstream
-            fallthrough in-addr.arpa ip6.arpa
-        }
-        forward . /etc/resolv.conf
-        cache 30
-        loop
-        reload
-        loadbalance
-    }
 {{- end }}

--- a/integration/testdata/kubedns/coredns.yaml
+++ b/integration/testdata/kubedns/coredns.yaml
@@ -68,23 +68,6 @@ data:
         loadbalance
     }
 
-    maesh:53 {
-        errors
-        rewrite continue {
-            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.maesh maesh-{1}-6d61657368-{2}.maesh.svc.cluster.local
-            answer name maesh-([a-zA-Z0-9-_]*)-6d61657368-([a-zA-Z0-9-_]*)\.maesh\.svc\.cluster\.local {1}.{2}.maesh
-        }
-        kubernetes cluster.local in-addr.arpa ip6.arpa {
-            pods insecure
-            upstream
-            fallthrough in-addr.arpa ip6.arpa
-        }
-        forward . /etc/resolv.conf
-        cache 30
-        loop
-        reload
-        loadbalance
-    }
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -117,7 +117,7 @@ func TestConfigureCoreDNS(t *testing.T) {
 			log.SetOutput(os.Stdout)
 			log.SetLevel(logrus.DebugLevel)
 			client := NewClient(log, clt)
-			err := client.ConfigureCoreDNS("titi", "toto")
+			err := client.ConfigureCoreDNS("kube-system", "titi", "toto")
 			if test.expectedErr {
 				assert.Error(t, err)
 				return
@@ -172,7 +172,7 @@ func TestConfigureKubeDNS(t *testing.T) {
 			log.SetOutput(os.Stdout)
 			log.SetLevel(logrus.DebugLevel)
 			client := NewClient(log, clt)
-			err := client.ConfigureKubeDNS("maesh")
+			err := client.ConfigureKubeDNS("cluster.local", "maesh")
 			if test.expectedErr {
 				assert.Error(t, err)
 				return

--- a/pkg/dns/testdata/configurekubedns_already_patched.yaml
+++ b/pkg/dns/testdata/configurekubedns_already_patched.yaml
@@ -23,3 +23,50 @@ metadata:
   namespace: maesh
 spec:
   clusterIP: "1.2.3.4"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: maesh
+spec:
+  template:
+    spec:
+      volumes:
+        - configMap:
+            name: "other-cfgmap"
+        - configMap:
+            name: "coredns-cfgmap"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: other-cfgmap
+  namespace: maesh
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-cfgmap
+  namespace: maesh
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health {
+            lameduck 5s
+        }
+        ready
+        kubernetes {{ pillar['dns_domain'] }} in-addr.arpa ip6.arpa {
+            pods insecure
+            fallthrough in-addr.arpa ip6.arpa
+            ttl 30
+        }
+        prometheus :9153
+        forward . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+  

--- a/pkg/dns/testdata/configurekubedns_not_patched.yaml
+++ b/pkg/dns/testdata/configurekubedns_not_patched.yaml
@@ -23,3 +23,49 @@ metadata:
   namespace: maesh
 spec:
   clusterIP: "1.2.3.4"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: maesh
+spec:
+  template:
+    spec:
+      volumes:
+        - configMap:
+            name: "other-cfgmap"
+        - configMap:
+            name: "coredns-cfgmap"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: other-cfgmap
+  namespace: maesh
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-cfgmap
+  namespace: maesh
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health {
+            lameduck 5s
+        }
+        ready
+        kubernetes {{ pillar['dns_domain'] }} in-addr.arpa ip6.arpa {
+            pods insecure
+            fallthrough in-addr.arpa ip6.arpa
+            ttl 30
+        }
+        prometheus :9153
+        forward . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }

--- a/pkg/prepare/prepare.go
+++ b/pkg/prepare/prepare.go
@@ -11,6 +11,7 @@ import (
 	specsinformer "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/specs/informers/externalversions"
 	splitinformer "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/informers/externalversions"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
@@ -124,13 +125,13 @@ func (p *Prepare) CheckDNSProvider() (dns.Provider, error) {
 }
 
 // ConfigureCoreDNS patches the CoreDNS configuration for Maesh.
-func (p *Prepare) ConfigureCoreDNS(clusterDomain, maeshNamespace string) error {
-	return p.dns.ConfigureCoreDNS(clusterDomain, maeshNamespace)
+func (p *Prepare) ConfigureCoreDNS(coreDNSNamespace, clusterDomain, maeshNamespace string) error {
+	return p.dns.ConfigureCoreDNS(coreDNSNamespace, clusterDomain, maeshNamespace)
 }
 
 // ConfigureKubeDNS patches the KubeDNS configuration for Maesh.
-func (p *Prepare) ConfigureKubeDNS(maeshNamespace string) error {
-	return p.dns.ConfigureKubeDNS(maeshNamespace)
+func (p *Prepare) ConfigureKubeDNS(clusterDomain, maeshNamespace string) error {
+	return p.dns.ConfigureKubeDNS(clusterDomain, maeshNamespace)
 }
 
 // ConfigureDNS configures and patches the DNS system.
@@ -142,11 +143,11 @@ func (p *Prepare) ConfigureDNS(clusterDomain, maeshNamespace string) error {
 
 	switch provider {
 	case dns.CoreDNS:
-		if err := p.ConfigureCoreDNS(clusterDomain, maeshNamespace); err != nil {
+		if err := p.ConfigureCoreDNS(metav1.NamespaceSystem, clusterDomain, maeshNamespace); err != nil {
 			return fmt.Errorf("unable to configure CoreDNS: %v", err)
 		}
 	case dns.KubeDNS:
-		if err := p.ConfigureKubeDNS(maeshNamespace); err != nil {
+		if err := p.ConfigureKubeDNS(clusterDomain, maeshNamespace); err != nil {
 			return fmt.Errorf("unable to configure KubeDNS: %v", err)
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

This PR:

- Modifies the `ConfigureCoreDNS` method to allow for a specified namespace within which to patch CoreDNS
- Leverages the above method to modify our custom coreDNS implementation when kubeDNS is used.

Fixes #593 

## Additional Notes

By patching our own coreDNS, we still have to restart the pods, and do incur a small delay before the DNS resolution is ready, but that is minimal.