### PR TITLE
Create optional kube-dns configmap if needed

### DIFF
--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -162,20 +162,24 @@ func TestConfigureKubeDNS(t *testing.T) {
 		expectedErr         bool
 	}{
 		{
-			desc:                "First time config of KubeDNS",
+			desc:        "should return an error if kube-dns deployment does not exist",
+			mockFile:    "configurekubedns_missing_deployment.yaml",
+			expectedErr: true,
+		},
+		{
+			desc:                "should add maesh stubdomain config in kube-dns configmap",
 			mockFile:            "configurekubedns_not_patched.yaml",
-			expectedErr:         false,
 			expectedStubDomains: `{"maesh":["1.2.3.4"]}`,
 		},
 		{
-			desc:                "Already patched",
+			desc:                "should replace maesh stubdomain config in kube-dns configmap",
 			mockFile:            "configurekubedns_already_patched.yaml",
 			expectedStubDomains: `{"maesh":["1.2.3.4"]}`,
 		},
 		{
-			desc:        "Missing KubeDNS deployment",
-			mockFile:    "configurekubedns_missing_deployment.yaml",
-			expectedErr: true,
+			desc:                "should create optional kube-dns configmap and add maesh stubdomain config",
+			mockFile:            "configurekubedns_optional_configmap.yaml",
+			expectedStubDomains: `{"maesh":["1.2.3.4"]}`,
 		},
 	}
 
@@ -201,7 +205,7 @@ func TestConfigureKubeDNS(t *testing.T) {
 
 			require.NoError(t, err)
 
-			cfgMap, err := k8sClient.KubernetesClient().CoreV1().ConfigMaps("kube-system").Get("kubedns-cfgmap", metav1.GetOptions{})
+			cfgMap, err := k8sClient.KubernetesClient().CoreV1().ConfigMaps("kube-system").Get("kube-dns", metav1.GetOptions{})
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expectedStubDomains, cfgMap.Data["stubDomains"])
@@ -311,7 +315,7 @@ func TestRestoreKubeDNS(t *testing.T) {
 			err := client.RestoreKubeDNS()
 			require.NoError(t, err)
 
-			cfgMap, err := k8sClient.KubernetesClient().CoreV1().ConfigMaps("kube-system").Get("kubedns-cfgmap", metav1.GetOptions{})
+			cfgMap, err := k8sClient.KubernetesClient().CoreV1().ConfigMaps("kube-system").Get("kube-dns", metav1.GetOptions{})
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expectedStubDomains, cfgMap.Data["stubDomains"])

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -139,7 +139,7 @@ func TestConfigureCoreDNS(t *testing.T) {
 
 			require.NoError(t, err)
 
-			cfgMap, err := k8sClient.KubernetesClient().CoreV1().ConfigMaps("kube-system").Get("coredns-cfgmap", metav1.GetOptions{})
+			cfgMap, err := k8sClient.KubernetesClient().CoreV1().ConfigMaps("kube-system").Get("coredns", metav1.GetOptions{})
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expectedCorefile, cfgMap.Data["Corefile"])
@@ -261,7 +261,7 @@ func TestRestoreCoreDNS(t *testing.T) {
 			err := client.RestoreCoreDNS()
 			require.NoError(t, err)
 
-			cfgMap, err := k8sClient.KubernetesClient().CoreV1().ConfigMaps("kube-system").Get("coredns-cfgmap", metav1.GetOptions{})
+			cfgMap, err := k8sClient.KubernetesClient().CoreV1().ConfigMaps("kube-system").Get("coredns", metav1.GetOptions{})
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expectedCorefile, cfgMap.Data["Corefile"])

--- a/pkg/dns/testdata/configurecoredns_already_patched.yaml
+++ b/pkg/dns/testdata/configurecoredns_already_patched.yaml
@@ -10,7 +10,7 @@ spec:
         - configMap:
             name: "other-cfgmap"
         - configMap:
-            name: "coredns-cfgmap"
+            name: "coredns"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -21,7 +21,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: coredns-cfgmap
+  name: coredns
   namespace: kube-system
 data:
   Corefile: |

--- a/pkg/dns/testdata/configurecoredns_custom_already_patched.yaml
+++ b/pkg/dns/testdata/configurecoredns_custom_already_patched.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       volumes:
         - configMap:
-            name: "coredns-cfgmap"
+            name: "coredns"
         - configMap:
             name: "coredns-custom"
 ---
@@ -42,7 +42,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: coredns-cfgmap
+  name: coredns
   namespace: kube-system
 data:
   Corefile: |

--- a/pkg/dns/testdata/configurecoredns_custom_not_patched.yaml
+++ b/pkg/dns/testdata/configurecoredns_custom_not_patched.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       volumes:
         - configMap:
-            name: "coredns-cfgmap"
+            name: "coredns"
         - configMap:
             name: "coredns-custom"
 ---
@@ -21,7 +21,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: coredns-cfgmap
+  name: coredns
   namespace: kube-system
 data:
   Corefile: |

--- a/pkg/dns/testdata/configurecoredns_not_patched.yaml
+++ b/pkg/dns/testdata/configurecoredns_not_patched.yaml
@@ -10,7 +10,7 @@ spec:
         - configMap:
             name: "other-cfgmap"
         - configMap:
-            name: "coredns-cfgmap"
+            name: "coredns"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -21,7 +21,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: coredns-cfgmap
+  name: coredns
   namespace: kube-system
 data:
   Corefile: |

--- a/pkg/dns/testdata/configurekubedns_already_patched.yaml
+++ b/pkg/dns/testdata/configurekubedns_already_patched.yaml
@@ -36,7 +36,7 @@ spec:
         - configMap:
             name: "other-cfgmap"
         - configMap:
-            name: "coredns-cfgmap"
+            name: "coredns"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -47,7 +47,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: coredns-cfgmap
+  name: coredns
   namespace: maesh
 data:
   Corefile: |

--- a/pkg/dns/testdata/configurekubedns_not_patched.yaml
+++ b/pkg/dns/testdata/configurekubedns_not_patched.yaml
@@ -36,7 +36,7 @@ spec:
         - configMap:
             name: "other-cfgmap"
         - configMap:
-            name: "coredns-cfgmap"
+            name: "coredns"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -47,7 +47,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: coredns-cfgmap
+  name: coredns
   namespace: maesh
 data:
   Corefile: |

--- a/pkg/dns/testdata/configurekubedns_not_patched.yaml
+++ b/pkg/dns/testdata/configurekubedns_not_patched.yaml
@@ -8,12 +8,12 @@ spec:
     spec:
       volumes:
         - configMap:
-            name: "kubedns-cfgmap"
+            name: "kube-dns"
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubedns-cfgmap
+  name: kube-dns
   namespace: kube-system
 ---
 apiVersion: v1

--- a/pkg/dns/testdata/configurekubedns_optional_configmap.yaml
+++ b/pkg/dns/testdata/configurekubedns_optional_configmap.yaml
@@ -31,7 +31,7 @@ spec:
         - configMap:
             name: "other-cfgmap"
         - configMap:
-            name: "coredns-cfgmap"
+            name: "coredns"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -42,7 +42,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: coredns-cfgmap
+  name: coredns
   namespace: maesh
 data:
   Corefile: |

--- a/pkg/dns/testdata/configurekubedns_optional_configmap.yaml
+++ b/pkg/dns/testdata/configurekubedns_optional_configmap.yaml
@@ -9,12 +9,7 @@ spec:
       volumes:
         - configMap:
             name: "kube-dns"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kube-dns
-  namespace: kube-system
+            optional: true
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/dns/testdata/restorecoredns_custom_not_patched.yaml
+++ b/pkg/dns/testdata/restorecoredns_custom_not_patched.yaml
@@ -10,7 +10,7 @@ spec:
         - configMap:
             name: "coredns-custom"
         - configMap:
-            name: "coredns-cfgmap"
+            name: "coredns"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -23,7 +23,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: coredns-cfgmap
+  name: coredns
   namespace: kube-system
 data:
   Corefile: |

--- a/pkg/dns/testdata/restorecoredns_custom_patched.yaml
+++ b/pkg/dns/testdata/restorecoredns_custom_patched.yaml
@@ -10,7 +10,7 @@ spec:
         - configMap:
             name: "coredns-custom"
         - configMap:
-            name: "coredns-cfgmap"
+            name: "coredns"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -43,7 +43,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: coredns-cfgmap
+  name: coredns
   namespace: kube-system
 data:
   Corefile: |

--- a/pkg/dns/testdata/restorecoredns_not_patched.yaml
+++ b/pkg/dns/testdata/restorecoredns_not_patched.yaml
@@ -10,7 +10,7 @@ spec:
         - configMap:
             name: "other-cfgmap"
         - configMap:
-            name: "coredns-cfgmap"
+            name: "coredns"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -21,7 +21,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: coredns-cfgmap
+  name: coredns
   namespace: kube-system
 data:
   Corefile: |

--- a/pkg/dns/testdata/restorecoredns_patched.yaml
+++ b/pkg/dns/testdata/restorecoredns_patched.yaml
@@ -10,7 +10,7 @@ spec:
         - configMap:
             name: "other-cfgmap"
         - configMap:
-            name: "coredns-cfgmap"
+            name: "coredns"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -21,7 +21,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: coredns-cfgmap
+  name: coredns
   namespace: kube-system
 data:
   Corefile: |

--- a/pkg/dns/testdata/restorekubedns_already_patched.yaml
+++ b/pkg/dns/testdata/restorekubedns_already_patched.yaml
@@ -8,12 +8,12 @@ spec:
     spec:
       volumes:
         - configMap:
-            name: "kubedns-cfgmap"
+            name: "kube-dns"
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubedns-cfgmap
+  name: kube-dns
   namespace: kube-system
 data:
   stubDomains: |

--- a/pkg/dns/testdata/restorekubedns_not_patched.yaml
+++ b/pkg/dns/testdata/restorekubedns_not_patched.yaml
@@ -8,12 +8,12 @@ spec:
     spec:
       volumes:
         - configMap:
-            name: "kubedns-cfgmap"
+            name: "kube-dns"
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubedns-cfgmap
+  name: kube-dns
   namespace: kube-system
 ---
 apiVersion: v1


### PR DESCRIPTION
## What does this PR do?

This PR:

- Cleanup the KubeDNS patching code.
- Fixes the KubeDNS patching code to create the `kube-dns` ConfigMap if it is optional and not yet created. For example, in a Kubernetes cluster deployed with `kops`, the `kube-dns` ConfigMap is optional and not created by default.

Fixes #652

### How to test it

* make test
* make test-integration