### PR TITLE
Fix CoreDNS config if version is greater than or equal to 1.7

### DIFF
--- a/integration/testdata/coredns/coredns.yaml
+++ b/integration/testdata/coredns/coredns.yaml
@@ -58,7 +58,6 @@ data:
         ready
         kubernetes cluster.local in-addr.arpa ip6.arpa {
           pods insecure
-          upstream
           fallthrough in-addr.arpa ip6.arpa
         }
         hosts /etc/coredns/NodeHosts {

--- a/integration/testdata/coredns/corednssafe.yaml
+++ b/integration/testdata/coredns/corednssafe.yaml
@@ -57,7 +57,6 @@ data:
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
           pods insecure
-          upstream
           fallthrough in-addr.arpa ip6.arpa
         }
         hosts /etc/coredns/NodeHosts {

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -32,6 +32,8 @@ const (
 	coreFileTrailer = "#### End Maesh Block"
 )
 
+var versionCoreDNS17 = goversion.Must(goversion.NewVersion("1.7"))
+
 // Client holds the client for interacting with the k8s DNS system.
 type Client struct {
 	kubeClient kubernetes.Interface
@@ -75,7 +77,7 @@ func (c *Client) coreDNSMatch() (bool, error) {
 	c.logger.Info("Checking CoreDNS")
 
 	deployment, err := c.kubeClient.AppsV1().Deployments(metav1.NamespaceSystem).Get("coredns", metav1.GetOptions{})
-	
+
 	if kerrors.IsNotFound(err) {
 		c.logger.Debugf("CoreDNS deployment does not exist in namespace %q", metav1.NamespaceSystem)
 		return false, nil
@@ -150,6 +152,11 @@ func (c *Client) ConfigureCoreDNS(coreDNSNamespace, clusterDomain, maeshNamespac
 }
 
 func (c *Client) patchCoreDNSConfig(deployment *appsv1.Deployment, clusterDomain, maeshNamespace string) (*corev1.ConfigMap, error) {
+	coreDNSVersion, err := c.getCoreDNSVersion(deployment)
+	if err != nil {
+		return nil, err
+	}
+
 	customConfigMap, err := c.getConfigMap(deployment, "coredns-custom")
 
 	// For AKS the CoreDNS config have to be added to the coredns-custom ConfigMap.
@@ -159,6 +166,7 @@ func (c *Client) patchCoreDNSConfig(deployment *appsv1.Deployment, clusterDomain
 			clusterDomain,
 			maeshNamespace,
 			"",
+			coreDNSVersion,
 		)
 
 		return customConfigMap, nil
@@ -173,12 +181,18 @@ func (c *Client) patchCoreDNSConfig(deployment *appsv1.Deployment, clusterDomain
 		clusterDomain,
 		maeshNamespace,
 		coreDNSConfigMap.Data["Corefile"],
+		coreDNSVersion,
 	)
 
 	return coreDNSConfigMap, nil
 }
 
-func (c *Client) addMaeshStubDomain(clusterDomain, maeshNamespace, coreDNSConfig string) string {
+func (c *Client) addMaeshStubDomain(clusterDomain, maeshNamespace, coreDNSConfig string, coreDNSVersion *goversion.Version) string {
+	// config already contains the maesh block.
+	if strings.Contains(coreDNSConfig, coreFileHeader) {
+		return coreDNSConfig
+	}
+
 	stubDomainFormat := `
 %[4]s
 maesh:53 {
@@ -189,7 +203,7 @@ maesh:53 {
     }
     kubernetes %[1]s in-addr.arpa ip6.arpa {
         pods insecure
-        upstream
+        %[6]s
         fallthrough in-addr.arpa ip6.arpa
     }
     forward . /etc/resolv.conf
@@ -200,6 +214,11 @@ maesh:53 {
 }
 %[5]s
 `
+	upstream := ""
+
+	if coreDNSVersion.LessThan(versionCoreDNS17) {
+		upstream = "upstream"
+	}
 
 	stubDomain := fmt.Sprintf(stubDomainFormat,
 		clusterDomain,
@@ -207,12 +226,8 @@ maesh:53 {
 		maeshNamespace,
 		coreFileHeader,
 		coreFileTrailer,
+		upstream,
 	)
-
-	// CoreDNS config already contains the maesh block.
-	if strings.Contains(coreDNSConfig, coreFileHeader) {
-		return coreDNSConfig
-	}
 
 	return coreDNSConfig + stubDomain
 }

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -111,6 +111,12 @@ func TestConfigureCoreDNS(t *testing.T) {
 			expectedCustom:   "\n#### Begin Maesh Block\nmaesh:53 {\n    errors\n    rewrite continue {\n        name regex ([a-zA-Z0-9-_]*)\\.([a-zv0-9-_]*)\\.maesh toto-{1}-6d61657368-{2}.toto.svc.titi\n        answer name toto-([a-zA-Z0-9-_]*)-6d61657368-([a-zA-Z0-9-_]*)\\.toto\\.svc\\.titi {1}.{2}.maesh\n    }\n    kubernetes titi in-addr.arpa ip6.arpa {\n        pods insecure\n        upstream\n        fallthrough in-addr.arpa ip6.arpa\n    }\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n}\n#### End Maesh Block\n",
 		},
 		{
+			desc:             "Config of CoreDNS 1.7",
+			mockFile:         "configurecoredns_17.yaml",
+			expectedErr:      false,
+			expectedCorefile: ".:53 {\n    errors\n    health {\n        lameduck 5s\n    }\n    ready\n    kubernetes {{ pillar['dns_domain'] }} in-addr.arpa ip6.arpa {\n        pods insecure\n        fallthrough in-addr.arpa ip6.arpa\n        ttl 30\n    }\n    prometheus :9153\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n}\n\n#### Begin Maesh Block\nmaesh:53 {\n    errors\n    rewrite continue {\n        name regex ([a-zA-Z0-9-_]*)\\.([a-zv0-9-_]*)\\.maesh toto-{1}-6d61657368-{2}.toto.svc.titi\n        answer name toto-([a-zA-Z0-9-_]*)-6d61657368-([a-zA-Z0-9-_]*)\\.toto\\.svc\\.titi {1}.{2}.maesh\n    }\n    kubernetes titi in-addr.arpa ip6.arpa {\n        pods insecure\n        \n        fallthrough in-addr.arpa ip6.arpa\n    }\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n}\n#### End Maesh Block\n",
+		},
+		{
 			desc:        "Missing CoreDNS deployment",
 			mockFile:    "configurecoredns_missing_deployment.yaml",
 			expectedErr: true,

--- a/pkg/dns/testdata/configurecoredns_17.yaml
+++ b/pkg/dns/testdata/configurecoredns_17.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: coredns
+          image: coredns:1.7.0
+      volumes:
+        - configMap:
+            name: "other-cfgmap"
+        - configMap:
+            name: "coredns"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: other-cfgmap
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health {
+            lameduck 5s
+        }
+        ready
+        kubernetes {{ pillar['dns_domain'] }} in-addr.arpa ip6.arpa {
+            pods insecure
+            fallthrough in-addr.arpa ip6.arpa
+            ttl 30
+        }
+        prometheus :9153
+        forward . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }

--- a/pkg/dns/testdata/configurecoredns_already_patched.yaml
+++ b/pkg/dns/testdata/configurecoredns_already_patched.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      containers:
+        - name: coredns
+          image: coredns:1.6.0
       volumes:
         - configMap:
             name: "other-cfgmap"

--- a/pkg/dns/testdata/configurecoredns_custom_already_patched.yaml
+++ b/pkg/dns/testdata/configurecoredns_custom_already_patched.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      containers:
+        - name: coredns
+          image: coredns:1.6.0
       volumes:
         - configMap:
             name: "coredns"

--- a/pkg/dns/testdata/configurecoredns_custom_not_patched.yaml
+++ b/pkg/dns/testdata/configurecoredns_custom_not_patched.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      containers:
+        - name: coredns
+          image: coredns:1.6.0
       volumes:
         - configMap:
             name: "coredns"

--- a/pkg/dns/testdata/configurecoredns_not_patched.yaml
+++ b/pkg/dns/testdata/configurecoredns_not_patched.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      containers:
+        - name: coredns
+          image: coredns:1.6.0
       volumes:
         - configMap:
             name: "other-cfgmap"

--- a/pkg/dns/testdata/configurekubedns_already_patched.yaml
+++ b/pkg/dns/testdata/configurekubedns_already_patched.yaml
@@ -32,6 +32,9 @@ metadata:
 spec:
   template:
     spec:
+      containers:
+        - name: coredns
+          image: coredns:1.6.0
       volumes:
         - configMap:
             name: "other-cfgmap"

--- a/pkg/dns/testdata/configurekubedns_not_patched.yaml
+++ b/pkg/dns/testdata/configurekubedns_not_patched.yaml
@@ -32,6 +32,9 @@ metadata:
 spec:
   template:
     spec:
+      containers:
+        - name: coredns
+          image: coredns:1.6.0
       volumes:
         - configMap:
             name: "other-cfgmap"

--- a/pkg/dns/testdata/configurekubedns_optional_configmap.yaml
+++ b/pkg/dns/testdata/configurekubedns_optional_configmap.yaml
@@ -27,6 +27,9 @@ metadata:
 spec:
   template:
     spec:
+      containers:
+        - name: coredns
+          image: coredns:1.6.0
       volumes:
         - configMap:
             name: "other-cfgmap"


### PR DESCRIPTION
## What does this PR do?

This PR:

- Removes the `upstream` keyword in the CoreDNS config if version is greater than `1.7` 

Fixes #685 

<!-- A brief description of the change being made with this pull request. -->

### How to test it

* make test
* make test-integration