### PR TITLE
Add migration documentation for Prometheus and Grafana services

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -38,14 +38,13 @@ helm install maesh helm/chart/maesh --set image.pullPolicy=IfNotPresent --set im
 
 ## KubeDNS support
 
-Maesh can support KubeDNS:
+Maesh supports KubeDNS:
 
 ```bash
 helm install maesh maesh/maesh --set kubedns=true
 ```
 
-With this parameter Maesh will install a CoreDNS as a daemonset.
-KubeDNS will be patched with [stubDomains](https://v1-17.docs.kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#example-stub-domain).
+With the `kubedns` parameter Maesh will install CoreDNS and patch KubeDNS to use it as a [stubDomain](https://v1-17.docs.kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#example-stub-domain).
 
 ## Custom cluster domain
 

--- a/docs/content/migration/helm-chart.md
+++ b/docs/content/migration/helm-chart.md
@@ -27,3 +27,9 @@ option as described in the [documentation](../install.md#access-control-list).
 
 The `controller.mesh.defaultMode` option has been deprecated and will be removed in a future major release.
 You should use the new `defaultMode` option to configure the default traffic mode for Maesh services.
+
+### Prometheus and Grafana services
+
+Prior to version `v2.1`, when the Metrics chart is deployed, Prometheus and Grafana services are exposed by default through 
+a `NodePort`. For security reasons, those services are not exposed by default anymore. To expose them you should use the 
+new `prometheus.service` and `grafana.service` options, more details in the corresponding [values.yaml](https://github.com/containous/maesh/blob/e59b861ac91261b950663410a6223a02fc7e2290/helm/chart/maesh/charts/metrics/values.yaml).


### PR DESCRIPTION
## What does this PR do?

This PR:

- Fixes the KubeDNS support wording.
- Adds a migration documentation for Prometheus and Grafana services.