### PR TITLE
Remove deprecated option mesh.defaultMode in the Helm chart

### DIFF
--- a/docs/content/migration/helm-chart.md
+++ b/docs/content/migration/helm-chart.md
@@ -25,7 +25,7 @@ option as described in the [documentation](../install.md#access-control-list).
 
 ### Default Mode
 
-The `controller.mesh.defaultMode` option has been deprecated and will be removed in a future major release.
+The `mesh.defaultMode` option has been deprecated and will be removed in a future major release.
 You should use the new `defaultMode` option to configure the default traffic mode for Maesh services.
 
 ### Prometheus and Grafana services
@@ -33,3 +33,10 @@ You should use the new `defaultMode` option to configure the default traffic mod
 Prior to version `v2.1`, when the Metrics chart is deployed, Prometheus and Grafana services are exposed by default through 
 a `NodePort`. For security reasons, those services are not exposed by default anymore. To expose them you should use the 
 new `prometheus.service` and `grafana.service` options, more details in the corresponding [values.yaml](https://github.com/containous/maesh/blob/e59b861ac91261b950663410a6223a02fc7e2290/helm/chart/maesh/charts/metrics/values.yaml).
+
+## v2.1 to v3.0
+
+### Default Mode
+
+The `mesh.defaultMode` option has been removed. You should use the new `defaultMode` option to configure the default traffic 
+mode for Maesh services.

--- a/helm/chart/maesh/templates/controller/controller-deployment.yaml
+++ b/helm/chart/maesh/templates/controller/controller-deployment.yaml
@@ -70,8 +70,8 @@ spec:
             {{- if or .Values.controller.logFormat .Values.logFormat }}
             - "--logFormat={{ or .Values.controller.logFormat .Values.logFormat }}"
             {{- end }}
-            {{- if or .Values.mesh.defaultMode .Values.defaultMode }}
-            - "--defaultMode={{ or .Values.mesh.defaultMode .Values.defaultMode }}"
+            {{- if .Values.defaultMode }}
+            - "--defaultMode={{ .Values.defaultMode }}"
             {{- end }}
             {{- if .Values.acl }}
             - "--acl"

--- a/helm/chart/maesh/values.yaml
+++ b/helm/chart/maesh/values.yaml
@@ -48,9 +48,6 @@ controller:
   affinity: {}
 
 mesh:
-  # (Deprecated)
-  # defaultMode: http
-
   # logLevel: error
   # logFormat: common
 

--- a/integration/testdata/values.yaml
+++ b/integration/testdata/values.yaml
@@ -28,7 +28,6 @@ mesh:
       mem: "50Mi"
       cpu: "100m"
   logging: ERROR
-  defaultMode: http
   pollInterval: "100ms"
   pollTimeout: "100ms"
 


### PR DESCRIPTION
## What does this PR do?

This PR:

- Removes the deprecated option `mesh.defaultMode` in the Helm chart.

Fixes #681.

### How to test it

* make test-integration