### PR TITLE
Upgrade CoreDNS component in Helm Chart

### DIFF
--- a/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
@@ -16,7 +16,6 @@ data:
         health
         kubernetes {{ default "cluster.local" .Values.clusterDomain }} in-addr.arpa ip6.arpa {
           pods insecure
-          upstream
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153

--- a/helm/chart/maesh/templates/dns/coredns/coredns-deployment.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
         - name: coredns
-          image: coredns/coredns:1.6.3
+          image: coredns/coredns:1.7.0
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/helm/chart/maesh/templates/dns/coredns/coredns-deployment.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       labels:
         k8s-app: coredns
     spec:
-      serviceAccountName: coredns
+      serviceAccountName: maesh-coredns
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/helm/chart/maesh/templates/dns/coredns/coredns-rbac.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote}}
     heritage: {{ .Release.Service | quote}}
-  name: coredns
+  name: maesh-coredns-role
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
@@ -39,12 +39,12 @@ metadata:
     heritage: {{ .Release.Service | quote}}
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
-  name: coredns
+  name: maesh-coredns
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: coredns
+  name: maesh-coredns-role
 subjects:
   - kind: ServiceAccount
     name: coredns

--- a/helm/chart/maesh/templates/dns/coredns/coredns-rbac.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-rbac.yaml
@@ -32,6 +32,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
+  name: maesh-coredns
+  namespace: {{ .Release.Namespace }}
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
     chart: {{ include "maesh.chartLabel" . | quote }}
@@ -39,14 +41,12 @@ metadata:
     heritage: {{ .Release.Service | quote}}
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
-  name: maesh-coredns
-  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: maesh-coredns-role
 subjects:
   - kind: ServiceAccount
-    name: coredns
+    name: maesh-coredns
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/helm/chart/maesh/templates/dns/coredns/coredns-sa.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-sa.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: coredns
+  name: maesh-coredns
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ include "maesh.chartLabel" . | quote }}


### PR DESCRIPTION
## What does this PR do?

This PR:

  - Upgrade CoreDNS to 1.7.0 in Helm Chart
  - Rename CoreDNS ClusterRole and ClusterRoleBinding in Helm Chart

Fixes #643
Fixes #646 

<!-- A brief description of the change being made with this pull request. -->

## Additional Notes

Removed `upstream` in CoreDNS configuration as it's causing an error. It last mentioned in [1.5.1](https://github.com/coredns/coredns/tree/6c33397d29f6f856e3a197177e63d1bc5341ab0d/plugin/kubernetes#stubdomains-and-upstreamnameservers) and removed since [1.5.2](https://github.com/coredns/coredns/tree/d933f635af392fb7b7938857576f460741151e46/plugin/kubernetes#stubdomains-and-upstreamnameservers).

Using name `maesh-coredns-role` and `maesh-coredns` for consistency with other ClusterRole and ClusterRoleBinding.

```
# ClusterRole
maesh-controller-role
maesh-coredns-role
maesh-mesh-role
```

```
# ClusterRoleBinding
maesh-controller
maesh-coredns
maesh-mesh
```