### PR TITLE
Wait for worker goroutine termination before exiting controller loop

### DIFF
--- a/cmd/maesh/maesh.go
+++ b/cmd/maesh/maesh.go
@@ -145,7 +145,7 @@ func maeshCommand(config *cmd.MaeshConfiguration) error {
 	go func() {
 		defer wg.Done()
 
-		if err := ctr.Run(ctx); err != nil {
+		if err := ctr.Run(); err != nil {
 			ctrlErrCh <- fmt.Errorf("controller has stopped unexpectedly: %w", err)
 		}
 	}()

--- a/cmd/maesh/maesh.go
+++ b/cmd/maesh/maesh.go
@@ -22,6 +22,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	minHTTPPort = int32(5000)
+	minTCPPort  = int32(10000)
+	minUDPPort  = int32(15000)
+)
+
 func main() {
 	maeshConfig := cmd.NewMaeshConfiguration()
 	maeshLoaders := []cli.ResourceLoader{&cmd.FileLoader{}, &cli.FlagLoader{}, &cmd.EnvLoader{}}
@@ -91,10 +97,6 @@ func maeshCommand(config *cmd.MaeshConfiguration) error {
 		return fmt.Errorf("no valid DNS provider found: %w", err)
 	}
 
-	minHTTPPort := int32(5000)
-	minTCPPort := int32(10000)
-	minUDPPort := int32(15000)
-
 	if config.SMI {
 		log.Warn("SMI mode is deprecated, please consider using --acl instead")
 	}
@@ -114,11 +116,11 @@ func maeshCommand(config *cmd.MaeshConfiguration) error {
 		WatchNamespaces:  config.WatchNamespaces,
 		IgnoreNamespaces: config.IgnoreNamespaces,
 		MinHTTPPort:      minHTTPPort,
-		MaxHTTPPort:      minHTTPPort + config.LimitHTTPPort - 1,
+		MaxHTTPPort:      getMaxPort(minHTTPPort, config.LimitHTTPPort),
 		MinTCPPort:       minTCPPort,
-		MaxTCPPort:       minTCPPort + config.LimitTCPPort - 1,
+		MaxTCPPort:       getMaxPort(minTCPPort, config.LimitTCPPort),
 		MinUDPPort:       minUDPPort,
-		MaxUDPPort:       minUDPPort + config.LimitUDPPort - 1,
+		MaxUDPPort:       getMaxPort(minUDPPort, config.LimitUDPPort),
 	}, apiServer, log)
 
 	var wg sync.WaitGroup
@@ -175,4 +177,8 @@ func stopAPIServer(apiServer *api.API, log logrus.FieldLogger) {
 	if err := apiServer.Shutdown(stopCtx); err != nil {
 		log.Errorf("Unable to stop the API server: %v", err)
 	}
+}
+
+func getMaxPort(min int32, limit int32) int32 {
+	return min + limit - 1
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -67,6 +67,9 @@ type Config struct {
 
 // Controller hold controller configuration.
 type Controller struct {
+	mu     sync.Mutex
+	stopCh chan struct{}
+
 	cfg                  Config
 	workQueue            workqueue.RateLimitingInterface
 	shadowServiceManager *ShadowServiceManager
@@ -77,7 +80,6 @@ type Controller struct {
 	topologyBuilder      TopologyBuilder
 	store                SharedStore
 	logger               logrus.FieldLogger
-	stopCh               chan struct{}
 
 	clients              k8s.Client
 	kubernetesFactory    informers.SharedInformerFactory
@@ -188,7 +190,7 @@ func NewMeshController(clients k8s.Client, cfg Config, store SharedStore, logger
 }
 
 // Run is the main controller loop.
-func (c *Controller) Run(ctx context.Context) error {
+func (c *Controller) Run() error {
 	// Handle a panic with logging and exiting.
 	defer utilruntime.HandleCrash()
 
@@ -204,7 +206,7 @@ func (c *Controller) Run(ctx context.Context) error {
 	c.logger.Debug("Initializing mesh controller")
 
 	// Start the informers.
-	if err := c.startInformers(ctx, 10*time.Second); err != nil {
+	if err := c.startInformers(10 * time.Second); err != nil {
 		return fmt.Errorf("could not start informers: %w", err)
 	}
 
@@ -226,24 +228,29 @@ func (c *Controller) Run(ctx context.Context) error {
 
 	go wait.Until(runWorker, time.Second, c.stopCh)
 
-	select {
-	case <-c.stopCh:
-	case <-ctx.Done():
-		close(c.stopCh)
-	}
+	<-c.stopCh
 
 	return nil
 }
 
 // Shutdown shut downs the controller.
 func (c *Controller) Shutdown() {
-	close(c.stopCh)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	select {
+	case <-c.stopCh:
+		// Already closed. Don't close again.
+	default:
+		// Safe to close. We're the only closer, guarded by c.mu.
+		close(c.stopCh)
+	}
 }
 
 // startInformers starts the controller informers.
-func (c *Controller) startInformers(ctx context.Context, syncTimeout time.Duration) error {
+func (c *Controller) startInformers(syncTimeout time.Duration) error {
 	// Start the informers with a timeout.
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, syncTimeout)
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), syncTimeout)
 	defer cancel()
 
 	c.logger.Debug("Starting Informers")
@@ -261,10 +268,10 @@ func (c *Controller) startInformers(ctx context.Context, syncTimeout time.Durati
 	return nil
 }
 
-func (c *Controller) startBaseInformers(ctxWithTimeout context.Context) error {
+func (c *Controller) startBaseInformers(ctx context.Context) error {
 	c.kubernetesFactory.Start(c.stopCh)
 
-	for t, ok := range c.kubernetesFactory.WaitForCacheSync(ctxWithTimeout.Done()) {
+	for t, ok := range c.kubernetesFactory.WaitForCacheSync(ctx.Done()) {
 		if !ok {
 			return fmt.Errorf("timed out waiting for controller caches to sync: %s", t)
 		}
@@ -272,7 +279,7 @@ func (c *Controller) startBaseInformers(ctxWithTimeout context.Context) error {
 
 	c.splitFactory.Start(c.stopCh)
 
-	for t, ok := range c.splitFactory.WaitForCacheSync(ctxWithTimeout.Done()) {
+	for t, ok := range c.splitFactory.WaitForCacheSync(ctx.Done()) {
 		if !ok {
 			return fmt.Errorf("timed out waiting for controller caches to sync: %s", t)
 		}
@@ -281,10 +288,10 @@ func (c *Controller) startBaseInformers(ctxWithTimeout context.Context) error {
 	return nil
 }
 
-func (c *Controller) startACLInformers(ctxWithTimeout context.Context) error {
+func (c *Controller) startACLInformers(ctx context.Context) error {
 	c.accessFactory.Start(c.stopCh)
 
-	for t, ok := range c.accessFactory.WaitForCacheSync(ctxWithTimeout.Done()) {
+	for t, ok := range c.accessFactory.WaitForCacheSync(ctx.Done()) {
 		if !ok {
 			return fmt.Errorf("timed out waiting for controller caches to sync: %s", t)
 		}
@@ -292,7 +299,7 @@ func (c *Controller) startACLInformers(ctxWithTimeout context.Context) error {
 
 	c.specsFactory.Start(c.stopCh)
 
-	for t, ok := range c.specsFactory.WaitForCacheSync(ctxWithTimeout.Done()) {
+	for t, ok := range c.specsFactory.WaitForCacheSync(ctx.Done()) {
 		if !ok {
 			return fmt.Errorf("timed out waiting for controller caches to sync: %s", t)
 		}


### PR DESCRIPTION
## What does this PR do?

This PR:

- Ensure that the worker goroutine is finished before exiting the controller loop.

Fixes #655

### How to test it

* make test
* make test-integration