### PR TITLE
Support named TargetPort in service resources

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -99,7 +99,7 @@ func NewAPI(log logrus.FieldLogger, port int32, host string, client kubernetes.I
 // SetReadiness sets the readiness flag in the API.
 func (a *API) SetReadiness(isReady bool) {
 	a.readiness.Set(isReady)
-	a.log.Debugf("API readiness: %s", isReady)
+	a.log.Debugf("API readiness: %t", isReady)
 }
 
 // SetConfig sets the current dynamic configuration.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -161,16 +161,16 @@ func NewMeshController(clients k8s.Client, cfg Config, store SharedStore, logger
 		c.clients.KubernetesClient(),
 	)
 
-	c.topologyBuilder = &topology.Builder{
-		ServiceLister:        c.serviceLister,
-		EndpointsLister:      c.endpointsLister,
-		PodLister:            c.podLister,
-		TrafficTargetLister:  c.trafficTargetLister,
-		TrafficSplitLister:   c.trafficSplitLister,
-		HTTPRouteGroupLister: c.httpRouteGroupLister,
-		TCPRoutesLister:      c.tcpRouteLister,
-		Logger:               c.logger,
-	}
+	c.topologyBuilder = topology.NewBuilder(
+		c.serviceLister,
+		c.endpointsLister,
+		c.podLister,
+		c.trafficTargetLister,
+		c.trafficSplitLister,
+		c.httpRouteGroupLister,
+		c.tcpRouteLister,
+		c.logger,
+	)
 
 	providerCfg := provider.Config{
 		MinHTTPPort:        c.cfg.MinHTTPPort,

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -215,10 +215,23 @@ func (s *ShadowServiceManager) getTargetPort(trafficType string, portID int, nam
 	switch trafficType {
 	case annotations.ServiceTypeHTTP:
 		return s.getHTTPPort(portID)
+
 	case annotations.ServiceTypeTCP:
-		return s.getMappedPort(s.tcpStateTable, name, namespace, port)
+		mappedPort, err := s.getMappedPort(s.tcpStateTable, name, namespace, port)
+		if err != nil {
+			return 0, fmt.Errorf("unable to map TCP service port: %w", err)
+		}
+
+		return mappedPort, nil
+
 	case annotations.ServiceTypeUDP:
-		return s.getMappedPort(s.udpStateTable, name, namespace, port)
+		mappedPort, err := s.getMappedPort(s.udpStateTable, name, namespace, port)
+		if err != nil {
+			return 0, fmt.Errorf("unable to map UDP service port: %w", err)
+		}
+
+		return mappedPort, nil
+
 	default:
 		return 0, errors.New("unknown service mode")
 	}
@@ -243,7 +256,7 @@ func (s *ShadowServiceManager) getMappedPort(stateTable PortMapper, name, namesp
 
 	mappedPort, err := stateTable.Add(namespace, name, port)
 	if err != nil {
-		return 0, fmt.Errorf("unable to add service to the TCP state table: %w", err)
+		return 0, fmt.Errorf("unable to add service port to the state table: %w", err)
 	}
 
 	s.logger.Debugf("Service %s/%s %d as been assigned port %d", namespace, name, port, mappedPort)

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -259,7 +259,7 @@ func (s *ShadowServiceManager) getMappedPort(stateTable PortMapper, name, namesp
 		return 0, fmt.Errorf("unable to add service port to the state table: %w", err)
 	}
 
-	s.logger.Debugf("Service %s/%s %d as been assigned port %d", namespace, name, port, mappedPort)
+	s.logger.Debugf("Service %s/%s %d has been assigned port %d", namespace, name, port, mappedPort)
 
 	return mappedPort, nil
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -249,7 +249,7 @@ func (p *Provider) buildServicesAndRoutersForHTTPService(t *topology.Topology, c
 		}
 
 		key := getServiceRouterKeyFromService(svc, svcPort.Port)
-		cfg.HTTP.Services[key] = p.buildHTTPServiceFromService(t, svc, scheme, svcPort.TargetPort.IntVal)
+		cfg.HTTP.Services[key] = p.buildHTTPServiceFromService(t, svc, scheme, svcPort)
 		cfg.HTTP.Routers[key] = buildHTTPRouter(httpRule, entrypoint, middlewares, key, priorityService)
 	}
 }
@@ -268,7 +268,7 @@ func (p *Provider) buildServicesAndRoutersForTCPService(t *topology.Topology, cf
 		}
 
 		key := getServiceRouterKeyFromService(svc, svcPort.Port)
-		cfg.TCP.Services[key] = p.buildTCPServiceFromService(t, svc, svcPort.TargetPort.IntVal)
+		cfg.TCP.Services[key] = p.buildTCPServiceFromService(t, svc, svcPort)
 		cfg.TCP.Routers[key] = buildTCPRouter(rule, entrypoint, key)
 	}
 }
@@ -285,7 +285,7 @@ func (p *Provider) buildServicesAndRoutersForUDPService(t *topology.Topology, cf
 		}
 
 		key := getServiceRouterKeyFromService(svc, svcPort.Port)
-		cfg.UDP.Services[key] = p.buildUDPServiceFromService(t, svc, svcPort.TargetPort.IntVal)
+		cfg.UDP.Services[key] = p.buildUDPServiceFromService(t, svc, svcPort)
 		cfg.UDP.Routers[key] = buildUDPRouter(entrypoint, key)
 	}
 }
@@ -332,7 +332,7 @@ func (p *Provider) buildHTTPServicesAndRoutersForTrafficTarget(t *topology.Topol
 		}
 
 		svcKey := getServiceKeyFromTrafficTarget(tt, svcPort.Port)
-		cfg.HTTP.Services[svcKey] = p.buildHTTPServiceFromTrafficTarget(t, tt, scheme, svcPort.TargetPort.IntVal)
+		cfg.HTTP.Services[svcKey] = p.buildHTTPServiceFromTrafficTarget(t, tt, scheme, svcPort)
 
 		rtrMiddlewares := addToSliceCopy(middlewares, whitelistDirectKey)
 
@@ -373,7 +373,7 @@ func (p *Provider) buildTCPServicesAndRoutersForTrafficTarget(t *topology.Topolo
 		}
 
 		key := getServiceRouterKeyFromService(ttSvc, svcPort.Port)
-		cfg.TCP.Services[key] = p.buildTCPServiceFromTrafficTarget(t, tt, svcPort.TargetPort.IntVal)
+		cfg.TCP.Services[key] = p.buildTCPServiceFromTrafficTarget(t, tt, svcPort)
 		cfg.TCP.Routers[key] = buildTCPRouter(rule, entrypoint, key)
 	}
 }
@@ -596,7 +596,7 @@ func (p Provider) buildUDPEntrypoint(svc *topology.Service, port int32) (string,
 	return fmt.Sprintf("udp-%d", meshPort), nil
 }
 
-func (p *Provider) buildHTTPServiceFromService(t *topology.Topology, svc *topology.Service, scheme string, port int32) *dynamic.Service {
+func (p *Provider) buildHTTPServiceFromService(t *topology.Topology, svc *topology.Service, scheme string, svcPort corev1.ServicePort) *dynamic.Service {
 	var servers []dynamic.Server
 
 	for _, podKey := range svc.Pods {
@@ -607,10 +607,17 @@ func (p *Provider) buildHTTPServiceFromService(t *topology.Topology, svc *topolo
 			continue
 		}
 
-		url := net.JoinHostPort(pod.IP, strconv.Itoa(int(port)))
+		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
+		if !ok {
+			p.logger.Warnf("Unable to resolve HTTP service port %q in Pod %q", svcPort.Name, podKey)
+
+			continue
+		}
+
+		address := net.JoinHostPort(pod.IP, strconv.Itoa(int(hostPort)))
 
 		servers = append(servers, dynamic.Server{
-			URL: fmt.Sprintf("%s://%s", scheme, url),
+			URL: fmt.Sprintf("%s://%s", scheme, address),
 		})
 	}
 
@@ -622,10 +629,10 @@ func (p *Provider) buildHTTPServiceFromService(t *topology.Topology, svc *topolo
 	}
 }
 
-func (p *Provider) buildHTTPServiceFromTrafficTarget(t *topology.Topology, tt *topology.ServiceTrafficTarget, scheme string, port int32) *dynamic.Service {
-	servers := make([]dynamic.Server, len(tt.Destination.Pods))
+func (p *Provider) buildHTTPServiceFromTrafficTarget(t *topology.Topology, tt *topology.ServiceTrafficTarget, scheme string, svcPort corev1.ServicePort) *dynamic.Service {
+	var servers []dynamic.Server
 
-	for i, podKey := range tt.Destination.Pods {
+	for _, podKey := range tt.Destination.Pods {
 		pod, ok := t.Pods[podKey]
 		if !ok {
 			p.logger.Errorf("Unable to find Pod %q for HTTP service from Traffic Target %s@%s", podKey, topology.Key{Name: tt.Name, Namespace: tt.Namespace})
@@ -633,9 +640,18 @@ func (p *Provider) buildHTTPServiceFromTrafficTarget(t *topology.Topology, tt *t
 			continue
 		}
 
-		url := net.JoinHostPort(pod.IP, strconv.Itoa(int(port)))
+		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
+		if !ok {
+			p.logger.Warnf("Unable to resolve HTTP service port %q in Pod %q", svcPort.TargetPort, podKey)
 
-		servers[i].URL = fmt.Sprintf("%s://%s", scheme, url)
+			continue
+		}
+
+		address := net.JoinHostPort(pod.IP, strconv.Itoa(int(hostPort)))
+
+		servers = append(servers, dynamic.Server{
+			URL: fmt.Sprintf("%s://%s", scheme, address),
+		})
 	}
 
 	return &dynamic.Service{
@@ -646,7 +662,7 @@ func (p *Provider) buildHTTPServiceFromTrafficTarget(t *topology.Topology, tt *t
 	}
 }
 
-func (p *Provider) buildTCPServiceFromService(t *topology.Topology, svc *topology.Service, port int32) *dynamic.TCPService {
+func (p *Provider) buildTCPServiceFromService(t *topology.Topology, svc *topology.Service, svcPort corev1.ServicePort) *dynamic.TCPService {
 	var servers []dynamic.TCPServer
 
 	for _, podKey := range svc.Pods {
@@ -657,7 +673,14 @@ func (p *Provider) buildTCPServiceFromService(t *topology.Topology, svc *topolog
 			continue
 		}
 
-		address := net.JoinHostPort(pod.IP, strconv.Itoa(int(port)))
+		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
+		if !ok {
+			p.logger.Warnf("Unable to resolve TCP service port %q in Pod %q", svcPort.Name, podKey)
+
+			continue
+		}
+
+		address := net.JoinHostPort(pod.IP, strconv.Itoa(int(hostPort)))
 
 		servers = append(servers, dynamic.TCPServer{
 			Address: address,
@@ -671,7 +694,39 @@ func (p *Provider) buildTCPServiceFromService(t *topology.Topology, svc *topolog
 	}
 }
 
-func (p *Provider) buildUDPServiceFromService(t *topology.Topology, svc *topology.Service, port int32) *dynamic.UDPService {
+func (p *Provider) buildTCPServiceFromTrafficTarget(t *topology.Topology, tt *topology.ServiceTrafficTarget, svcPort corev1.ServicePort) *dynamic.TCPService {
+	var servers []dynamic.TCPServer
+
+	for _, podKey := range tt.Destination.Pods {
+		pod, ok := t.Pods[podKey]
+		if !ok {
+			p.logger.Errorf("Unable to find Pod %q for TCP service from Traffic Target %s@%s", podKey, topology.Key{Name: tt.Name, Namespace: tt.Namespace})
+
+			continue
+		}
+
+		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
+		if !ok {
+			p.logger.Warnf("Unable to resolve TCP service port %q in Pod %q", svcPort.Name, podKey)
+
+			continue
+		}
+
+		address := net.JoinHostPort(pod.IP, strconv.Itoa(int(hostPort)))
+
+		servers = append(servers, dynamic.TCPServer{
+			Address: address,
+		})
+	}
+
+	return &dynamic.TCPService{
+		LoadBalancer: &dynamic.TCPServersLoadBalancer{
+			Servers: servers,
+		},
+	}
+}
+
+func (p *Provider) buildUDPServiceFromService(t *topology.Topology, svc *topology.Service, svcPort corev1.ServicePort) *dynamic.UDPService {
 	var servers []dynamic.UDPServer
 
 	for _, podKey := range svc.Pods {
@@ -682,7 +737,14 @@ func (p *Provider) buildUDPServiceFromService(t *topology.Topology, svc *topolog
 			continue
 		}
 
-		address := net.JoinHostPort(pod.IP, strconv.Itoa(int(port)))
+		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
+		if !ok {
+			p.logger.Warnf("Unable to resolve UDP service port %q in Pod %q", svcPort.Name, podKey)
+
+			continue
+		}
+
+		address := net.JoinHostPort(pod.IP, strconv.Itoa(int(hostPort)))
 
 		servers = append(servers, dynamic.UDPServer{
 			Address: address,
@@ -691,27 +753,6 @@ func (p *Provider) buildUDPServiceFromService(t *topology.Topology, svc *topolog
 
 	return &dynamic.UDPService{
 		LoadBalancer: &dynamic.UDPServersLoadBalancer{
-			Servers: servers,
-		},
-	}
-}
-
-func (p *Provider) buildTCPServiceFromTrafficTarget(t *topology.Topology, tt *topology.ServiceTrafficTarget, port int32) *dynamic.TCPService {
-	servers := make([]dynamic.TCPServer, len(tt.Destination.Pods))
-
-	for i, podKey := range tt.Destination.Pods {
-		pod, ok := t.Pods[podKey]
-		if !ok {
-			p.logger.Errorf("Unable to find Pod %q for TCP service from Traffic Target %s@%s", podKey, topology.Key{Name: tt.Name, Namespace: tt.Namespace})
-
-			continue
-		}
-
-		servers[i].Address = net.JoinHostPort(pod.IP, strconv.Itoa(int(port)))
-	}
-
-	return &dynamic.TCPService{
-		LoadBalancer: &dynamic.TCPServersLoadBalancer{
 			Servers: servers,
 		},
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -608,7 +608,7 @@ func (p *Provider) buildHTTPServiceFromService(t *topology.Topology, svc *topolo
 
 		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
 		if !ok {
-			p.logger.Warnf("Unable to resolve HTTP service port %q in Pod %q", svcPort.Name, podKey)
+			p.logger.Warnf("Unable to resolve HTTP service port %q for Pod %q", svcPort.Name, podKey)
 			continue
 		}
 
@@ -633,13 +633,17 @@ func (p *Provider) buildHTTPServiceFromTrafficTarget(t *topology.Topology, tt *t
 	for _, podKey := range tt.Destination.Pods {
 		pod, ok := t.Pods[podKey]
 		if !ok {
-			p.logger.Errorf("Unable to find Pod %q for HTTP service from Traffic Target %s@%s", podKey, topology.Key{Name: tt.Name, Namespace: tt.Namespace})
+			p.logger.Errorf("Unable to find Pod %q for HTTP service from Traffic Target %q", podKey, topology.ServiceTrafficTargetKey{
+				Service:       tt.Service,
+				TrafficTarget: topology.Key{Name: tt.Name, Namespace: tt.Namespace},
+			})
+
 			continue
 		}
 
 		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
 		if !ok {
-			p.logger.Warnf("Unable to resolve HTTP service port %q in Pod %q", svcPort.TargetPort, podKey)
+			p.logger.Warnf("Unable to resolve HTTP service port %q for Pod %q", svcPort.TargetPort, podKey)
 			continue
 		}
 
@@ -670,7 +674,7 @@ func (p *Provider) buildTCPServiceFromService(t *topology.Topology, svc *topolog
 
 		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
 		if !ok {
-			p.logger.Warnf("Unable to resolve TCP service port %q in Pod %q", svcPort.Name, podKey)
+			p.logger.Warnf("Unable to resolve TCP service port %q for Pod %q", svcPort.Name, podKey)
 			continue
 		}
 
@@ -700,7 +704,7 @@ func (p *Provider) buildTCPServiceFromTrafficTarget(t *topology.Topology, tt *to
 
 		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
 		if !ok {
-			p.logger.Warnf("Unable to resolve TCP service port %q in Pod %q", svcPort.Name, podKey)
+			p.logger.Warnf("Unable to resolve TCP service port %q for Pod %q", svcPort.Name, podKey)
 			continue
 		}
 
@@ -730,7 +734,7 @@ func (p *Provider) buildUDPServiceFromService(t *topology.Topology, svc *topolog
 
 		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
 		if !ok {
-			p.logger.Warnf("Unable to resolve UDP service port %q in Pod %q", svcPort.Name, podKey)
+			p.logger.Warnf("Unable to resolve UDP service port %q for Pod %q", svcPort.Name, podKey)
 			continue
 		}
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -603,14 +603,12 @@ func (p *Provider) buildHTTPServiceFromService(t *topology.Topology, svc *topolo
 		pod, ok := t.Pods[podKey]
 		if !ok {
 			p.logger.Errorf("Unable to find Pod %q for HTTP service from Service %s@%s", podKey, topology.Key{Name: svc.Name, Namespace: svc.Namespace})
-
 			continue
 		}
 
 		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
 		if !ok {
 			p.logger.Warnf("Unable to resolve HTTP service port %q in Pod %q", svcPort.Name, podKey)
-
 			continue
 		}
 
@@ -636,14 +634,12 @@ func (p *Provider) buildHTTPServiceFromTrafficTarget(t *topology.Topology, tt *t
 		pod, ok := t.Pods[podKey]
 		if !ok {
 			p.logger.Errorf("Unable to find Pod %q for HTTP service from Traffic Target %s@%s", podKey, topology.Key{Name: tt.Name, Namespace: tt.Namespace})
-
 			continue
 		}
 
 		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
 		if !ok {
 			p.logger.Warnf("Unable to resolve HTTP service port %q in Pod %q", svcPort.TargetPort, podKey)
-
 			continue
 		}
 
@@ -669,14 +665,12 @@ func (p *Provider) buildTCPServiceFromService(t *topology.Topology, svc *topolog
 		pod, ok := t.Pods[podKey]
 		if !ok {
 			p.logger.Errorf("Unable to find Pod %q for TCP service from Service %s@%s", podKey, topology.Key{Name: svc.Name, Namespace: svc.Namespace})
-
 			continue
 		}
 
 		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
 		if !ok {
 			p.logger.Warnf("Unable to resolve TCP service port %q in Pod %q", svcPort.Name, podKey)
-
 			continue
 		}
 
@@ -701,14 +695,12 @@ func (p *Provider) buildTCPServiceFromTrafficTarget(t *topology.Topology, tt *to
 		pod, ok := t.Pods[podKey]
 		if !ok {
 			p.logger.Errorf("Unable to find Pod %q for TCP service from Traffic Target %s@%s", podKey, topology.Key{Name: tt.Name, Namespace: tt.Namespace})
-
 			continue
 		}
 
 		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
 		if !ok {
 			p.logger.Warnf("Unable to resolve TCP service port %q in Pod %q", svcPort.Name, podKey)
-
 			continue
 		}
 
@@ -733,14 +725,12 @@ func (p *Provider) buildUDPServiceFromService(t *topology.Topology, svc *topolog
 		pod, ok := t.Pods[podKey]
 		if !ok {
 			p.logger.Errorf("Unable to find Pod %q for UDP service from Service %s@%s", podKey, topology.Key{Name: svc.Name, Namespace: svc.Namespace})
-
 			continue
 		}
 
 		hostPort, ok := topology.ResolveServicePort(svcPort, pod.ContainerPorts)
 		if !ok {
 			p.logger.Warnf("Unable to resolve UDP service port %q in Pod %q", svcPort.Name, podKey)
-
 			continue
 		}
 
@@ -769,7 +759,6 @@ func (p *Provider) buildWhitelistMiddlewareFromTrafficTargetDirect(t *topology.T
 			pod, ok := t.Pods[podKey]
 			if !ok {
 				p.logger.Errorf("Unable to find Pod %q for WhitelistMiddleware from Traffic Target %s@%s", podKey, topology.Key{Name: tt.Name, Namespace: tt.Namespace})
-
 				continue
 			}
 
@@ -794,7 +783,6 @@ func (p *Provider) buildWhitelistMiddlewareFromTrafficSplitDirect(t *topology.To
 		pod, ok := t.Pods[podKey]
 		if !ok {
 			p.logger.Errorf("Unable to find Pod %q for WhitelistMiddleware from Traffic Split %s@%s", podKey, topology.Key{Name: ts.Name, Namespace: ts.Namespace})
-
 			continue
 		}
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -67,6 +67,7 @@ func TestProvider_BuildConfig(t *testing.T) {
 			defaultTrafficType: "tcp",
 			tcpStateTable: map[servicePort]int32{
 				{Namespace: "my-ns", Name: "svc-a", Port: 8080}: 5000,
+				{Namespace: "my-ns", Name: "svc-a", Port: 8081}: 5001,
 			},
 			topology:   "testdata/acl-disabled-tcp-basic-topology.json",
 			wantConfig: "testdata/acl-disabled-tcp-basic-config.json",
@@ -77,6 +78,7 @@ func TestProvider_BuildConfig(t *testing.T) {
 			defaultTrafficType: "udp",
 			udpStateTable: map[servicePort]int32{
 				{Namespace: "my-ns", Name: "svc-a", Port: 8080}: 15000,
+				{Namespace: "my-ns", Name: "svc-a", Port: 8081}: 15001,
 			},
 			topology:   "testdata/acl-disabled-udp-basic-topology.json",
 			wantConfig: "testdata/acl-disabled-udp-basic-config.json",
@@ -101,6 +103,7 @@ func TestProvider_BuildConfig(t *testing.T) {
 			defaultTrafficType: "tcp",
 			tcpStateTable: map[servicePort]int32{
 				{Namespace: "my-ns", Name: "svc-b", Port: 8080}: 5000,
+				{Namespace: "my-ns", Name: "svc-b", Port: 8081}: 5001,
 			},
 			topology:   "testdata/acl-enabled-tcp-basic-topology.json",
 			wantConfig: "testdata/acl-enabled-tcp-basic-config.json",

--- a/pkg/provider/testdata/acl-disabled-http-basic-config.json
+++ b/pkg/provider/testdata/acl-disabled-http-basic-config.json
@@ -9,6 +9,14 @@
         "rule": "Host(`svc-a.my-ns.maesh`) || Host(`10.10.14.1`)",
         "priority": 1001
       },
+      "my-ns-svc-a-8081": {
+        "entryPoints": [
+          "http-10001"
+        ],
+        "service": "my-ns-svc-a-8081",
+        "rule": "Host(`svc-a.my-ns.maesh`) || Host(`10.10.14.1`)",
+        "priority": 1001
+      },
       "readiness": {
         "entryPoints": [
           "readiness"
@@ -31,6 +39,19 @@
             },
             {
               "url": "http://10.10.2.2:8080"
+            }
+          ],
+          "passHostHeader": true
+        }
+      },
+      "my-ns-svc-a-8081": {
+        "loadBalancer": {
+          "servers": [
+            {
+              "url": "http://10.10.2.1:8080"
+            },
+            {
+              "url": "http://10.10.2.2:8081"
             }
           ],
           "passHostHeader": true

--- a/pkg/provider/testdata/acl-disabled-http-basic-topology.json
+++ b/pkg/provider/testdata/acl-disabled-http-basic-topology.json
@@ -11,6 +11,12 @@
           "protocol": "TCP",
           "port": 8080,
           "targetPort": 8080
+        },
+        {
+          "name": "port-8081",
+          "protocol": "TCP",
+          "port": 8081,
+          "targetPort": "web"
         }
       ],
       "clusterIp": "10.10.14.1",
@@ -25,13 +31,27 @@
       "name": "pod-a1",
       "namespace": "my-ns",
       "serviceAccount": "default",
-      "ip": "10.10.2.1"
+      "ip": "10.10.2.1",
+      "containerPorts": [
+        {
+          "name": "web",
+          "protocol": "TCP",
+          "containerPort": 8080
+        }
+      ]
     },
     "pod-a2@my-ns": {
       "name": "pod-a2",
       "namespace": "my-ns",
       "serviceAccount": "default",
-      "ip": "10.10.2.2"
+      "ip": "10.10.2.2",
+      "containerPorts": [
+        {
+          "name": "web",
+          "protocol": "TCP",
+          "containerPort": 8081
+        }
+      ]
     }
   },
   "serviceTrafficTargets": {},

--- a/pkg/provider/testdata/acl-disabled-tcp-basic-config.json
+++ b/pkg/provider/testdata/acl-disabled-tcp-basic-config.json
@@ -44,6 +44,13 @@
         ],
         "service": "my-ns-svc-a-8080",
         "rule": "HostSNI(`*`)"
+      },
+      "my-ns-svc-a-8081": {
+        "entryPoints": [
+          "tcp-5001"
+        ],
+        "service": "my-ns-svc-a-8081",
+        "rule": "HostSNI(`*`)"
       }
     },
     "services": {
@@ -55,6 +62,18 @@
             },
             {
               "address": "10.10.2.2:8080"
+            }
+          ]
+        }
+      },
+      "my-ns-svc-a-8081": {
+        "loadBalancer": {
+          "servers": [
+            {
+              "address": "10.10.2.1:8080"
+            },
+            {
+              "address": "10.10.2.2:8081"
             }
           ]
         }

--- a/pkg/provider/testdata/acl-disabled-tcp-basic-topology.json
+++ b/pkg/provider/testdata/acl-disabled-tcp-basic-topology.json
@@ -11,6 +11,12 @@
           "protocol": "TCP",
           "port": 8080,
           "targetPort": 8080
+        },
+        {
+          "name": "port-8081",
+          "protocol": "TCP",
+          "port": 8081,
+          "targetPort": "web"
         }
       ],
       "clusterIp": "10.10.14.1",
@@ -25,13 +31,27 @@
       "name": "pod-a1",
       "namespace": "my-ns",
       "serviceAccount": "default",
-      "ip": "10.10.2.1"
+      "ip": "10.10.2.1",
+      "containerPorts": [
+        {
+          "name": "web",
+          "protocol": "TCP",
+          "containerPort": 8080
+        }
+      ]
     },
     "pod-a2@my-ns": {
       "name": "pod-a2",
       "namespace": "my-ns",
       "serviceAccount": "default",
-      "ip": "10.10.2.2"
+      "ip": "10.10.2.2",
+      "containerPorts": [
+        {
+          "name": "web",
+          "protocol": "TCP",
+          "containerPort": 8081
+        }
+      ]
     }
   },
   "serviceTrafficTargets": {},

--- a/pkg/provider/testdata/acl-disabled-udp-basic-config.json
+++ b/pkg/provider/testdata/acl-disabled-udp-basic-config.json
@@ -44,6 +44,12 @@
           "udp-15000"
         ],
         "service": "my-ns-svc-a-8080"
+      },
+      "my-ns-svc-a-8081": {
+        "entryPoints": [
+          "udp-15001"
+        ],
+        "service": "my-ns-svc-a-8081"
       }
     },
     "services": {
@@ -55,6 +61,18 @@
             },
             {
               "address": "10.10.2.2:8080"
+            }
+          ]
+        }
+      },
+      "my-ns-svc-a-8081": {
+        "loadBalancer": {
+          "servers": [
+            {
+              "address": "10.10.2.1:8080"
+            },
+            {
+              "address": "10.10.2.2:8081"
             }
           ]
         }

--- a/pkg/provider/testdata/acl-disabled-udp-basic-topology.json
+++ b/pkg/provider/testdata/acl-disabled-udp-basic-topology.json
@@ -11,6 +11,12 @@
           "protocol": "UDP",
           "port": 8080,
           "targetPort": 8080
+        },
+        {
+          "name": "port-8081",
+          "protocol": "UDP",
+          "port": 8081,
+          "targetPort": "ping"
         }
       ],
       "clusterIp": "10.10.14.1",
@@ -25,13 +31,27 @@
       "name": "pod-a1",
       "namespace": "my-ns",
       "serviceAccount": "default",
-      "ip": "10.10.2.1"
+      "ip": "10.10.2.1",
+      "containerPorts": [
+        {
+          "name": "ping",
+          "protocol": "UDP",
+          "containerPort": 8080
+        }
+      ]
     },
     "pod-a2@my-ns": {
       "name": "pod-a2",
       "namespace": "my-ns",
       "serviceAccount": "default",
-      "ip": "10.10.2.2"
+      "ip": "10.10.2.2",
+      "containerPorts": [
+        {
+          "name": "ping",
+          "protocol": "UDP",
+          "containerPort": 8081
+        }
+      ]
     }
   },
   "serviceTrafficTargets": {},

--- a/pkg/provider/testdata/acl-enabled-http-basic-config.json
+++ b/pkg/provider/testdata/acl-enabled-http-basic-config.json
@@ -12,6 +12,17 @@
         "rule": "Host(`svc-b.my-ns.maesh`) || Host(`10.10.14.1`)",
         "priority": 1
       },
+      "my-ns-svc-b-8081": {
+        "entryPoints": [
+          "http-10001"
+        ],
+        "middlewares": [
+          "block-all-middleware"
+        ],
+        "service": "block-all-service",
+        "rule": "Host(`svc-b.my-ns.maesh`) || Host(`10.10.14.1`)",
+        "priority": 1
+      },
       "my-ns-svc-b-tt-8080-traffic-target-direct": {
         "entryPoints": [
           "http-10000"
@@ -20,6 +31,17 @@
           "my-ns-svc-b-tt-whitelist-traffic-target-direct"
         ],
         "service": "my-ns-svc-b-tt-8080-traffic-target",
+        "rule": "Host(`svc-b.my-ns.maesh`) || Host(`10.10.14.1`)",
+        "priority": 2001
+      },
+      "my-ns-svc-b-tt-8081-traffic-target-direct": {
+        "entryPoints": [
+          "http-10001"
+        ],
+        "middlewares": [
+          "my-ns-svc-b-tt-whitelist-traffic-target-direct"
+        ],
+        "service": "my-ns-svc-b-tt-8081-traffic-target",
         "rule": "Host(`svc-b.my-ns.maesh`) || Host(`10.10.14.1`)",
         "priority": 2001
       },
@@ -42,6 +64,16 @@
           "servers": [
             {
               "url": "http://10.10.3.1:8080"
+            }
+          ],
+          "passHostHeader": true
+        }
+      },
+      "my-ns-svc-b-tt-8081-traffic-target": {
+        "loadBalancer": {
+          "servers": [
+            {
+              "url": "http://10.10.3.1:8081"
             }
           ],
           "passHostHeader": true

--- a/pkg/provider/testdata/acl-enabled-http-basic-topology.json
+++ b/pkg/provider/testdata/acl-enabled-http-basic-topology.json
@@ -11,13 +11,21 @@
           "protocol": "TCP",
           "port": 8080,
           "targetPort": 8080
+        },
+        {
+          "name": "port-8081",
+          "protocol": "TCP",
+          "port": 8081,
+          "targetPort": "web"
         }
       ],
       "clusterIp": "10.10.14.1",
       "pods": [
         "pod-b@my-ns"
       ],
-      "trafficTargets": ["svc-b@my-ns:tt@my-ns"]
+      "trafficTargets": [
+        "svc-b@my-ns:tt@my-ns"
+      ]
     }
   },
   "pods": {
@@ -31,7 +39,14 @@
       "name": "pod-b",
       "namespace": "my-ns",
       "serviceAccount": "server",
-      "ip": "10.10.3.1"
+      "ip": "10.10.3.1",
+      "containerPorts": [
+        {
+          "name": "web",
+          "protocol": "TCP",
+          "containerPort": 8081
+        }
+      ]
     }
   },
   "serviceTrafficTargets": {
@@ -57,6 +72,12 @@
             "protocol": "TCP",
             "port": 8080,
             "targetPort": 8080
+          },
+          {
+            "name": "port-8081",
+            "protocol": "TCP",
+            "port": 8081,
+            "targetPort": "web"
           }
         ],
         "pods": [

--- a/pkg/provider/testdata/acl-enabled-tcp-basic-config.json
+++ b/pkg/provider/testdata/acl-enabled-tcp-basic-config.json
@@ -44,6 +44,13 @@
         ],
         "service": "my-ns-svc-b-8080",
         "rule": "HostSNI(`*`)"
+      },
+      "my-ns-svc-b-8081": {
+        "entryPoints": [
+          "tcp-5001"
+        ],
+        "service": "my-ns-svc-b-8081",
+        "rule": "HostSNI(`*`)"
       }
     },
     "services": {
@@ -52,6 +59,15 @@
           "servers": [
             {
               "address": "10.10.3.1:8080"
+            }
+          ]
+        }
+      },
+      "my-ns-svc-b-8081": {
+        "loadBalancer": {
+          "servers": [
+            {
+              "address": "10.10.3.1:8081"
             }
           ]
         }

--- a/pkg/provider/testdata/acl-enabled-tcp-basic-topology.json
+++ b/pkg/provider/testdata/acl-enabled-tcp-basic-topology.json
@@ -11,13 +11,21 @@
           "protocol": "TCP",
           "port": 8080,
           "targetPort": 8080
+        },
+        {
+          "name": "port-8081",
+          "protocol": "TCP",
+          "port": 8081,
+          "targetPort": "web"
         }
       ],
       "clusterIp": "10.10.14.1",
       "pods": [
         "pod-b@my-ns"
       ],
-      "trafficTargets": ["svc-b@my-ns:tt@my-ns"]
+      "trafficTargets": [
+        "svc-b@my-ns:tt@my-ns"
+      ]
     }
   },
   "pods": {
@@ -31,7 +39,14 @@
       "name": "pod-b",
       "namespace": "my-ns",
       "serviceAccount": "server",
-      "ip": "10.10.3.1"
+      "ip": "10.10.3.1",
+      "containerPorts": [
+        {
+          "name": "web",
+          "protocol": "TCP",
+          "containerPort": 8081
+        }
+      ]
     }
   },
   "serviceTrafficTargets": {
@@ -68,6 +83,12 @@
             "protocol": "TCP",
             "port": 8080,
             "targetPort": 8080
+          },
+          {
+            "name": "port-8081",
+            "protocol": "TCP",
+            "port": 8081,
+            "targetPort": "web"
           }
         ],
         "pods": [

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -587,11 +587,18 @@ func getOrCreatePod(topology *Topology, pod *corev1.Pod) Key {
 	podKey := Key{pod.Name, pod.Namespace}
 
 	if _, ok := topology.Pods[podKey]; !ok {
+		var containerPorts []corev1.ContainerPort
+
+		for _, container := range pod.Spec.Containers {
+			containerPorts = append(containerPorts, container.Ports...)
+		}
+
 		topology.Pods[podKey] = &Pod{
 			Name:            pod.Name,
 			Namespace:       pod.Namespace,
 			ServiceAccount:  pod.Spec.ServiceAccountName,
 			OwnerReferences: pod.OwnerReferences,
+			ContainerPorts:  containerPorts,
 			IP:              pod.Status.PodIP,
 		}
 	}

--- a/pkg/topology/builder_test.go
+++ b/pkg/topology/builder_test.go
@@ -638,14 +638,14 @@ func createBuilder(k8sClient k8s.Interface, smiAccessClient accessclient.Interfa
 	logger.SetOutput(ioutil.Discard)
 
 	return &Builder{
-		ServiceLister:        svcLister,
-		EndpointsLister:      epLister,
-		PodLister:            podLister,
-		TrafficTargetLister:  trafficTargetLister,
-		TrafficSplitLister:   trafficSplitLister,
-		HTTPRouteGroupLister: httpRouteGroupLister,
-		TCPRoutesLister:      tcpRouteLister,
-		Logger:               logger,
+		serviceLister:        svcLister,
+		endpointsLister:      epLister,
+		podLister:            podLister,
+		trafficTargetLister:  trafficTargetLister,
+		trafficSplitLister:   trafficSplitLister,
+		httpRouteGroupLister: httpRouteGroupLister,
+		tcpRoutesLister:      tcpRouteLister,
+		logger:               logger,
 	}, nil
 }
 

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -7,6 +7,7 @@ import (
 	specs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // Key references a resource.
@@ -203,11 +204,12 @@ type TrafficSpec struct {
 
 // Pod is a node of the graph representing a kubernetes pod.
 type Pod struct {
-	Name            string              `json:"name"`
-	Namespace       string              `json:"namespace"`
-	ServiceAccount  string              `json:"serviceAccount"`
-	OwnerReferences []v1.OwnerReference `json:"ownerReferences,omitempty"`
-	IP              string              `json:"ip"`
+	Name            string                 `json:"name"`
+	Namespace       string                 `json:"namespace"`
+	ServiceAccount  string                 `json:"serviceAccount"`
+	OwnerReferences []v1.OwnerReference    `json:"ownerReferences,omitempty"`
+	ContainerPorts  []corev1.ContainerPort `json:"containerPorts,omitempty"`
+	IP              string                 `json:"ip"`
 
 	SourceOf      []ServiceTrafficTargetKey `json:"sourceOf,omitempty"`
 	DestinationOf []ServiceTrafficTargetKey `json:"destinationOf,omitempty"`
@@ -236,4 +238,24 @@ func (ts *TrafficSplit) AddError(err error) {
 type TrafficSplitBackend struct {
 	Weight  int `json:"weight"`
 	Service Key `json:"service"`
+}
+
+// ResolveServicePort resolves the given service port against the given container port list, as described in the
+// Kubernetes documentation, and returns true if it has been successfully resolved, false otherwise.
+//
+// The Kubernetes documentation says: Port definitions in Pods have names, and you can reference these names in the
+// targetPort attribute of a Service. This works even if there is a mixture of Pods in the Service using a single
+// configured name, with the same network protocol available via different port numbers.
+func ResolveServicePort(svcPort corev1.ServicePort, containerPorts []corev1.ContainerPort) (int32, bool) {
+	if svcPort.TargetPort.Type == intstr.Int {
+		return svcPort.TargetPort.IntVal, true
+	}
+
+	for _, containerPort := range containerPorts {
+		if svcPort.TargetPort.StrVal == containerPort.Name && svcPort.Protocol == containerPort.Protocol {
+			return containerPort.ContainerPort, true
+		}
+	}
+
+	return 0, false
 }

--- a/pkg/topology/topology_test.go
+++ b/pkg/topology/topology_test.go
@@ -1,0 +1,81 @@
+package topology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestTopology_ResolveServicePort(t *testing.T) {
+	tests := []struct {
+		desc           string
+		svcPort        corev1.ServicePort
+		containerPorts []corev1.ContainerPort
+		expPort        int32
+		expResult      bool
+	}{
+		{
+			desc: "should return the service TargetPort if it as Int",
+			svcPort: corev1.ServicePort{
+				TargetPort: intstr.FromInt(3000),
+			},
+			expPort:   3000,
+			expResult: true,
+		},
+		{
+			desc: "should return false if the service TargetPort is a String and the container port list is empty",
+			svcPort: corev1.ServicePort{
+				TargetPort: intstr.FromString("foo"),
+			},
+			expPort:   0,
+			expResult: false,
+		},
+		{
+			desc: "should return false if the service TargetPort is a String and it cannot be resolved",
+			svcPort: corev1.ServicePort{
+				TargetPort: intstr.FromString("foo"),
+				Protocol:   corev1.ProtocolTCP,
+			},
+			containerPorts: []corev1.ContainerPort{
+				{
+					Name:          "bar",
+					ContainerPort: 3000,
+				},
+				{
+					Name:          "foo",
+					Protocol:      corev1.ProtocolUDP,
+					ContainerPort: 3000,
+				},
+			},
+			expPort:   0,
+			expResult: false,
+		},
+		{
+			desc: "should return true and the resolved service TargetPort",
+			svcPort: corev1.ServicePort{
+				TargetPort: intstr.FromString("foo"),
+				Protocol:   corev1.ProtocolUDP,
+			},
+			containerPorts: []corev1.ContainerPort{
+				{
+					Name:          "foo",
+					Protocol:      corev1.ProtocolUDP,
+					ContainerPort: 3000,
+				},
+			},
+			expPort:   3000,
+			expResult: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			port, result := ResolveServicePort(test.svcPort, test.containerPorts)
+
+			assert.Equal(t, test.expResult, result)
+			assert.Equal(t, test.expPort, port)
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

This PR:

- Adds the support for named TargetPort in service resources.
- Fixes the error message returned when a service port mapping fails.
- Fixes the API readiness logging format.

Fixes #517

In the Kubernetes [documentation](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service):

> Port definitions in Pods have names, and you can reference these names in the targetPort attribute of a Service. This works even if there is a mixture of Pods in the Service using a single configured name, with the same network protocol available via different port numbers. This offers a lot of flexibility for deploying and evolving your Services.

### How to test it

* make test