### PR TITLE
Support env, envFrom and additional args for mesh proxies in Helm chart

### DIFF
--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -70,6 +70,14 @@ spec:
         - name: maesh-mesh
           image: {{ include "maesh.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          {{- with .Values.mesh.env }}
+          env:
+{{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.mesh.envFrom }}
+          envFrom:
+{{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - "proxy"
             - "--entryPoints.readiness.address=:1081"

--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -257,6 +257,11 @@ spec:
             - "--metrics.statsd.pushInterval={{ .Values.metrics.statsd.pushInterval }}"
               {{- end }}
             {{- end }}
+            {{- with .Values.mesh.additionalArguments }}
+            {{- range . }}
+            - {{ . | quote }}
+            {{- end }}
+            {{- end }}
           ports:
             - name: readiness
               containerPort: 1081

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -69,6 +69,9 @@ mesh:
   #   - configMapRef:
   #       name: config
 
+  # additionalArguments:
+  #   - "--name=value"
+
   resources:
     limit:
       mem: 100Mi

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -56,6 +56,12 @@ mesh:
   #   responseHeaderTimeout: 0s
   #   (Optional)
   #   idleConnTimeout: 1s
+  # env:
+  #   - name: NAME
+  #     value: "value"
+  # envFrom:
+  #   - configMapRef:
+  #       name: config
 
   resources:
     limit:

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -1,4 +1,4 @@
-## Default values for maesh
+# Default values for Maesh.
 image:
   name: containous/maesh
   # (Optional)
@@ -39,7 +39,7 @@ controller:
       mem: 50Mi
       cpu: 100m
 
-  # Added so we can launch on nodes with restrictions
+  # Added so we can launch on nodes with restrictions.
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -77,18 +77,18 @@ mesh:
       mem: 50Mi
       cpu: 100m
 
-  # Added so we can launch on nodes with restrictions
+  # Added so we can launch on nodes with restrictions.
   nodeSelector: {}
   tolerations: []
 
-  # Additional deployment annotations
+  # Additional deployment annotations.
   # annotations: {}
 
-  # Additional pod annotations
+  # Additional pod annotations.
   # podAnnotations: {}
 
 #
-# Tracing configuration
+# Tracing configuration.
 #
 tracing:
   deploy: true
@@ -133,7 +133,7 @@ tracing:
     # baggagePrefixHeaderName: "sample"
 
 #
-# Metrics configuration
+# Metrics configuration.
 #
 metrics:
   deploy: true

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -27,6 +27,7 @@ limits:
 controller:
   # logLevel: error
   # logFormat: common
+
   # ignoreNamespaces:
   #  - example
 
@@ -46,19 +47,24 @@ controller:
 mesh:
   # (Deprecated)
   # defaultMode: http
+
   # logLevel: error
   # logFormat: common
+
   # pollInterval: 1s
   # pollTimeout: 1s
+
   # forwardingTimeouts:
   #   dialTimeout: 30s
   #   (Optional)
   #   responseHeaderTimeout: 0s
   #   (Optional)
   #   idleConnTimeout: 1s
+
   # env:
   #   - name: NAME
   #     value: "value"
+
   # envFrom:
   #   - configMapRef:
   #       name: config
@@ -74,11 +80,11 @@ mesh:
   # Added so we can launch on nodes with restrictions
   nodeSelector: {}
   tolerations: []
+
   # Additional deployment annotations
-  # (Optional)
   # annotations: {}
+
   # Additional pod annotations
-  # (Optional)
   # podAnnotations: {}
 
 #


### PR DESCRIPTION
## What does this PR do?

This PR:

- Adds `env` and `envFrom` config options to Helm chart for mesh proxies.
- Adds `additionalArguments` config options to the Helm chart for mesh proxies.
- Adds some empty lines to the `values.yml` to increase readability.

Fixes #621, #617