### PR TITLE
Stop wrapping nil error when patching DNS

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -77,7 +77,7 @@ func (c *Client) CheckDNSProvider() (Provider, error) {
 		return KubeDNS, nil
 	}
 
-	return UnknownDNS, fmt.Errorf("no supported DNS service available for installing maesh: %w", err)
+	return UnknownDNS, errors.New("no supported DNS service available for installing maesh")
 }
 
 func (c *Client) coreDNSMatch() (bool, error) {


### PR DESCRIPTION
## What does this PR do?

This PR:
- Returns an `errors.New` instead of wrapping a nil error in the log message
> no supported DNS service available for installing maesh: %w

Fixes #633

### How to test it

* `make test`
* Install Maesh without coredns:
```
k3d create --server-arg --no-deploy="traefik" --server-arg --no-deploy=coredns
```
* Install Maesh using helm
* Log at the logs of the init container


Once fixed, the output become:
```
$> kubectl logs -n maesh pod/maesh-controller-7577cdfdb-f6j8t -c maesh-prepare
time="2020-06-16T08:45:11Z" level=info msg="Configuration loaded from flags."
time="2020-06-16T08:45:11Z" level=debug msg="Starting maesh prepare..."
time="2020-06-16T08:45:11Z" level=debug msg="Using masterURL: \"\""
time="2020-06-16T08:45:11Z" level=debug msg="Using kubeconfig: \"\""
time="2020-06-16T08:45:11Z" level=info msg="Creating in-cluster client"
time="2020-06-16T08:45:11Z" level=debug msg="Building Kubernetes Client..."
time="2020-06-16T08:45:11Z" level=debug msg="Building SMI Access Client..."
time="2020-06-16T08:45:11Z" level=debug msg="Building SMI Specs Client..."
time="2020-06-16T08:45:11Z" level=debug msg="Building SMI Split Client..."
time="2020-06-16T08:45:11Z" level=debug msg="ACL mode enabled: true"
time="2020-06-16T08:45:12Z" level=info msg="Checking DNS provider"
time="2020-06-16T08:45:12Z" level=info msg="Checking CoreDNS"
time="2020-06-16T08:45:12Z" level=debug msg="CoreDNS deployment does not exist in namespace \"kube-system\""
time="2020-06-16T08:45:12Z" level=info msg="Checking KubeDNS"
time="2020-06-16T08:45:12Z" level=debug msg="KubeDNS deployment does not exist in namespace \"kube-system\""
2020/06/16 08:45:12 command prepare error: unable to configure DNS: error during cluster check: no supported DNS service available for installing maesh
```