### PR TITLE
Update values.yaml

### DIFF
--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -73,7 +73,7 @@ tracing:
   deploy: true
   jaeger:
     image:
-      name: groundnuty/k8s-wait-for:v1.2
+      name: groundnuty/k8s-wait-for:v1.3
     enabled: true
     localagenthostport: ""
     samplingserverurl: ""


### PR DESCRIPTION
fixes issue where a non-existent jaeger agent service will pass this init check - see: https://github.com/groundnuty/k8s-wait-for/issues/18

## What does this PR do?

This PR: 

- fixes issue with k8s-wait-for where a non-existent service will cause the init container to return 0 instead of waiting for the service to exist (and be-alive)

updated k8s-wait-for to v1.3, which addresses the issue as noted in https://github.com/groundnuty/k8s-wait-for/issues/18