### PR TITLE
Move the defaultMode Helm key to be global

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -30,9 +30,6 @@ You will then be able to use the tagged image as your image in your `values.yaml
 
 ### Deploy Helm Chart
 
-??? Note "Helm V3"
-    Please keep in mind, that our current Helm Chart (v1.1.0) is v3 compatible only.
-
 To deploy the Helm Chart, run:
 
 ```shell

--- a/docs/content/migration/helm-chart.md
+++ b/docs/content/migration/helm-chart.md
@@ -21,7 +21,9 @@ and `mesh.logLevel` options to configure the logging level for the controller an
 The `smi.enable` option has been deprecated and removed. You should use the new and backward compatible ACL mode 
 option as described in the [documentation](../install.md#access-control-list). 
 
+## v2.0 to v2.1
+
 ### Default Mode
 
-The `controller.mesh.defaultMode` option has been removed. You should use the new `defaultMode` option to configure
- the default traffic mode for Maesh services.
+The `controller.mesh.defaultMode` option has been deprecated and will be removed in a future major release.
+You should use the new `defaultMode` option to configure the default traffic mode for Maesh services.

--- a/docs/content/migration/helm-chart.md
+++ b/docs/content/migration/helm-chart.md
@@ -20,3 +20,8 @@ and `mesh.logLevel` options to configure the logging level for the controller an
 
 The `smi.enable` option has been deprecated and removed. You should use the new and backward compatible ACL mode 
 option as described in the [documentation](../install.md#access-control-list). 
+
+### Default Mode
+
+The `controller.mesh.defaultMode` option has been removed. You should use the new `defaultMode` option to configure
+ the default traffic mode for Maesh services.

--- a/helm/chart/maesh/templates/controller/controller-deployment.yaml
+++ b/helm/chart/maesh/templates/controller/controller-deployment.yaml
@@ -70,8 +70,8 @@ spec:
             {{- if or .Values.controller.logFormat .Values.logFormat }}
             - "--logFormat={{ or .Values.controller.logFormat .Values.logFormat }}"
             {{- end }}
-            {{- if .Values.mesh.defaultMode }}
-            - "--defaultMode={{ .Values.mesh.defaultMode }}"
+            {{- if or .Values.mesh.defaultMode .Values.defaultMode }}
+            - "--defaultMode={{ or .Values.mesh.defaultMode .Values.defaultMode }}"
             {{- end }}
             {{- if .Values.acl }}
             - "--acl"

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -17,6 +17,8 @@ image:
 # logLevel: error
 # logFormat: common
 
+# defaultMode: http
+
 limits:
   http: 10
   tcp: 25
@@ -42,6 +44,7 @@ controller:
   affinity: {}
 
 mesh:
+  # (Deprecated)
   # defaultMode: http
   # logLevel: error
   # logFormat: common


### PR DESCRIPTION
## What does this PR do?

This PR:

- Moves the defaultMode configuration to be global

Fixes #605


## Additional Notes

We may want to introduce a `global` key similar to Traefik's config, to handle these values, as they seem to be piling up.