### PR TITLE
Prevent shadow-service creation for CoreDNS and a custom release name

### DIFF
--- a/helm/chart/maesh/charts/metrics/templates/grafana-pdb.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/grafana-pdb.yaml
@@ -4,7 +4,8 @@ kind: PodDisruptionBudget
 metadata:
   name: grafana
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: grafana
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -12,5 +13,5 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app: grafana
-      component: core
+      app: maesh
+      component: grafana

--- a/helm/chart/maesh/charts/metrics/templates/grafana.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/grafana.yaml
@@ -5,22 +5,22 @@ metadata:
   name: grafana-core
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: grafana
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-    component: grafana
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: grafana
-      component: core
+      app: maesh
+      component: grafana
   template:
     metadata:
       labels:
-        app: grafana
-        component: core
+        app: maesh
+        component: grafana
     spec:
       serviceAccountName: grafana-k8s
       automountServiceAccountToken: false
@@ -100,11 +100,11 @@ metadata:
   name: grafana-config
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: grafana
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-    component: grafana
 data:
   grafana.ini: |-
     instance_name = containous-grafana
@@ -155,11 +155,11 @@ metadata:
   name: grafana
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: grafana
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-    component: grafana
 spec:
   type: {{ .Values.grafana.service.type }}
   ports:
@@ -169,8 +169,8 @@ spec:
       nodePort: {{ .Values.grafana.service.nodePort }}
       {{- end }}
   selector:
-    app: grafana
-    component: core
+    app: maesh
+    component: grafana
 
 ---
 {{- $files := .Files }}
@@ -183,6 +183,7 @@ metadata:
   name: grafana-dashboard-{{ $filename }}
   namespace: {{ $ns }}
   labels:
+    app: maesh
     component: grafana
 data:
   {{ base $path }}: '{{ $files.Get $path }}'

--- a/helm/chart/maesh/charts/metrics/templates/prometheus-pdb.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/prometheus-pdb.yaml
@@ -4,7 +4,8 @@ kind: PodDisruptionBudget
 metadata:
   name: prometheus
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: prometheus
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -12,5 +13,5 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app: prometheus
-      component: core
+      app: maesh
+      component: prometheus

--- a/helm/chart/maesh/charts/metrics/templates/prometheus.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/prometheus.yaml
@@ -6,11 +6,11 @@ metadata:
   name: prometheus-rules
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: prometheus
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-    component: prometheus
 data:
   general.yaml: |
     groups:
@@ -29,11 +29,11 @@ metadata:
   name: prometheus-core
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: prometheus
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-    component: prometheus
 data:
   prometheus.yaml: |
     global:
@@ -71,23 +71,23 @@ metadata:
   name: prometheus-core
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: prometheus
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-    component: prometheus
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: prometheus
-      component: core
+      app: maesh
+      component: prometheus
   template:
     metadata:
       name: prometheus-main
       labels:
-        app: prometheus
-        component: core
+        app: maesh
+        component: prometheus
     spec:
       serviceAccountName: prometheus-k8s
       automountServiceAccountToken: true
@@ -175,11 +175,11 @@ metadata:
   name: prometheus
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: prometheus
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-    component: prometheus
   annotations:
     prometheus.io/scrape: 'true'
 spec:
@@ -193,5 +193,5 @@ spec:
       protocol: TCP
       name: webui
   selector:
-    app: prometheus
-    component: core
+    app: maesh
+    component: prometheus

--- a/helm/chart/maesh/charts/metrics/templates/rbac.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/rbac.yaml
@@ -4,6 +4,8 @@ kind: ClusterRoleBinding
 metadata:
   name: prometheus
   labels:
+    app: maesh
+    component: prometheus
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -22,6 +24,8 @@ kind: ClusterRole
 metadata:
   name: prometheus
   labels:
+    app: maesh
+    component: prometheus
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -51,6 +55,8 @@ metadata:
   name: prometheus-k8s
   namespace: {{ .Release.Namespace }}
   labels:
+    app: maesh
+    component: prometheus
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -62,6 +68,8 @@ metadata:
   name: grafana-k8s
   namespace: {{ .Release.Namespace }}
   labels:
+    app: maesh
+    component: grafana
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/helm/chart/maesh/charts/metrics/templates/storage.yaml
+++ b/helm/chart/maesh/charts/metrics/templates/storage.yaml
@@ -5,6 +5,8 @@ metadata:
   name: metrics-storage
   namespace: {{ .Release.Namespace }}
   labels:
+    app: maesh
+    component: grafana
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -25,6 +27,8 @@ metadata:
   name: prometheus-storage
   namespace: {{ .Release.Namespace }}
   labels:
+    app: maesh
+    component: prometheus
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/helm/chart/maesh/charts/tracing/templates/jaeger-deployment.yaml
+++ b/helm/chart/maesh/charts/tracing/templates/jaeger-deployment.yaml
@@ -19,21 +19,24 @@ metadata:
   name: jaeger
   namespace: {{ .Release.Namespace }}
   labels:
-    app: maesh
-    component: jaeger
+    app: jaeger
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/component: all-in-one
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: maesh
-      component: jaeger
+      app: jaeger
+      app.kubernetes.io/name: jaeger
+      app.kubernetes.io/component: all-in-one
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: maesh
-        component: jaeger
+        app: jaeger
+        app.kubernetes.io/name: jaeger
+        app.kubernetes.io/component: all-in-one
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "16686"

--- a/helm/chart/maesh/charts/tracing/templates/jaeger-deployment.yaml
+++ b/helm/chart/maesh/charts/tracing/templates/jaeger-deployment.yaml
@@ -19,24 +19,21 @@ metadata:
   name: jaeger
   namespace: {{ .Release.Namespace }}
   labels:
-    app: jaeger
-    app.kubernetes.io/name: jaeger
-    app.kubernetes.io/component: all-in-one
+    app: maesh
+    component: jaeger
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: jaeger
-      app.kubernetes.io/name: jaeger
-      app.kubernetes.io/component: all-in-one
+      app: maesh
+      component: jaeger
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: jaeger
-        app.kubernetes.io/name: jaeger
-        app.kubernetes.io/component: all-in-one
+        app: maesh
+        component: jaeger
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "16686"
@@ -47,52 +44,52 @@ spec:
         runAsNonRoot: true
         runAsUser: 999
       containers:
-        -   env:
-              - name: COLLECTOR_ZIPKIN_HTTP_PORT
-                value: "9411"
-            image: {{ .Values.image.jaeger | quote }}
-            name: jaeger
-            ports:
-              - containerPort: 5775
-                protocol: UDP
-                name: thrift-legacy
-              - containerPort: 6831
-                protocol: UDP
-                name: compact-thrift
-              - containerPort: 6832
-                protocol: UDP
-                name: binary-thrift
-              - containerPort: 5778
-                protocol: TCP
-                name: serve-configs
-              - containerPort: 9411
-                protocol: TCP
-                name: collector-zip
-              - containerPort: 14267
-                protocol: TCP
-                name: collector-tch
-              - containerPort: 14268
-                protocol: TCP
-                name: collector-http
-              - containerPort: 14269
-                protocol: TCP
-                name: readiness
-              - containerPort: 16686
-                protocol: TCP
-                name: serve-frontend
-            readinessProbe:
-              httpGet:
-                path: "/"
-                port: readiness
-              initialDelaySeconds: 5
-            livenessProbe:
-              tcpSocket:
-                port: readiness
-              initialDelaySeconds: 5
-            resources:
-              requests:
-                memory: "50Mi"
-                cpu: "100m"
-              limits:
-                memory: "100Mi"
-                cpu: "200m"
+        - env:
+          - name: COLLECTOR_ZIPKIN_HTTP_PORT
+            value: "9411"
+          image: {{ .Values.image.jaeger | quote }}
+          name: jaeger
+          ports:
+            - containerPort: 5775
+              protocol: UDP
+              name: thrift-legacy
+            - containerPort: 6831
+              protocol: UDP
+              name: compact-thrift
+            - containerPort: 6832
+              protocol: UDP
+              name: binary-thrift
+            - containerPort: 5778
+              protocol: TCP
+              name: serve-configs
+            - containerPort: 9411
+              protocol: TCP
+              name: collector-zip
+            - containerPort: 14267
+              protocol: TCP
+              name: collector-tch
+            - containerPort: 14268
+              protocol: TCP
+              name: collector-http
+            - containerPort: 14269
+              protocol: TCP
+              name: readiness
+            - containerPort: 16686
+              protocol: TCP
+              name: serve-frontend
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: readiness
+            initialDelaySeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: readiness
+            initialDelaySeconds: 5
+          resources:
+            requests:
+              memory: "50Mi"
+              cpu: "100m"
+            limits:
+              memory: "100Mi"
+              cpu: "200m"

--- a/helm/chart/maesh/charts/tracing/templates/jaeger-pdb.yaml
+++ b/helm/chart/maesh/charts/tracing/templates/jaeger-pdb.yaml
@@ -4,7 +4,8 @@ kind: PodDisruptionBudget
 metadata:
   name: jaeger
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: jaeger
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -12,6 +13,5 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app: jaeger
-      app.kubernetes.io/name: jaeger
-      app.kubernetes.io/component: all-in-one
+      app: maesh
+      component: jaeger

--- a/helm/chart/maesh/charts/tracing/templates/jaeger-pdb.yaml
+++ b/helm/chart/maesh/charts/tracing/templates/jaeger-pdb.yaml
@@ -4,8 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   name: jaeger
   labels:
-    app: maesh
-    component: jaeger
+    app: jaeger
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -13,5 +12,6 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app: maesh
-      component: jaeger
+      app: jaeger
+      app.kubernetes.io/name: jaeger
+      app.kubernetes.io/component: all-in-one

--- a/helm/chart/maesh/charts/tracing/templates/jaeger-sa.yaml
+++ b/helm/chart/maesh/charts/tracing/templates/jaeger-sa.yaml
@@ -5,8 +5,7 @@ metadata:
   name: jaeger
   namespace: {{ .Release.Namespace }}
   labels:
-    app: maesh
-    component: jaeger
+    app: jaeger
     chart: {{ include "maesh.chartLabel" . | quote}}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/helm/chart/maesh/charts/tracing/templates/jaeger-sa.yaml
+++ b/helm/chart/maesh/charts/tracing/templates/jaeger-sa.yaml
@@ -5,7 +5,8 @@ metadata:
   name: jaeger
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote}}
+    app: maesh
+    component: jaeger
     chart: {{ include "maesh.chartLabel" . | quote}}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/helm/chart/maesh/charts/tracing/templates/jaeger-services.yaml
+++ b/helm/chart/maesh/charts/tracing/templates/jaeger-services.yaml
@@ -5,8 +5,9 @@ metadata:
   name: jaeger-query
   namespace: {{ .Release.Namespace }}
   labels:
-    app: maesh
-    component: jaeger-query
+    app: jaeger
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/component: query
 spec:
   ports:
     - name: query-http
@@ -14,8 +15,8 @@ spec:
       port: 16686
       targetPort: serve-frontend
   selector:
-    app: maesh
-    component: jaeger
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/component: all-in-one
   type: ClusterIP
 
 ---
@@ -25,8 +26,9 @@ metadata:
   name: jaeger-collector
   namespace: {{ .Release.Namespace }}
   labels:
-    app: maesh
-    component: jaeger-collector
+    app: jaeger
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/component: collector
 spec:
   ports:
     - name: jaeger-collector-tchannel
@@ -42,8 +44,8 @@ spec:
       protocol: TCP
       targetPort: collector-zip
   selector:
-    app: maesh
-    component: jaeger
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/component: all-in-one
   type: ClusterIP
 
 ---
@@ -53,8 +55,9 @@ metadata:
   name: jaeger-agent
   namespace: {{ .Release.Namespace }}
   labels:
-    app: maesh
-    component: jaeger-agent
+    app: jaeger
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/component: agent
 spec:
   ports:
     - name: agent-zipkin-thrift
@@ -75,8 +78,8 @@ spec:
       targetPort: serve-configs
   clusterIP: None
   selector:
-    app: maesh
-    component: jaeger
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/component: all-in-one
 
 ---
 apiVersion: v1
@@ -85,8 +88,9 @@ metadata:
   name: zipkin
   namespace: {{ .Release.Namespace }}
   labels:
-    app: maesh
-    component: jaeger-zipkin
+    app: jaeger
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/component: zipkin
 spec:
   ports:
     - name: jaeger-collector-zipkin
@@ -95,5 +99,5 @@ spec:
       targetPort: collector-zip
   clusterIP: None
   selector:
-    app: maesh
-    component: jaeger
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/component: all-in-one

--- a/helm/chart/maesh/charts/tracing/templates/jaeger-services.yaml
+++ b/helm/chart/maesh/charts/tracing/templates/jaeger-services.yaml
@@ -5,9 +5,8 @@ metadata:
   name: jaeger-query
   namespace: {{ .Release.Namespace }}
   labels:
-    app: jaeger
-    app.kubernetes.io/name: jaeger
-    app.kubernetes.io/component: query
+    app: maesh
+    component: jaeger-query
 spec:
   ports:
     - name: query-http
@@ -15,8 +14,8 @@ spec:
       port: 16686
       targetPort: serve-frontend
   selector:
-    app.kubernetes.io/name: jaeger
-    app.kubernetes.io/component: all-in-one
+    app: maesh
+    component: jaeger
   type: ClusterIP
 
 ---
@@ -26,9 +25,8 @@ metadata:
   name: jaeger-collector
   namespace: {{ .Release.Namespace }}
   labels:
-    app: jaeger
-    app.kubernetes.io/name: jaeger
-    app.kubernetes.io/component: collector
+    app: maesh
+    component: jaeger-collector
 spec:
   ports:
     - name: jaeger-collector-tchannel
@@ -44,8 +42,8 @@ spec:
       protocol: TCP
       targetPort: collector-zip
   selector:
-    app.kubernetes.io/name: jaeger
-    app.kubernetes.io/component: all-in-one
+    app: maesh
+    component: jaeger
   type: ClusterIP
 
 ---
@@ -55,9 +53,8 @@ metadata:
   name: jaeger-agent
   namespace: {{ .Release.Namespace }}
   labels:
-    app: jaeger
-    app.kubernetes.io/name: jaeger
-    app.kubernetes.io/component: agent
+    app: maesh
+    component: jaeger-agent
 spec:
   ports:
     - name: agent-zipkin-thrift
@@ -78,8 +75,8 @@ spec:
       targetPort: serve-configs
   clusterIP: None
   selector:
-    app.kubernetes.io/name: jaeger
-    app.kubernetes.io/component: all-in-one
+    app: maesh
+    component: jaeger
 
 ---
 apiVersion: v1
@@ -88,9 +85,8 @@ metadata:
   name: zipkin
   namespace: {{ .Release.Namespace }}
   labels:
-    app: jaeger
-    app.kubernetes.io/name: jaeger
-    app.kubernetes.io/component: zipkin
+    app: maesh
+    component: jaeger-zipkin
 spec:
   ports:
     - name: jaeger-collector-zipkin
@@ -99,5 +95,5 @@ spec:
       targetPort: collector-zip
   clusterIP: None
   selector:
-    app.kubernetes.io/name: jaeger
-    app.kubernetes.io/component: all-in-one
+    app: maesh
+    component: jaeger

--- a/helm/chart/maesh/templates/controller/controller-deployment.yaml
+++ b/helm/chart/maesh/templates/controller/controller-deployment.yaml
@@ -5,7 +5,8 @@ metadata:
   name: maesh-controller
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: controller
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -13,13 +14,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name | quote }}
+      app: maesh
       component: controller
       release: {{ .Release.Name | quote }}
   template:
     metadata:
       labels:
-        app: {{ .Release.Name | quote }}
+        app: maesh
         component: controller
         release: {{ .Release.Name | quote }}
       annotations:

--- a/helm/chart/maesh/templates/controller/controller-pdb.yaml
+++ b/helm/chart/maesh/templates/controller/controller-pdb.yaml
@@ -5,7 +5,8 @@ metadata:
   name: maesh-controller
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: controller
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -13,6 +14,6 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name | quote }}
+      app: maesh
       component: controller
       release: {{ .Release.Name | quote }}

--- a/helm/chart/maesh/templates/controller/controller-rbac.yaml
+++ b/helm/chart/maesh/templates/controller/controller-rbac.yaml
@@ -5,7 +5,8 @@ metadata:
   name: maesh-controller-role
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote}}
+    app: maesh
+    component: controller
     chart: {{ include "maesh.chartLabel" . | quote}}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -75,7 +76,8 @@ metadata:
   name: maesh-controller
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote}}
+    app: maesh
+    component: controller
     chart: {{ include "maesh.chartLabel" . | quote}}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/helm/chart/maesh/templates/controller/controller-sa.yaml
+++ b/helm/chart/maesh/templates/controller/controller-sa.yaml
@@ -5,7 +5,8 @@ metadata:
   name: maesh-controller
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote}}
+    app: maesh
+    component: controller
     chart: {{ include "maesh.chartLabel" . | quote}}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
+++ b/helm/chart/maesh/templates/controller/hooks/cleanup-hook.yaml
@@ -5,7 +5,8 @@ metadata:
   name: maesh-cleanup
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote}}
+    app: maesh
+    component: cleanup
     chart: {{ include "maesh.chartLabel" . | quote}}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -21,7 +22,8 @@ metadata:
   name: maesh-cleanup-role
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote}}
+    app: maesh
+    component: cleanup
     chart: {{ include "maesh.chartLabel" . | quote}}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -61,7 +63,8 @@ metadata:
   name: maesh-cleanup
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote}}
+    app: maesh
+    component: cleanup
     chart: {{ include "maesh.chartLabel" . | quote}}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -85,7 +88,8 @@ metadata:
   name: maesh-cleanup
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote}}
+    app: maesh
+    component: cleanup
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote}}
     heritage: {{ .Release.Service | quote}}
@@ -99,7 +103,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ .Release.Name | quote}}
+        app: maesh
         component: cleanup
         release: {{ .Release.Name | quote}}
     spec:

--- a/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-configmap.yaml
@@ -6,6 +6,8 @@ metadata:
   name: coredns
   namespace: {{ .Release.Namespace }}
   labels:
+    app: maesh
+    component: coredns
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote}}
     heritage: {{ .Release.Service | quote}}

--- a/helm/chart/maesh/templates/dns/coredns/coredns-deployment.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-deployment.yaml
@@ -6,8 +6,8 @@ metadata:
   name: coredns
   namespace: {{ .Release.Namespace }}
   labels:
-    k8s-app: coredns
-    kubernetes.io/name: "CoreDNS"
+    app: maesh
+    component: coredns
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote}}
     heritage: {{ .Release.Service | quote}}
@@ -19,11 +19,13 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      k8s-app: coredns
+      app: maesh
+      component: coredns
   template:
     metadata:
       labels:
-        k8s-app: coredns
+        app: maesh
+        component: coredns
     spec:
       serviceAccountName: maesh-coredns
       affinity:
@@ -33,10 +35,14 @@ spec:
               podAffinityTerm:
                 labelSelector:
                   matchExpressions:
-                    - key: k8s-app
+                    - key: app
                       operator: In
                       values:
-                        - corednss
+                        - maesh
+                    - key: component
+                      operator: In
+                      values:
+                        - coredns
                 topologyKey: "kubernetes.io/hostname"
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/helm/chart/maesh/templates/dns/coredns/coredns-rbac.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-rbac.yaml
@@ -4,7 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   labels:
-    kubernetes.io/bootstrapping: rbac-defaults
+    app: maesh
+    component: coredns
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote}}
     heritage: {{ .Release.Service | quote}}
@@ -35,7 +36,8 @@ metadata:
   name: maesh-coredns
   namespace: {{ .Release.Namespace }}
   labels:
-    kubernetes.io/bootstrapping: rbac-defaults
+    app: maesh
+    component: coredns
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote}}
     heritage: {{ .Release.Service | quote}}

--- a/helm/chart/maesh/templates/dns/coredns/coredns-sa.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-sa.yaml
@@ -6,6 +6,8 @@ metadata:
   name: maesh-coredns
   namespace: {{ .Release.Namespace }}
   labels:
+    app: maesh
+    component: coredns
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote}}
     heritage: {{ .Release.Service | quote}}

--- a/helm/chart/maesh/templates/dns/coredns/coredns-service.yaml
+++ b/helm/chart/maesh/templates/dns/coredns/coredns-service.yaml
@@ -6,9 +6,8 @@ metadata:
   name: coredns
   namespace: {{ .Release.Namespace }}
   labels:
-    k8s-app: coredns
-    kubernetes.io/name: "CoreDNS"
-    kubernetes.io/cluster-service: "true"
+    app: maesh
+    component: coredns
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote}}
     heritage: {{ .Release.Service | quote}}
@@ -17,7 +16,8 @@ metadata:
     prometheus.io/scrape: "true"
 spec:
   selector:
-    k8s-app: coredns
+    app: maesh
+    component: coredns
   type: ClusterIP
   ports:
     - name: dns

--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -5,7 +5,8 @@ metadata:
   name: maesh-mesh
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: maesh-mesh
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -16,13 +17,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name | quote }}
+      app: maesh
       component: maesh-mesh
       release: {{ .Release.Name | quote }}
   template:
     metadata:
       labels:
-        app: {{ .Release.Name | quote }}
+        app: maesh
         component: maesh-mesh
         release: {{ .Release.Name | quote }}
       annotations:
@@ -57,7 +58,7 @@ spec:
           imagePullPolicy: {{ .Values.tracing.jaeger.image.pullPolicy | default "IfNotPresent" }}
           args:
             - "service"
-            - "-lapp.kubernetes.io/name=jaeger,app.kubernetes.io/component=agent"
+            - "-lapp=maesh,component=jaeger-agent"
           resources:
             requests:
               memory: "10Mi"

--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -58,7 +58,7 @@ spec:
           imagePullPolicy: {{ .Values.tracing.jaeger.image.pullPolicy | default "IfNotPresent" }}
           args:
             - "service"
-            - "-lapp=maesh,component=jaeger-agent"
+            - "-lapp.kubernetes.io/name=jaeger,app.kubernetes.io/component=agent"
           resources:
             requests:
               memory: "10Mi"

--- a/helm/chart/maesh/templates/mesh/mesh-pdb.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-pdb.yaml
@@ -5,7 +5,8 @@ metadata:
   name: maesh-mesh
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote }}
+    app: maesh
+    component: maesh-mesh
     chart: {{ include "maesh.chartLabel" . | quote }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -13,6 +14,6 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name | quote }}
+      app: maesh
       component: maesh-mesh
       release: {{ .Release.Name | quote }}

--- a/helm/chart/maesh/templates/mesh/mesh-rbac.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-rbac.yaml
@@ -5,7 +5,8 @@ metadata:
   name: maesh-mesh-role
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote}}
+    app: maesh
+    component: maesh-mesh
     chart: {{ include "maesh.chartLabel" . | quote}}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -24,7 +25,8 @@ metadata:
   name: maesh-mesh
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote}}
+    app: maesh
+    component: maesh-mesh
     chart: {{ include "maesh.chartLabel" . | quote}}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/helm/chart/maesh/templates/mesh/mesh-sa.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-sa.yaml
@@ -5,7 +5,8 @@ metadata:
   name: maesh-mesh
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name | quote}}
+    app: maesh
+    component: maesh-mesh
     chart: {{ include "maesh.chartLabel" . | quote}}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/helm/chart/maesh/templates/mesh/mesh-service.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: maesh
+    component: maesh-mesh
 spec:
   type: ClusterIP
   ports:
@@ -13,4 +14,5 @@ spec:
       name: mesh-api
       targetPort: api
   selector:
+    app: maesh
     component: maesh-mesh

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -112,7 +112,7 @@ func NewMeshController(clients k8s.Client, cfg Config, store SharedStore, logger
 		k8s.IgnoreNamespaces(cfg.IgnoreNamespaces...),
 		k8s.IgnoreNamespaces(metav1.NamespaceSystem),
 		k8s.IgnoreService(metav1.NamespaceDefault, "kubernetes"),
-		k8s.IgnoreApps("maesh", "jaeger"),
+		k8s.IgnoreApps("maesh"),
 	)
 
 	// Create the work queue and the enqueue handler.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -112,7 +112,7 @@ func NewMeshController(clients k8s.Client, cfg Config, store SharedStore, logger
 		k8s.IgnoreNamespaces(cfg.IgnoreNamespaces...),
 		k8s.IgnoreNamespaces(metav1.NamespaceSystem),
 		k8s.IgnoreService(metav1.NamespaceDefault, "kubernetes"),
-		k8s.IgnoreApps("maesh"),
+		k8s.IgnoreApps("maesh", "jaeger"),
 	)
 
 	// Create the work queue and the enqueue handler.


### PR DESCRIPTION
## What does this PR do?

This PR updates the labels in resources defined in the Helm Chart:
- Harmonize them to only use `app` and `component`. This will allow to ease the implementation of #693
- Add a `app: maesh` label on coredns files to make sure we ignore this service and not create a shadow-service

Fixes #692, #690 

### How to test it

* make test-integration
* Install Maesh and make sure Jaeger and Grafana integration still works.