### PR TITLE
Fix HTTP/TCP/UDP port limits

### DIFF
--- a/cmd/maesh/maesh.go
+++ b/cmd/maesh/maesh.go
@@ -114,11 +114,11 @@ func maeshCommand(config *cmd.MaeshConfiguration) error {
 		WatchNamespaces:  config.WatchNamespaces,
 		IgnoreNamespaces: config.IgnoreNamespaces,
 		MinHTTPPort:      minHTTPPort,
-		MaxHTTPPort:      minHTTPPort + config.LimitHTTPPort,
+		MaxHTTPPort:      minHTTPPort + config.LimitHTTPPort - 1,
 		MinTCPPort:       minTCPPort,
-		MaxTCPPort:       minTCPPort + config.LimitTCPPort,
+		MaxTCPPort:       minTCPPort + config.LimitTCPPort - 1,
 		MinUDPPort:       minUDPPort,
-		MaxUDPPort:       minUDPPort + config.LimitUDPPort,
+		MaxUDPPort:       minUDPPort + config.LimitUDPPort - 1,
 	}, apiServer, log)
 
 	var wg sync.WaitGroup

--- a/pkg/controller/portmapping.go
+++ b/pkg/controller/portmapping.go
@@ -100,7 +100,7 @@ func (p *PortMapping) Find(namespace, name string, port int32) (int32, bool) {
 // Add adds a new mapping between the given service port and the first port available in the range defined
 // within minPort and maxPort. If there's no port left, an error will be returned.
 func (p *PortMapping) Add(namespace, name string, port int32) (int32, error) {
-	for i := p.minPort; i < p.maxPort+1; i++ {
+	for i := p.minPort; i <= p.maxPort; i++ {
 		// Skip until an available port is found
 		if _, exists := p.table[i]; exists {
 			continue

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -158,7 +158,7 @@ func (s *ShadowServiceManager) removeUnusedPortMappings(shadowSvc, svc *corev1.S
 
 func (s *ShadowServiceManager) removeServicePortMapping(namespace, name string, svcPort corev1.ServicePort) {
 	// Nothing to do here as there is no port table for HTTP ports.
-	if svcPort.TargetPort.IntVal < s.maxHTTPPort {
+	if svcPort.TargetPort.IntVal <= s.maxHTTPPort {
 		return
 	}
 
@@ -239,7 +239,7 @@ func (s *ShadowServiceManager) getTargetPort(trafficType string, portID int, nam
 
 // getHTTPPort returns the HTTP port associated with the given portID.
 func (s *ShadowServiceManager) getHTTPPort(portID int) (int32, error) {
-	if s.minHTTPPort+int32(portID) >= s.maxHTTPPort {
+	if s.minHTTPPort+int32(portID) > s.maxHTTPPort {
 		return 0, errors.New("unable to find an available HTTP port")
 	}
 

--- a/pkg/controller/service_test.go
+++ b/pkg/controller/service_test.go
@@ -426,7 +426,7 @@ func TestShadowServiceManager_getHTTPPort(t *testing.T) {
 	}{
 		{
 			desc:        "should return an error if no HTTP port mapping is available",
-			portID:      2,
+			portID:      3,
 			expectedErr: true,
 		},
 		{

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -571,7 +571,7 @@ func (p *Provider) buildBlockAllRouters(cfg *dynamic.Configuration, svc *topolog
 
 func (p Provider) buildHTTPEntrypoint(portID int) (string, error) {
 	port := p.config.MinHTTPPort + int32(portID)
-	if port >= p.config.MaxHTTPPort {
+	if port > p.config.MaxHTTPPort {
 		return "", errors.New("too many HTTP entrypoints")
 	}
 


### PR DESCRIPTION
## What does this PR do?

This PR makes sure the HTTP, TCP and UDP port limits are enforced correctly. There was a mismatch on how HTTP port limit was handled compared to TCP and UDP. 

### How to test it

For HTTP, TCP and UDP, test the following
- Install Maesh with a limit set to 1. Make sure we can only use 1 port
- Install Maesh with a limit set to 3. Make sure we can only use 3 ports.