### PR TITLE
Remove init container used to wait for jaeger init

### DIFF
--- a/helm/chart/maesh/Chart.yaml
+++ b/helm/chart/maesh/Chart.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v2
 name: maesh
 version: 2.1.2
@@ -25,7 +24,6 @@ maintainers:
     email: harold@containo.us
   - name: kevinpollet
     email: kevin@containo.us
-engine: gotpl
 icon: https://raw.githubusercontent.com/containous/maesh/v1.2/docs/content/assets/img/maesh.png
 dependencies:
   - name: tracing

--- a/helm/chart/maesh/Chart.yaml
+++ b/helm/chart/maesh/Chart.yaml
@@ -4,6 +4,7 @@ name: maesh
 version: 2.1.2
 appVersion: v1.3.2
 description: Maesh - Simpler Service Mesh
+type: application
 keywords:
   - traefik
   - mesh

--- a/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-daemonset.yaml
@@ -51,21 +51,6 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
-      {{- if .Values.tracing.deploy }}
-      initContainers:
-        - name: wait-for-jaeger-init
-          image: groundnuty/k8s-wait-for:v1.3
-          args:
-            - "service"
-            - "-lapp.kubernetes.io/name=jaeger,app.kubernetes.io/component=agent"
-          resources:
-            requests:
-              memory: "10Mi"
-              cpu: "50m"
-            limits:
-              memory: "20Mi"
-              cpu: "100m"
-      {{- end }}
       containers:
         - name: maesh-mesh
           image: {{ include "maesh.meshImage" . | quote }}
@@ -110,6 +95,7 @@ spec:
               {{- else }}
             - {{ printf "--tracing.jaeger.samplingServerURL=http://jaeger-agent.%s.svc.%s:5778/sampling" .Release.Namespace (default "cluster.local" .Values.clusterDomain) | quote }}
               {{- end }}
+            - "--tracing.jaeger.disableAttemptReconnecting=false"
             {{- end }}
             {{- if .Values.tracing.datadog }}
               {{- if .Values.tracing.datadog.localagenthostport }}


### PR DESCRIPTION
## What does this PR do?

This PR:

- Adds the `type` field to the Helm chart [descriptor](https://helm.sh/docs/topics/charts/#the-chartyaml-file)
- Removes the unsupported `engine` property from the Helm chart [descriptor](https://helm.sh/docs/topics/charts/#the-chartyaml-file)
- Removes the init container used to wait for the Jaeger service to be ready as of Traefik `v2.3-rc4` the Jaeger client will attempt to [reconnect](https://github.com/containous/traefik/pull/7198).

### How to test it

* Install `Maesh` with Helm
* Install a `whoami` service
* Make a request and check that the `Uber-Trace-Id` header is here. 
