### PR TITLE
Add Helm keys to configure annotations for mesh deployment and pods

### DIFF
--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -9,10 +9,10 @@ metadata:
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-    {{- with .Values.mesh.annotations }}
+  {{- with .Values.mesh.annotations }}
   annotations:
 {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    {{- with .Values.mesh.annotations }}
+  annotations:
+{{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -24,6 +28,9 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
+        {{- with .Values.mesh.podAnnotations }}
+{{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: maesh-mesh
       automountServiceAccountToken: true

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -65,6 +65,10 @@ mesh:
   # Added so we can launch on nodes with restrictions
   nodeSelector: {}
   tolerations: []
+  # Additional deployment annotations (e.g. for jaeger-operator sidecar injection)
+  annotations: {}
+  # Additional pod annotations (e.g. for mesh injection or prometheus scraping)
+  podAnnotations: {}
 
 #
 # Tracing configuration

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -65,10 +65,12 @@ mesh:
   # Added so we can launch on nodes with restrictions
   nodeSelector: {}
   tolerations: []
-  # Additional deployment annotations (e.g. for jaeger-operator sidecar injection)
-  annotations: {}
-  # Additional pod annotations (e.g. for mesh injection or prometheus scraping)
-  podAnnotations: {}
+  # Additional deployment annotations
+  # (Optional)
+  # annotations: {}
+  # Additional pod annotations
+  # (Optional)
+  # podAnnotations: {}
 
 #
 # Tracing configuration


### PR DESCRIPTION
## What does this PR do?

This PR:

- Adds configurable annotations for Mesh deployment, and mesh pods

Fixes #612 
