### PR TITLE
Fix jaeger init container

### DIFF
--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         prometheus.io/port: "8080"
     spec:
       serviceAccountName: maesh-mesh
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 999
@@ -48,7 +48,9 @@ spec:
         - name: wait-for-jaeger-init
           image: {{ .Values.tracing.jaeger.image.name | quote }}
           imagePullPolicy: {{ .Values.tracing.jaeger.image.pullPolicy | default "IfNotPresent" }}
-          args: ["service", "-lapp.kubernetes.io/name=jaeger-agent"]
+          args:
+            - "service"
+            - "-lapp.kubernetes.io/name=jaeger,app.kubernetes.io/component=agent"
           resources:
             requests:
               memory: "10Mi"

--- a/helm/chart/maesh/templates/mesh/mesh-rbac.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-rbac.yaml
@@ -1,0 +1,38 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: maesh-mesh-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name | quote}}
+    chart: {{ include "maesh.chartLabel" . | quote}}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+    verbs:
+      - list
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: maesh-mesh
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name | quote}}
+    chart: {{ include "maesh.chartLabel" . | quote}}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: maesh-mesh-role
+subjects:
+  - kind: ServiceAccount
+    name: maesh-mesh
+    namespace: {{ .Release.Namespace }}

--- a/helm/chart/maesh/templates/mesh/mesh-sa.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-sa.yaml
@@ -9,4 +9,3 @@ metadata:
     chart: {{ include "maesh.chartLabel" . | quote}}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-automountServiceAccountToken: false


### PR DESCRIPTION
## What does this PR do?

This PR:

- Fixes the `mesh` pods startup.
- Fixes the labels used to check that the `jaeger-agent` service is ready.
- Adds the missing rights to the `mesh` pods to allow `jaeger-agent` readiness check.

## Additional Notes

- This bug is a side effect of #609 because `k8s-wait-for` is now working properly. 
- It's not necessary to add the `namespace` to the check because the `jaeger-agent` service is in the Maesh namespace.
