### PR TITLE
Remove unused Azure/go-autorest dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,10 +20,7 @@ require (
 	k8s.io/client-go v0.17.4
 )
 
-replace (
-	github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.1.0+incompatible
-	github.com/docker/docker => github.com/docker/engine v1.4.2-0.20200204220554-5f6d6f3f2203
-)
+replace github.com/docker/docker => github.com/docker/engine v1.4.2-0.20200204220554-5f6d6f3f2203
 
 // Containous forks
 replace (


### PR DESCRIPTION
## What does this PR do?

This PR removes the unused `github.com/Azure/go-autorest` dependency.

### How to test it

* make test
* make test-integration

## Additional Notes

You can check that the dependency is not required anymore with `go mod why -m github.com/Azure/go-autorest`