### PR TITLE
Add a max retry for getting coredns service

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -268,7 +268,7 @@ func (c *Client) ConfigureKubeDNS(clusterDomain, maeshNamespace string) error {
 
 		serviceIP = svc.Spec.ClusterIP
 		return nil
-	}), ebo); err != nil {
+	}), backoff.WithMaxRetries(ebo, 12)); err != nil {
 		return fmt.Errorf("unable get the service %q in namespace %q: %w", "coredns", "maesh", err)
 	}
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes #638 by adding a `WithMaxRetries` to the call to `backoff.Retry` call in the DNS patching code.

### How to test it

* Try to run the `prepare` command on a cluster which does not have a `coredns` service
* It should fail after 2 minutes and log the appropriate error