### PR TITLE
Ignore ExternalName services

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -18,7 +18,6 @@ import (
 	splitlister "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/listers/split/v1alpha2"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -296,14 +295,7 @@ func (c *Controller) loadPortMappersState() error {
 
 // isWatchedResource returns true if the given resource is not ignored, false otherwise.
 func (c *Controller) isWatchedResource(obj interface{}) bool {
-	accessor, err := meta.Accessor(obj)
-	if err != nil {
-		return false
-	}
-
-	pMeta := meta.AsPartialObjectMetadata(accessor)
-
-	return !c.ignoredResources.IsIgnored(pMeta.ObjectMeta)
+	return !c.ignoredResources.IsIgnored(obj)
 }
 
 // runWorker is a long-running function that will continually call the processNextWorkItem function in order to read and

--- a/pkg/k8s/ignore.go
+++ b/pkg/k8s/ignore.go
@@ -1,9 +1,8 @@
 package k8s
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 )
 
 // IgnoreWrapper holds namespaces and services to ignore.
@@ -37,41 +36,36 @@ func (i *IgnoreWrapper) AddIgnoredApps(app ...string) {
 	i.Apps = append(i.Apps, app...)
 }
 
-// LabelSelector returns the labels.Selector image of the ignored object.
-func (i *IgnoreWrapper) LabelSelector() (labels.Selector, error) {
-	sel := labels.Everything()
-
-	r, err := labels.NewRequirement("app", selection.NotIn, i.Apps)
-	if err != nil {
-		return nil, err
-	}
-
-	sel = sel.Add(*r)
-
-	return sel, nil
-}
-
 // IsIgnored returns if the object events should be ignored.
-func (i *IgnoreWrapper) IsIgnored(obj metav1.ObjectMeta) bool {
+func (i *IgnoreWrapper) IsIgnored(obj interface{}) bool {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return false
+	}
+
+	pMeta := meta.AsPartialObjectMetadata(accessor)
+
 	// Is the object's namespace ignored?
-	if i.Namespaces.Contains(obj.GetNamespace()) {
+	if i.Namespaces.Contains(pMeta.GetNamespace()) {
 		return true
 	}
 
-	// Is the object explicitly ignored?
-	if i.Services.Contains(obj.GetName(), obj.GetNamespace()) {
+	// Is the app ignored?
+	if contains(i.Apps, pMeta.GetLabels()["app"]) {
 		return true
 	}
 
-	// Is the app ignored ?
-	if contains(i.Apps, obj.GetLabels()["app"]) {
-		return true
+	if svc, ok := obj.(*corev1.Service); ok {
+		// Is the object explicitly ignored?
+		if i.Services.Contains(pMeta.GetName(), pMeta.GetNamespace()) {
+			return true
+		}
+
+		// Ignore ExternalName services.
+		if svc.Spec.Type == corev1.ServiceTypeExternalName {
+			return true
+		}
 	}
 
 	return false
-}
-
-// IsIgnoredNamespace returns if the service's events should be ignored.
-func (i *IgnoreWrapper) IsIgnoredNamespace(namespace string) bool {
-	return i.Namespaces.Contains(namespace)
 }

--- a/pkg/k8s/ignore.go
+++ b/pkg/k8s/ignore.go
@@ -40,7 +40,7 @@ func (i *IgnoreWrapper) AddIgnoredApps(app ...string) {
 func (i *IgnoreWrapper) IsIgnored(obj interface{}) bool {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
-		return false
+		return true
 	}
 
 	pMeta := meta.AsPartialObjectMetadata(accessor)

--- a/pkg/k8s/ignore.go
+++ b/pkg/k8s/ignore.go
@@ -36,7 +36,7 @@ func (i *IgnoreWrapper) AddIgnoredApps(app ...string) {
 	i.Apps = append(i.Apps, app...)
 }
 
-// IsIgnored returns if the object events should be ignored.
+// IsIgnored returns true if the object events should be ignored.
 func (i *IgnoreWrapper) IsIgnored(obj interface{}) bool {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
@@ -56,7 +56,7 @@ func (i *IgnoreWrapper) IsIgnored(obj interface{}) bool {
 	}
 
 	if svc, ok := obj.(*corev1.Service); ok {
-		// Is the object explicitly ignored?
+		// Is the service explicitly ignored?
 		if i.Services.Contains(pMeta.GetName(), pMeta.GetNamespace()) {
 			return true
 		}

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -620,7 +620,7 @@ func (b *Builder) loadServices(ignoredResources mk8s.IgnoreWrapper, res *resourc
 	}
 
 	for _, svc := range svcs {
-		if ignoredResources.IsIgnored(svc.ObjectMeta) {
+		if ignoredResources.IsIgnored(svc) {
 			continue
 		}
 
@@ -656,7 +656,7 @@ func (r *resources) indexPods(ignoredResources mk8s.IgnoreWrapper, pods []*corev
 
 func (r *resources) indexPodsByServiceAccount(ignoredResources mk8s.IgnoreWrapper, pods []*corev1.Pod, podsByName map[Key]*corev1.Pod) {
 	for _, pod := range pods {
-		if ignoredResources.IsIgnored(pod.ObjectMeta) {
+		if ignoredResources.IsIgnored(pod) {
 			continue
 		}
 
@@ -670,7 +670,7 @@ func (r *resources) indexPodsByServiceAccount(ignoredResources mk8s.IgnoreWrappe
 
 func (r *resources) indexPodsByService(ignoredResources mk8s.IgnoreWrapper, eps []*corev1.Endpoints, podsByName map[Key]*corev1.Pod) {
 	for _, ep := range eps {
-		if ignoredResources.IsIgnored(ep.ObjectMeta) {
+		if ignoredResources.IsIgnored(ep) {
 			continue
 		}
 
@@ -707,7 +707,7 @@ func (r *resources) indexPodByService(ep *corev1.Endpoints, address corev1.Endpo
 
 func (r *resources) indexSMIResources(ignoredResources mk8s.IgnoreWrapper, tts []*access.TrafficTarget, tss []*split.TrafficSplit, tcpRts []*spec.TCPRoute, httpRtGrps []*spec.HTTPRouteGroup) {
 	for _, httpRouteGroup := range httpRtGrps {
-		if ignoredResources.IsIgnored(httpRouteGroup.ObjectMeta) {
+		if ignoredResources.IsIgnored(httpRouteGroup) {
 			continue
 		}
 
@@ -716,7 +716,7 @@ func (r *resources) indexSMIResources(ignoredResources mk8s.IgnoreWrapper, tts [
 	}
 
 	for _, tcpRoute := range tcpRts {
-		if ignoredResources.IsIgnored(tcpRoute.ObjectMeta) {
+		if ignoredResources.IsIgnored(tcpRoute) {
 			continue
 		}
 
@@ -725,7 +725,7 @@ func (r *resources) indexSMIResources(ignoredResources mk8s.IgnoreWrapper, tts [
 	}
 
 	for _, trafficTarget := range tts {
-		if ignoredResources.IsIgnored(trafficTarget.ObjectMeta) {
+		if ignoredResources.IsIgnored(trafficTarget) {
 			continue
 		}
 
@@ -739,7 +739,7 @@ func (r *resources) indexSMIResources(ignoredResources mk8s.IgnoreWrapper, tts [
 	}
 
 	for _, trafficSplit := range tss {
-		if ignoredResources.IsIgnored(trafficSplit.ObjectMeta) {
+		if ignoredResources.IsIgnored(trafficSplit) {
 			continue
 		}
 


### PR DESCRIPTION
## What does this PR do?

This PR update the IgnoreWrapper so it ignores Services of type `ExternalName`.

Fixes #618 

In the same time, I fixed an issue in the IgnoredWrapper on the way we handled ignored services. We weren't checking the type of the object, so if a pod had the same name as an ignored service we would have ignored it.

Some deadcode have also been removed.

### How to test it

- `make test`