### PR TITLE
Evaluate all services targeted by a TrafficTarget even if one of them already has a TrafficSplit

### DIFF
--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -132,7 +132,7 @@ func (b *Builder) evaluateTrafficTarget(res *resources, topology *Topology, tt *
 		if ok && len(svc.TrafficSplits) > 0 {
 			b.logger.Warnf("Service %q already has a TrafficSplit attached, TrafficTarget %q will not be evaluated on this service", svcKey, svcTTKey.TrafficTarget)
 
-			return
+			continue
 		}
 
 		topology.ServiceTrafficTargets[svcTTKey] = stt

--- a/pkg/topology/testdata/topology-traffic-split-traffic-target.json
+++ b/pkg/topology/testdata/topology-traffic-split-traffic-target.json
@@ -1,10 +1,10 @@
 {
   "services": {
-    "svc-b@my-ns": {
-      "name": "svc-b",
+    "svc-b1@my-ns": {
+      "name": "svc-b1",
       "namespace": "my-ns",
       "selector": {
-        "app": "app-b"
+        "app": "app-b1"
       },
       "annotations": {
         "maesh.containo.us/ratelimit-average": "100",
@@ -21,10 +21,37 @@
       ],
       "clusterIp": "10.10.1.16",
       "pods": [
-        "app-b@my-ns"
+        "app-b1@my-ns"
       ],
       "trafficSplits": [
         "ts@my-ns"
+      ]
+    },
+    "svc-b2@my-ns": {
+      "name": "svc-b2",
+      "namespace": "my-ns",
+      "selector": {
+        "app": "app-b2"
+      },
+      "annotations": {
+        "maesh.containo.us/ratelimit-average": "100",
+        "maesh.containo.us/ratelimit-burst": "200",
+        "maesh.containo.us/traffic-type": "http"
+      },
+      "ports": [
+        {
+          "name": "port-8080",
+          "protocol": "TCP",
+          "port": 8080,
+          "targetPort": 8080
+        }
+      ],
+      "clusterIp": "10.10.3.16",
+      "pods": [
+        "app-b2@my-ns"
+      ],
+      "trafficTargets": [
+        "svc-b2@my-ns:tt@my-ns"
       ]
     },
     "svc-c@my-ns": {
@@ -87,13 +114,25 @@
       "name": "app-a",
       "namespace": "my-ns",
       "serviceAccount": "service-account-a",
-      "ip": "10.10.1.1"
+      "ip": "10.10.1.1",
+      "sourceOf": [
+        "svc-b2@my-ns:tt@my-ns"
+      ]
     },
-    "app-b@my-ns": {
-      "name": "app-b",
+    "app-b1@my-ns": {
+      "name": "app-b1",
       "namespace": "my-ns",
       "serviceAccount": "service-account-b",
       "ip": "10.10.2.1"
+    },
+    "app-b2@my-ns": {
+      "name": "app-b2",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-b",
+      "ip": "10.10.3.1",
+      "destinationOf": [
+        "svc-b2@my-ns:tt@my-ns"
+      ]
     },
     "app-c@my-ns": {
       "name": "app-c",
@@ -108,12 +147,83 @@
       "ip": "10.10.2.3"
     }
   },
-  "serviceTrafficTargets": {},
+  "serviceTrafficTargets": {
+    "svc-b2@my-ns:tt@my-ns": {
+      "service": "svc-b2@my-ns",
+      "name": "tt",
+      "namespace": "my-ns",
+      "sources": [
+        {
+          "serviceAccount": "service-account-a",
+          "namespace": "my-ns",
+          "pods": [
+            "app-a@my-ns"
+          ]
+        }
+      ],
+      "destination": {
+        "serviceAccount": "service-account-b",
+        "namespace": "my-ns",
+        "ports": [
+          {
+            "name": "port-8080",
+            "protocol": "TCP",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "pods": [
+          "app-b2@my-ns"
+        ]
+      },
+      "specs": [
+        {
+          "httpRouteGroup": {
+            "kind": "HTTPRouteGroup",
+            "apiVersion": "specs.smi-spec.io/v1alpha1",
+            "metadata": {
+              "name": "http-rt-grp",
+              "namespace": "my-ns",
+              "creationTimestamp": null
+            },
+            "matches": [
+              {
+                "name": "api",
+                "methods": [
+                  "GET",
+                  "POST"
+                ],
+                "pathRegex": "/api"
+              },
+              {
+                "name": "metric",
+                "methods": [
+                  "GET"
+                ],
+                "pathRegex": "/metric"
+              }
+            ]
+          },
+          "httpMatches": [
+            {
+              "name": "api",
+              "methods": [
+                "GET",
+                "POST"
+              ],
+              "pathRegex": "/api"
+            }
+          ]
+        }
+      ],
+      "errors": null
+    }
+  },
   "trafficSplits": {
     "ts@my-ns": {
       "name": "ts",
       "namespace": "my-ns",
-      "service": "svc-b@my-ns",
+      "service": "svc-b1@my-ns",
       "backends": [
         {
           "weight": 80,


### PR DESCRIPTION
## What does this PR do?

When evaluating a TrafficTarget, targeted services should all be evaluated, even if one of them already has a TrafficSplit attached to it.

This PR fixes a mistakes in the `evaluateTrafficTarget` method of the Topology builder. The function, and so the loop get exited immediately if one of the services already has a TrafficSplit. Instead it should just skip this service and continue on the next one.

Fixes #675 

### How to test it

* `make test`
