### PR TITLE
Stop accepting multiple TrafficSplits or both TrafficSplit and TrafficTarget on the same Service

### DIFF
--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -59,7 +59,7 @@ func (b *Builder) Build(resourceFilter *mk8s.ResourceFilter) (*Topology, error) 
 	return topology, nil
 }
 
-// evaluateService evaluates the given service. It adds the Service to the topology and it's selected Pods.
+// evaluateService evaluates the given service. It adds the Service to the topology and its selected Pods.
 func (b *Builder) evaluateService(res *resources, topology *Topology, svc *corev1.Service) {
 	svcKey := Key{svc.Name, svc.Namespace}
 
@@ -104,10 +104,10 @@ func (b *Builder) evaluateTrafficTarget(res *resources, topology *Topology, tt *
 		}
 
 		svc, ok := topology.Services[svcKey]
-		// In the current version of the spec, the traffic will always go to a TrafficSplit. So we don't need to evaluate
-		// Pods if there's already a TrafficSplit on the Service.
+		// Since in the current version of the spec, the traffic will always go to a TrafficSplit, we don't need to evaluate
+		// Pods if there is already a TrafficSplit on the Service.
 		if ok && len(svc.TrafficSplits) > 0 {
-			b.Logger.Warnf("Service %q already has a TrafficSplit attached, TrafficTarget %q won't be evaluated on this service", svcKey, svcTTKey.TrafficTarget)
+			b.Logger.Warnf("Service %q already has a TrafficSplit attached, TrafficTarget %q will not be evaluated on this service", svcKey, svcTTKey.TrafficTarget)
 
 			return
 		}
@@ -177,7 +177,7 @@ func (b *Builder) buildTrafficTargetDestination(topology *Topology, tt *access.T
 func addSourceAndDestinationToPods(topology *Topology, sources []ServiceTrafficTargetSource, svcTTKey ServiceTrafficTargetKey) {
 	for _, source := range sources {
 		for _, podKey := range source.Pods {
-			// Skip pods which haven't been added to the topology.
+			// Skip pods which have not been added to the topology.
 			if _, ok := topology.Pods[podKey]; !ok {
 				continue
 			}
@@ -187,7 +187,7 @@ func addSourceAndDestinationToPods(topology *Topology, sources []ServiceTrafficT
 	}
 
 	for _, podKey := range topology.ServiceTrafficTargets[svcTTKey].Destination.Pods {
-		// Skip pods which haven't been added to the topology.
+		// Skip pods which have not been added to the topology.
 		if _, ok := topology.Pods[podKey]; !ok {
 			continue
 		}
@@ -209,9 +209,9 @@ func (b *Builder) evaluateTrafficSplit(topology *Topology, trafficSplit *split.T
 	tsKey := Key{trafficSplit.Name, trafficSplit.Namespace}
 
 	svc, ok := topology.Services[svcKey]
-	// The current version of the spec doesn't support having more than one TrafficSplit attached to a service.
+	// The current version of the spec does not support having more than one TrafficSplit attached to the same service.
 	if ok && len(svc.TrafficSplits) > 0 {
-		b.Logger.Warnf("Service %q already has a TrafficSplit attached, TrafficSplit %q won't be evaluated", svcKey, tsKey)
+		b.Logger.Warnf("Service %q already has a TrafficSplit attached, TrafficSplit %q will not be evaluated", svcKey, tsKey)
 
 		return
 	}

--- a/pkg/topology/builder_test.go
+++ b/pkg/topology/builder_test.go
@@ -286,6 +286,7 @@ func TestTopologyBuilder_EvaluatesIncomingTrafficSplit(t *testing.T) {
 	incoming := got.TrafficSplits[tsKeys[0]].Incoming
 
 	assert.Equal(t, 1, len(incoming))
+
 	if tsKeys[0].Name == "ts2" {
 		assert.Equal(t, "10.10.1.2", got.Pods[incoming[0]].IP)
 	} else {

--- a/pkg/topology/builder_test.go
+++ b/pkg/topology/builder_test.go
@@ -212,6 +212,8 @@ func TestTopologyBuilder_TrafficTargetSourcesForbiddenTrafficSplit(t *testing.T)
 	assert.Equal(t, 0, len(got.TrafficSplits[tsKey].Incoming))
 }
 
+// TestTopologyBuilder_EvaluatesIncomingTrafficSplit makes sure a topology can be built with TrafficSplits. It also
+// checks that if multiple TrafficSplits are applied to the same Service, only one will be used.
 func TestTopologyBuilder_EvaluatesIncomingTrafficSplit(t *testing.T) {
 	selectorAppA := map[string]string{"app": "app-a"}
 	selectorAppB := map[string]string{"app": "app-b"}
@@ -277,24 +279,61 @@ func TestTopologyBuilder_EvaluatesIncomingTrafficSplit(t *testing.T) {
 	svcKey := nn(svcB.Name, svcB.Namespace)
 	tsKeys := got.Services[svcKey].TrafficSplits
 
-	assert.Equal(t, 1, len(got.TrafficSplits[tsKeys[0]].Incoming))
-	assert.Equal(t, 1, len(got.TrafficSplits[tsKeys[1]].Incoming))
+	// Make sure only one TrafficSplit will be present.
+	assert.Len(t, tsKeys, 1)
+	assert.Len(t, got.TrafficSplits, 1)
 
-	for _, tsKey := range tsKeys {
-		ts := got.TrafficSplits[tsKey]
-		pod := got.Pods[ts.Incoming[0]]
+	incoming := got.TrafficSplits[tsKeys[0]].Incoming
 
-		if ts.Name == "ts2" {
-			assert.Equal(t, "10.10.1.2", pod.IP)
-		} else {
-			assert.Equal(t, "10.10.1.1", pod.IP)
-		}
+	assert.Equal(t, 1, len(incoming))
+	if tsKeys[0].Name == "ts2" {
+		assert.Equal(t, "10.10.1.2", got.Pods[incoming[0]].IP)
+	} else {
+		assert.Equal(t, "10.10.1.1", got.Pods[incoming[0]].IP)
 	}
 }
 
-// TestTopologyBuilder_BuildWithTrafficTargetAndTrafficSplit makes sure the topology can be built with TrafficTargets
-// and TrafficSplits.
-func TestTopologyBuilder_BuildWithTrafficTargetAndTrafficSplit(t *testing.T) {
+// TestTopologyBuilder_BuildWithTrafficTarget makes sure a topology can be built using TrafficTargets.
+func TestTopologyBuilder_BuildWithTrafficTarget(t *testing.T) {
+	selectorAppA := map[string]string{"app": "app-a"}
+	selectorAppB := map[string]string{"app": "app-b"}
+	annotations := map[string]string{}
+	svcPorts := []corev1.ServicePort{svcPort("port-8080", 8080, 8080)}
+
+	saA := createServiceAccount("my-ns", "service-account-a")
+	podA := createPod("my-ns", "app-a", saA, selectorAppA, "10.10.1.1")
+
+	saB := createServiceAccount("my-ns", "service-account-b")
+	svcB := createService("my-ns", "svc-b", annotations, svcPorts, selectorAppB, "10.10.1.16")
+	podB := createPod("my-ns", "app-b", saB, svcB.Spec.Selector, "10.10.2.1")
+
+	epB := createEndpoints(svcB, []*corev1.Pod{podB})
+
+	apiMatch := createHTTPMatch("api", []string{"GET", "POST"}, "/api")
+	metricMatch := createHTTPMatch("metric", []string{"GET"}, "/metric")
+	rtGrp := createHTTPRouteGroup("my-ns", "http-rt-grp", []spec.HTTPMatch{apiMatch, metricMatch})
+
+	ttMatch := []string{apiMatch.Name}
+	tt := createTrafficTarget("my-ns", "tt", saB, "8080", []*corev1.ServiceAccount{saA}, rtGrp, ttMatch)
+
+	k8sClient := fake.NewSimpleClientset(saA, saB, podA, podB, svcB, epB)
+	smiAccessClient := accessfake.NewSimpleClientset(tt)
+	smiSplitClient := splitfake.NewSimpleClientset()
+	smiSpecClient := specfake.NewSimpleClientset(rtGrp)
+
+	builder, err := createBuilder(k8sClient, smiAccessClient, smiSpecClient, smiSplitClient)
+	require.NoError(t, err)
+
+	resourceFilter := mk8s.NewResourceFilter()
+	got, err := builder.Build(resourceFilter)
+	require.NoError(t, err)
+
+	assertTopology(t, "testdata/topology-traffic-target.json", got)
+}
+
+// TestTopologyBuilder_BuildWithTrafficTargetAndTrafficSplitOnSameService makes sure a TrafficTarget won't be applied on
+// a service if there is already a TrafficSplit applied to it.
+func TestTopologyBuilder_BuildWithTrafficTargetAndTrafficSplitOnSameService(t *testing.T) {
 	selectorAppA := map[string]string{"app": "app-a"}
 	selectorAppB := map[string]string{"app": "app-b"}
 	selectorAppC := map[string]string{"app": "app-c"}
@@ -348,7 +387,7 @@ func TestTopologyBuilder_BuildWithTrafficTargetAndTrafficSplit(t *testing.T) {
 	got, err := builder.Build(resourceFilter)
 	require.NoError(t, err)
 
-	assertTopology(t, "testdata/topology-basic.json", got)
+	assertTopology(t, "testdata/topology-traffic-split-traffic-target.json", got)
 }
 
 // TestTopologyBuilder_BuildWithTrafficTargetSpecEmptyMatch makes sure that when TrafficTarget.Spec.Matches is empty,

--- a/pkg/topology/builder_test.go
+++ b/pkg/topology/builder_test.go
@@ -279,7 +279,7 @@ func TestTopologyBuilder_EvaluatesIncomingTrafficSplit(t *testing.T) {
 	svcKey := nn(svcB.Name, svcB.Namespace)
 	tsKeys := got.Services[svcKey].TrafficSplits
 
-	// Make sure only one TrafficSplit will be present.
+	// Make sure the resulting Topology only has a single TrafficSplit.
 	assert.Len(t, tsKeys, 1)
 	assert.Len(t, got.TrafficSplits, 1)
 

--- a/pkg/topology/testdata/topology-traffic-split-traffic-target.json
+++ b/pkg/topology/testdata/topology-traffic-split-traffic-target.json
@@ -1,0 +1,129 @@
+{
+  "services": {
+    "svc-b@my-ns": {
+      "name": "svc-b",
+      "namespace": "my-ns",
+      "selector": {
+        "app": "app-b"
+      },
+      "annotations": {
+        "maesh.containo.us/ratelimit-average": "100",
+        "maesh.containo.us/ratelimit-burst": "200",
+        "maesh.containo.us/traffic-type": "http"
+      },
+      "ports": [
+        {
+          "name": "port-8080",
+          "protocol": "TCP",
+          "port": 8080,
+          "targetPort": 8080
+        }
+      ],
+      "clusterIp": "10.10.1.16",
+      "pods": [
+        "app-b@my-ns"
+      ],
+      "trafficSplits": [
+        "ts@my-ns"
+      ]
+    },
+    "svc-c@my-ns": {
+      "name": "svc-c",
+      "namespace": "my-ns",
+      "selector": {
+        "app": "app-c"
+      },
+      "annotations": {
+        "maesh.containo.us/ratelimit-average": "100",
+        "maesh.containo.us/ratelimit-burst": "200",
+        "maesh.containo.us/traffic-type": "http"
+      },
+      "ports": [
+        {
+          "name": "port-8080",
+          "protocol": "TCP",
+          "port": 8080,
+          "targetPort": 8080
+        }
+      ],
+      "clusterIp": "10.10.1.17",
+      "pods": [
+        "app-c@my-ns"
+      ],
+      "backendOf": [
+        "ts@my-ns"
+      ]
+    },
+    "svc-d@my-ns": {
+      "name": "svc-d",
+      "namespace": "my-ns",
+      "selector": {
+        "app": "app-d"
+      },
+      "annotations": {
+        "maesh.containo.us/ratelimit-average": "100",
+        "maesh.containo.us/ratelimit-burst": "200",
+        "maesh.containo.us/traffic-type": "http"
+      },
+      "ports": [
+        {
+          "name": "port-8080",
+          "protocol": "TCP",
+          "port": 8080,
+          "targetPort": 8080
+        }
+      ],
+      "clusterIp": "10.10.1.18",
+      "pods": [
+        "app-d@my-ns"
+      ],
+      "backendOf": [
+        "ts@my-ns"
+      ]
+    }
+  },
+  "pods": {
+    "app-a@my-ns": {
+      "name": "app-a",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-a",
+      "ip": "10.10.1.1"
+    },
+    "app-b@my-ns": {
+      "name": "app-b",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-b",
+      "ip": "10.10.2.1"
+    },
+    "app-c@my-ns": {
+      "name": "app-c",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-c",
+      "ip": "10.10.2.2"
+    },
+    "app-d@my-ns": {
+      "name": "app-d",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-d",
+      "ip": "10.10.2.3"
+    }
+  },
+  "serviceTrafficTargets": {},
+  "trafficSplits": {
+    "ts@my-ns": {
+      "name": "ts",
+      "namespace": "my-ns",
+      "service": "svc-b@my-ns",
+      "backends": [
+        {
+          "weight": 80,
+          "service": "svc-c@my-ns"
+        },
+        {
+          "weight": 20,
+          "service": "svc-d@my-ns"
+        }
+      ]
+    }
+  }
+}

--- a/pkg/topology/testdata/topology-traffic-target.json
+++ b/pkg/topology/testdata/topology-traffic-target.json
@@ -6,11 +6,7 @@
       "selector": {
         "app": "app-b"
       },
-      "annotations": {
-        "maesh.containo.us/ratelimit-average": "100",
-        "maesh.containo.us/ratelimit-burst": "200",
-        "maesh.containo.us/traffic-type": "http"
-      },
+      "annotations": {},
       "ports": [
         {
           "name": "port-8080",
@@ -25,63 +21,6 @@
       ],
       "trafficTargets": [
         "svc-b@my-ns:tt@my-ns"
-      ],
-      "trafficSplits": [
-        "ts@my-ns"
-      ]
-    },
-    "svc-c@my-ns": {
-      "name": "svc-c",
-      "namespace": "my-ns",
-      "selector": {
-        "app": "app-c"
-      },
-      "annotations": {
-        "maesh.containo.us/ratelimit-average": "100",
-        "maesh.containo.us/ratelimit-burst": "200",
-        "maesh.containo.us/traffic-type": "http"
-      },
-      "ports": [
-        {
-          "name": "port-8080",
-          "protocol": "TCP",
-          "port": 8080,
-          "targetPort": 8080
-        }
-      ],
-      "clusterIp": "10.10.1.17",
-      "pods": [
-        "app-c@my-ns"
-      ],
-      "backendOf": [
-        "ts@my-ns"
-      ]
-    },
-    "svc-d@my-ns": {
-      "name": "svc-d",
-      "namespace": "my-ns",
-      "selector": {
-        "app": "app-d"
-      },
-      "annotations": {
-        "maesh.containo.us/ratelimit-average": "100",
-        "maesh.containo.us/ratelimit-burst": "200",
-        "maesh.containo.us/traffic-type": "http"
-      },
-      "ports": [
-        {
-          "name": "port-8080",
-          "protocol": "TCP",
-          "port": 8080,
-          "targetPort": 8080
-        }
-      ],
-      "clusterIp": "10.10.1.18",
-      "pods": [
-        "app-d@my-ns"
-      ],
-      "backendOf": [
-        "ts@my-ns"
       ]
     }
   },
@@ -103,18 +42,6 @@
       "destinationOf": [
         "svc-b@my-ns:tt@my-ns"
       ]
-    },
-    "app-c@my-ns": {
-      "name": "app-c",
-      "namespace": "my-ns",
-      "serviceAccount": "service-account-c",
-      "ip": "10.10.2.2"
-    },
-    "app-d@my-ns": {
-      "name": "app-d",
-      "namespace": "my-ns",
-      "serviceAccount": "service-account-d",
-      "ip": "10.10.2.3"
     }
   },
   "serviceTrafficTargets": {
@@ -188,21 +115,5 @@
       ]
     }
   },
-  "trafficSplits": {
-    "ts@my-ns": {
-      "name": "ts",
-      "namespace": "my-ns",
-      "service": "svc-b@my-ns",
-      "backends": [
-        {
-          "weight": 80,
-          "service": "svc-c@my-ns"
-        },
-        {
-          "weight": 20,
-          "service": "svc-d@my-ns"
-        }
-      ]
-    }
-  }
+  "trafficSplits": {}
 }

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -108,7 +108,7 @@ func (k *ServiceTrafficTargetKey) UnmarshalJSON(data []byte) error {
 	return k.UnmarshalText(data)
 }
 
-// Topology holds the graph and represents the different path a request can follow. Each Pods and services are nodes
+// Topology holds the graph and represents the different paths a request can follow. Each Pods and services are nodes
 // of the graph.
 type Topology struct {
 	Services              map[Key]*Service                                  `json:"services"`

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -108,7 +108,8 @@ func (k *ServiceTrafficTargetKey) UnmarshalJSON(data []byte) error {
 	return k.UnmarshalText(data)
 }
 
-// Topology holds the graph. Each Pods and services are nodes of the graph.
+// Topology holds the graph and represents the different path a request can follow. Each Pods and services are nodes
+// of the graph.
 type Topology struct {
 	Services              map[Key]*Service                                  `json:"services"`
 	Pods                  map[Key]*Pod                                      `json:"pods"`


### PR DESCRIPTION
## What does this PR do?

This PR:
- Checks if there is already a TrafficSplit on a service before adding a second one.
- Checks if there is already a TrafficSplit on a service before adding a TrafficTarget.
- Update the tests to cover these cases

Fixes #635 

### How to test it

* `make test`
* Manually by applying multiple traffic-split on the same service or a traffic-split + a traffic-target on the same service.