### PR TITLE
Add support for TrafficSplit filtering

### DIFF
--- a/pkg/k8s/constants.go
+++ b/pkg/k8s/constants.go
@@ -8,12 +8,21 @@ const (
 	// ResyncPeriod set the resync period.
 	ResyncPeriod = 5 * time.Minute
 
+	// TrafficSplitObjectKind is the name of an SMI object of kind TrafficSplit.
+	TrafficSplitObjectKind = "TrafficSplit"
+	// TrafficTargetObjectKind is the name of an SMI object of kind TrafficTarget.
+	TrafficTargetObjectKind = "TrafficTarget"
+	// HTTPRouteGroupObjectKind is the name of an SMI object of kind HTTPRouteGroup.
+	HTTPRouteGroupObjectKind = "HTTPRouteGroup"
+	// TCPRouteObjectKind is the name of an SMI object of kind TCPRoute.
+	TCPRouteObjectKind = "TCPRoute"
+
 	// CoreObjectKinds is a filter for objects to process by the core client.
 	CoreObjectKinds = "Deployment|Endpoints|Service|Ingress|Secret|Namespace|Pod|ConfigMap"
 	// AccessObjectKinds is a filter for objects to process by the access client.
-	AccessObjectKinds = "TrafficTarget"
+	AccessObjectKinds = TrafficTargetObjectKind
 	// SpecsObjectKinds is a filter for objects to process by the specs client.
-	SpecsObjectKinds = "HTTPRouteGroup|TCPRoute"
+	SpecsObjectKinds = HTTPRouteGroupObjectKind + "|" + TCPRouteObjectKind
 	// SplitObjectKinds is a filter for objects to process by the split client.
-	SplitObjectKinds = "TrafficSplit"
+	SplitObjectKinds = TrafficSplitObjectKind
 )

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -405,7 +405,7 @@ func (p *Provider) buildServiceAndRoutersForTrafficSplit(t *topology.Topology, c
 }
 
 func (p *Provider) buildHTTPServiceAndRoutersForTrafficSplit(t *topology.Topology, cfg *dynamic.Configuration, tsKey topology.Key, scheme string, ts *topology.TrafficSplit, tsSvc *topology.Service, middlewares []string) {
-	rule := buildHTTPRuleFromService(tsSvc)
+	rule := buildHTTPRuleFromTrafficSplit(ts, tsSvc)
 
 	rtrMiddlewares := middlewares
 
@@ -449,7 +449,7 @@ func (p *Provider) buildHTTPServiceAndRoutersForTrafficSplit(t *topology.Topolog
 			whitelistIndirectKey := getWhitelistMiddlewareKeyFromTrafficSplitIndirect(ts)
 			cfg.HTTP.Middlewares[whitelistIndirectKey] = whitelistIndirect
 
-			rule = buildHTTPRuleFromTrafficSplitIndirect(tsSvc)
+			rule = buildHTTPRuleFromTrafficSplitIndirect(ts, tsSvc)
 			rtrMiddlewaresindirect := addToSliceCopy(middlewares, whitelistIndirectKey)
 
 			indirectRtrKey := getRouterKeyFromTrafficSplitIndirect(ts, svcPort.Port)

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -122,6 +122,13 @@ func TestProvider_BuildConfig(t *testing.T) {
 			topology:           "testdata/acl-enabled-http-traffic-split-topology.json",
 			wantConfig:         "testdata/acl-enabled-http-traffic-split-config.json",
 		},
+		{
+			desc:               "ACL enabled: HTTP service with traffic-split and http-route-group",
+			acl:                true,
+			defaultTrafficType: "http",
+			topology:           "testdata/acl-enabled-http-traffic-split-http-route-group-topology.json",
+			wantConfig:         "testdata/acl-enabled-http-traffic-split-http-route-group-config.json",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/provider/rule.go
+++ b/pkg/provider/rule.go
@@ -105,7 +105,7 @@ func buildHTTPRuleFromTrafficTarget(tt *topology.ServiceTrafficTarget, ttSvc *to
 }
 
 func buildHTTPRuleFromTrafficSplit(ts *topology.TrafficSplit, tsSvc *topology.Service) string {
-	tsRule := buildHTTPRuleFromTrafficSpecs(ts.Specs)
+	tsRule := buildHTTPRuleFromTrafficSpecs(ts.Rules)
 	svcRule := buildHTTPRuleFromService(tsSvc)
 
 	if tsRule != "" {
@@ -128,7 +128,7 @@ func buildHTTPRuleFromTrafficTargetIndirect(tt *topology.ServiceTrafficTarget, t
 }
 
 func buildHTTPRuleFromTrafficSplitIndirect(ts *topology.TrafficSplit, tsSvc *topology.Service) string {
-	tsRule := buildHTTPRuleFromTrafficSpecs(ts.Specs)
+	tsRule := buildHTTPRuleFromTrafficSpecs(ts.Rules)
 	svcRule := buildHTTPRuleFromService(tsSvc)
 	indirectRule := "HeadersRegexp(`X-Forwarded-For`, `.+`)"
 

--- a/pkg/provider/testdata/acl-enabled-http-traffic-split-http-route-group-config.json
+++ b/pkg/provider/testdata/acl-enabled-http-traffic-split-http-route-group-config.json
@@ -1,0 +1,221 @@
+{
+  "http": {
+    "routers": {
+      "my-ns-svc-a-8080": {
+        "entryPoints": [
+          "http-10000"
+        ],
+        "middlewares": [
+          "block-all-middleware"
+        ],
+        "service": "block-all-service",
+        "rule": "Host(`svc-a.my-ns.maesh`) || Host(`10.10.14.1`)",
+        "priority": 1
+      },
+      "my-ns-svc-a-split-8080-traffic-split-direct": {
+        "entryPoints": [
+          "http-10000"
+        ],
+        "middlewares": [
+          "my-ns-svc-a-split-whitelist-traffic-split-direct"
+        ],
+        "service": "my-ns-svc-a-split-8080-traffic-split",
+        "rule": "(Host(`svc-a.my-ns.maesh`) || Host(`10.10.14.1`)) && (PathPrefix(`/{path:app}`))",
+        "priority": 4002
+      },
+
+      "my-ns-svc-b-8080": {
+        "entryPoints": [
+          "http-10000"
+        ],
+        "middlewares": [
+          "block-all-middleware"
+        ],
+        "service": "block-all-service",
+        "rule": "Host(`svc-b.my-ns.maesh`) || Host(`10.10.15.1`)",
+        "priority": 1
+      },
+      "my-ns-svc-b-tt-8080-traffic-target-direct": {
+        "entryPoints": [
+          "http-10000"
+        ],
+        "middlewares": [
+          "my-ns-svc-b-tt-whitelist-traffic-target-direct"
+        ],
+        "service": "my-ns-svc-b-tt-8080-traffic-target",
+        "rule": "Host(`svc-b.my-ns.maesh`) || Host(`10.10.15.1`)",
+        "priority": 2001
+      },
+      "my-ns-svc-b-tt-8080-traffic-target-indirect": {
+        "entryPoints": [
+          "http-10000"
+        ],
+        "middlewares": [
+          "my-ns-svc-b-tt-whitelist-traffic-target-indirect"
+        ],
+        "service": "my-ns-svc-b-tt-8080-traffic-target",
+        "rule": "(Host(`svc-b.my-ns.maesh`) || Host(`10.10.15.1`)) && HeadersRegexp(`X-Forwarded-For`, `.+`)",
+        "priority": 3002
+      },
+
+      "my-ns-svc-c-8080": {
+        "entryPoints": [
+          "http-10000"
+        ],
+        "middlewares": [
+          "block-all-middleware"
+        ],
+        "service": "block-all-service",
+        "rule": "Host(`svc-c.my-ns.maesh`) || Host(`10.10.16.1`)",
+        "priority": 1
+      },
+      "my-ns-svc-c-tt-8080-traffic-target-direct": {
+        "entryPoints": [
+          "http-10000"
+        ],
+        "middlewares": [
+          "my-ns-svc-c-tt-whitelist-traffic-target-direct"
+        ],
+        "service": "my-ns-svc-c-tt-8080-traffic-target",
+        "rule": "Host(`svc-c.my-ns.maesh`) || Host(`10.10.16.1`)",
+        "priority": 2001
+      },
+      "my-ns-svc-c-tt-8080-traffic-target-indirect": {
+        "entryPoints": [
+          "http-10000"
+        ],
+        "middlewares": [
+          "my-ns-svc-c-tt-whitelist-traffic-target-indirect"
+        ],
+        "service": "my-ns-svc-c-tt-8080-traffic-target",
+        "rule": "(Host(`svc-c.my-ns.maesh`) || Host(`10.10.16.1`)) && HeadersRegexp(`X-Forwarded-For`, `.+`)",
+        "priority": 3002
+      },
+
+      "readiness": {
+        "entryPoints": [
+          "readiness"
+        ],
+        "service": "readiness",
+        "rule": "Path(`/ping`)"
+      }
+    },
+    "services": {
+      "block-all-service": {
+        "loadBalancer": {
+          "passHostHeader": false
+        }
+      },
+      "my-ns-svc-a-split-8080-traffic-split": {
+        "weighted": {
+          "services": [
+            {
+              "name": "my-ns-svc-a-split-8080-svc-b-traffic-split-backend",
+              "weight": 80
+            },
+            {
+              "name": "my-ns-svc-a-split-8080-svc-c-traffic-split-backend",
+              "weight": 20
+            }
+          ]
+        }
+      },
+      "my-ns-svc-a-split-8080-svc-b-traffic-split-backend": {
+        "loadBalancer": {
+          "servers": [
+            {
+              "url": "http://svc-b.my-ns.maesh:8080"
+            }
+          ],
+          "passHostHeader": false
+        }
+      },
+      "my-ns-svc-a-split-8080-svc-c-traffic-split-backend": {
+        "loadBalancer": {
+          "servers": [
+            {
+              "url": "http://svc-c.my-ns.maesh:8080"
+            }
+          ],
+          "passHostHeader": false
+        }
+      },
+      "my-ns-svc-b-tt-8080-traffic-target": {
+        "loadBalancer": {
+          "servers": [
+            {
+              "url": "http://10.10.2.1:80"
+            }
+          ],
+          "passHostHeader": true
+        }
+      },
+      "my-ns-svc-c-tt-8080-traffic-target": {
+        "loadBalancer": {
+          "servers": [
+            {
+              "url": "http://10.10.3.1:80"
+            }
+          ],
+          "passHostHeader": true
+        }
+      },
+      "readiness": {
+        "loadBalancer": {
+          "servers": [
+            {
+              "url": "http://127.0.0.1:8080"
+            }
+          ],
+          "passHostHeader": true
+        }
+      }
+    },
+    "middlewares": {
+      "block-all-middleware": {
+        "ipWhiteList": {
+          "sourceRange": [
+            "255.255.255.255"
+          ]
+        }
+      },
+      "my-ns-svc-a-split-whitelist-traffic-split-direct": {
+        "ipWhiteList": {}
+      },
+      "my-ns-svc-b-tt-whitelist-traffic-target-direct": {
+        "ipWhiteList": {
+          "sourceRange": [
+            "10.10.1.1"
+          ]
+        }
+      },
+      "my-ns-svc-b-tt-whitelist-traffic-target-indirect": {
+        "ipWhiteList": {
+          "sourceRange": [
+            "10.10.1.1"
+          ],
+          "ipStrategy": {
+            "depth": 1
+          }
+        }
+      },
+      "my-ns-svc-c-tt-whitelist-traffic-target-direct": {
+        "ipWhiteList": {
+          "sourceRange": [
+            "10.10.1.1"
+          ]
+        }
+      },
+      "my-ns-svc-c-tt-whitelist-traffic-target-indirect": {
+        "ipWhiteList": {
+          "sourceRange": [
+            "10.10.1.1"
+          ],
+          "ipStrategy": {
+            "depth": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkg/provider/testdata/acl-enabled-http-traffic-split-http-route-group-topology.json
+++ b/pkg/provider/testdata/acl-enabled-http-traffic-split-http-route-group-topology.json
@@ -96,7 +96,7 @@
           "service": "svc-c@my-ns"
         }
       ],
-      "specs": [
+      "rules": [
         {
           "httpRouteGroup": {
             "kind": "HTTPRouteGroup",

--- a/pkg/provider/testdata/acl-enabled-http-traffic-split-http-route-group-topology.json
+++ b/pkg/provider/testdata/acl-enabled-http-traffic-split-http-route-group-topology.json
@@ -1,0 +1,189 @@
+{
+  "services": {
+    "svc-a@my-ns": {
+      "name": "svc-a",
+      "namespace": "my-ns",
+      "selector": {},
+      "annotations": {},
+      "ports": [
+        {
+          "name": "port-8080",
+          "protocol": "TCP",
+          "port": 8080,
+          "targetPort": 8080
+        }
+      ],
+      "clusterIp": "10.10.14.1",
+      "pods": [],
+      "trafficSplits": ["split@my-ns"]
+    },
+    "svc-b@my-ns": {
+      "name": "svc-b",
+      "namespace": "my-ns",
+      "selector": {},
+      "annotations": {},
+      "ports": [
+        {
+          "name": "port-8080",
+          "protocol": "TCP",
+          "port": 8080,
+          "targetPort": 80
+        }
+      ],
+      "clusterIp": "10.10.15.1",
+      "pods": [
+        "pod-b@my-ns"
+      ],
+      "backendOf": ["split@my-ns"],
+      "trafficTargets": ["svc-b@my-ns:tt@my-ns"]
+    },
+    "svc-c@my-ns": {
+      "name": "svc-c",
+      "namespace": "my-ns",
+      "selector": {},
+      "annotations": {},
+      "ports": [
+        {
+          "name": "port-8080",
+          "protocol": "TCP",
+          "port": 8080,
+          "targetPort": 80
+        }
+      ],
+      "clusterIp": "10.10.16.1",
+      "pods": [
+        "pod-c@my-ns"
+      ],
+      "backendOf": ["split@my-ns"],
+      "trafficTargets": ["svc-c@my-ns:tt@my-ns"]
+    }
+  },
+  "pods": {
+    "pod-a@my-ns": {
+      "name": "pod-a",
+      "namespace": "my-ns",
+      "serviceAccount": "client",
+      "ip": "10.10.1.1",
+      "sourceOf": ["svc-b@my-ns:tt@my-ns", "svc-c@my-ns:tt@my-ns"]
+    },
+    "pod-b@my-ns": {
+      "name": "pod-b",
+      "namespace": "my-ns",
+      "serviceAccount": "server",
+      "ip": "10.10.2.1",
+      "destinationOf": ["svc-b@my-ns:tt@my-ns"]
+    },
+    "pod-c@my-ns": {
+      "name": "pod-c",
+      "namespace": "my-ns",
+      "serviceAccount": "server",
+      "ip": "10.10.3.1",
+      "destinationOf": ["svc-c@my-ns:tt@my-ns"]
+    }
+  },
+  "trafficSplits": {
+    "split@my-ns": {
+      "name": "split",
+      "namespace": "my-ns",
+      "service": "svc-a@my-ns",
+      "backends": [
+        {
+          "weight": 80,
+          "service": "svc-b@my-ns"
+        },
+        {
+          "weight": 20,
+          "service": "svc-c@my-ns"
+        }
+      ],
+      "specs": [
+        {
+          "httpRouteGroup": {
+            "kind": "HTTPRouteGroup",
+            "apiVersion": "specs.smi-spec.io/v1alpha3",
+            "metadata": {
+              "name": "app-route-group",
+              "namespace": "my-ns"
+            },
+            "spec": {
+              "matches": [
+                {
+                  "name": "app",
+                  "methods": ["*"],
+                  "pathRegex": "/app"
+                }
+              ]
+            }
+          },
+          "httpMatches": [
+            {
+              "name": "app",
+              "methods": ["*"],
+              "pathRegex": "/app"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "serviceTrafficTargets": {
+    "svc-b@my-ns:tt@my-ns": {
+      "service": "svc-b@my-ns",
+      "name": "tt",
+      "namespace": "my-ns",
+      "sources": [
+        {
+          "serviceAccount": "client",
+          "namespace": "my-ns",
+          "pods": [
+            "pod-a@my-ns"
+          ]
+        }
+      ],
+      "destination": {
+        "serviceAccount": "server",
+        "namespace": "my-ns",
+        "ports": [
+          {
+            "name": "port-8080",
+            "protocol": "TCP",
+            "port": 8080,
+            "targetPort": 80
+          }
+        ],
+        "pods": [
+          "pod-b@my-ns"
+        ]
+      }
+    },
+    "svc-c@my-ns:tt@my-ns": {
+      "service": "svc-c@my-ns",
+      "name": "tt",
+      "namespace": "my-ns",
+      "sources": [
+        {
+          "serviceAccount": "client",
+          "namespace": "my-ns",
+          "pods": [
+            "pod-a@my-ns"
+          ]
+        }
+      ],
+      "destination": {
+        "serviceAccount": "server",
+        "namespace": "my-ns",
+        "ports": [
+          {
+            "name": "port-8080",
+            "protocol": "TCP",
+            "port": 8080,
+            "targetPort": 80
+          }
+        ],
+        "pods": [
+          "pod-c@my-ns"
+        ]
+      }
+    }
+  }
+}

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -224,7 +224,7 @@ func (b *Builder) evaluateTrafficSplit(res *resources, topology *Topology, traff
 
 	var err error
 
-	ts.Specs, err = b.buildTrafficSplitSpecs(res, trafficSplit)
+	ts.Rules, err = b.buildTrafficSplitSpecs(res, trafficSplit)
 	if err != nil {
 		err = fmt.Errorf("unable to build spec: %v", err)
 		ts.AddError(err)

--- a/pkg/topology/builder_test.go
+++ b/pkg/topology/builder_test.go
@@ -281,19 +281,16 @@ func TestTopologyBuilder_EvaluatesIncomingTrafficSplit(t *testing.T) {
 	svcKey := nn(svcB.Name, svcB.Namespace)
 	tsKeys := got.Services[svcKey].TrafficSplits
 
-	// Make sure the resulting Topology only has a single TrafficSplit.
-	assert.Len(t, tsKeys, 1)
-	assert.Len(t, got.TrafficSplits, 1)
+	assert.Len(t, tsKeys, 2)
+	assert.Len(t, got.TrafficSplits, 2)
 
-	incoming := got.TrafficSplits[tsKeys[0]].Incoming
+	// Sort TrafficSplit keys as order may differ between different run.
+	//
+	//sort.Slice(got.Services[], func(i, j int) bool {
+	//	return strings.Compare(tsKeys[i].Name, tsKeys[j].Name) < 0
+	//})
 
-	assert.Equal(t, 1, len(incoming))
-
-	if tsKeys[0].Name == "ts2" {
-		assert.Equal(t, "10.10.1.2", got.Pods[incoming[0]].IP)
-	} else {
-		assert.Equal(t, "10.10.1.1", got.Pods[incoming[0]].IP)
-	}
+	assertTopology(t, "testdata/topology-traffic-split-traffic-target.json", got)
 }
 
 // TestTopologyBuilder_EvaluatesTrafficSplitSpecs makes sure a topology can be built with TrafficSplits containing
@@ -347,13 +344,6 @@ func TestTopologyBuilder_EvaluatesTrafficSplitSpecs(t *testing.T) {
 	got, err := builder.Build(resourceFilter)
 	require.NoError(t, err)
 
-	// Pod.SourceOf has to be sorted as it can change between 2 runs.
-	for _, pod := range got.Pods {
-		sort.Slice(pod.SourceOf, func(i, j int) bool {
-			return strings.Compare(pod.SourceOf[i].String(), pod.SourceOf[j].String()) < 0
-		})
-	}
-
 	assertTopology(t, "testdata/topology-traffic-split-specs.json", got)
 }
 
@@ -395,69 +385,6 @@ func TestTopologyBuilder_BuildWithTrafficTarget(t *testing.T) {
 	require.NoError(t, err)
 
 	assertTopology(t, "testdata/topology-traffic-target.json", got)
-}
-
-// TestTopologyBuilder_BuildWithTrafficTargetAndTrafficSplitOnSameService makes sure a TrafficTarget won't be applied on
-// a service if there is already a TrafficSplit applied to it.
-func TestTopologyBuilder_BuildWithTrafficTargetAndTrafficSplitOnSameService(t *testing.T) {
-	selectorAppA := map[string]string{"app": "app-a"}
-	selectorAppB1 := map[string]string{"app": "app-b1"}
-	selectorAppB2 := map[string]string{"app": "app-b2"}
-	selectorAppC := map[string]string{"app": "app-c"}
-	selectorAppD := map[string]string{"app": "app-d"}
-	annotations := map[string]string{
-		"maesh.containo.us/traffic-type":      "http",
-		"maesh.containo.us/ratelimit-average": "100",
-		"maesh.containo.us/ratelimit-burst":   "200",
-	}
-	svcPorts := []corev1.ServicePort{svcPort("port-8080", 8080, 8080)}
-
-	saA := createServiceAccount("my-ns", "service-account-a")
-	podA := createPod("my-ns", "app-a", saA, selectorAppA, "10.10.1.1")
-
-	saB := createServiceAccount("my-ns", "service-account-b")
-	svcB1 := createService("my-ns", "svc-b1", annotations, svcPorts, selectorAppB1, "10.10.1.16")
-	podB1 := createPod("my-ns", "app-b1", saB, svcB1.Spec.Selector, "10.10.2.1")
-	svcB2 := createService("my-ns", "svc-b2", annotations, svcPorts, selectorAppB2, "10.10.3.16")
-	podB2 := createPod("my-ns", "app-b2", saB, svcB2.Spec.Selector, "10.10.3.1")
-
-	saC := createServiceAccount("my-ns", "service-account-c")
-	svcC := createService("my-ns", "svc-c", annotations, svcPorts, selectorAppC, "10.10.1.17")
-	podC := createPod("my-ns", "app-c", saC, svcC.Spec.Selector, "10.10.2.2")
-
-	saD := createServiceAccount("my-ns", "service-account-d")
-	svcD := createService("my-ns", "svc-d", annotations, svcPorts, selectorAppD, "10.10.1.18")
-	podD := createPod("my-ns", "app-d", saD, svcD.Spec.Selector, "10.10.2.3")
-
-	epB1 := createEndpoints(svcB1, createEndpointSubset(svcPorts, podB1))
-	epB2 := createEndpoints(svcB2, createEndpointSubset(svcPorts, podB2))
-	epC := createEndpoints(svcC, createEndpointSubset(svcPorts, podC))
-	epD := createEndpoints(svcD, createEndpointSubset(svcPorts, podD))
-
-	apiMatch := createHTTPMatch("api", []string{"GET", "POST"}, "/api", nil)
-	metricMatch := createHTTPMatch("metric", []string{"GET"}, "/metric", nil)
-	rtGrp := createHTTPRouteGroup("my-ns", "http-rt-grp", []specs.HTTPMatch{apiMatch, metricMatch})
-
-	ttMatch := []string{apiMatch.Name}
-	tt := createTrafficTarget("my-ns", "tt", saB, intPtr(8080), []*corev1.ServiceAccount{saA}, rtGrp, ttMatch)
-	ts := createTrafficSplit("my-ns", "ts", svcB1, svcC, svcD, nil)
-
-	k8sClient := fake.NewSimpleClientset(saA, saB, saC, saD,
-		podA, podB1, podB2, podC, podD,
-		svcB1, svcB2, svcC, svcD,
-		epB1, epB2, epC, epD)
-	smiAccessClient := accessfake.NewSimpleClientset(tt)
-	smiSplitClient := splitfake.NewSimpleClientset(ts)
-	smiSpecClient := specsfake.NewSimpleClientset(rtGrp)
-
-	builder, err := createBuilder(k8sClient, smiAccessClient, smiSpecClient, smiSplitClient)
-	require.NoError(t, err)
-
-	resourceFilter := mk8s.NewResourceFilter()
-	got, err := builder.Build(resourceFilter)
-	require.NoError(t, err)
-
-	assertTopology(t, "testdata/topology-traffic-split-traffic-target.json", got)
 }
 
 // TestTopologyBuilder_BuildWithTrafficTargetSpecEmptyMatch makes sure that when TrafficTarget.Spec.Matches is empty,
@@ -1009,10 +936,34 @@ func assertTopology(t *testing.T, filename string, got *Topology) {
 	wantMarshaled, err := json.MarshalIndent(&want, "", "  ")
 	require.NoError(t, err)
 
+	// Sort slices which order may be affected by a map iteration.
+	for _, svc := range got.Services {
+		sort.Slice(svc.TrafficSplits, buildKeySorter(svc.TrafficSplits))
+		sort.Slice(svc.Pods, buildKeySorter(svc.Pods))
+		sort.Slice(svc.BackendOf, buildKeySorter(svc.BackendOf))
+		sort.Slice(svc.TrafficTargets, buildServiceTrafficTargetKeySorter(svc.TrafficTargets))
+	}
+
+	for _, pod := range got.Pods {
+		sort.Slice(pod.SourceOf, buildServiceTrafficTargetKeySorter(pod.SourceOf))
+		sort.Slice(pod.DestinationOf, buildServiceTrafficTargetKeySorter(pod.DestinationOf))
+	}
+
 	gotMarshaled, err := json.MarshalIndent(got, "", "  ")
 	require.NoError(t, err)
 
 	assert.Equal(t, string(wantMarshaled), string(gotMarshaled))
+}
+
+func buildKeySorter(keys []Key) func(i, j int) bool {
+	return func(i, j int) bool {
+		return strings.Compare(keys[i].String(), keys[j].String()) < 0
+	}
+}
+func buildServiceTrafficTargetKeySorter(keys []ServiceTrafficTargetKey) func(i, j int) bool {
+	return func(i, j int) bool {
+		return strings.Compare(keys[i].String(), keys[j].String()) < 0
+	}
 }
 
 func intPtr(value int) *int {

--- a/pkg/topology/builder_test.go
+++ b/pkg/topology/builder_test.go
@@ -284,12 +284,6 @@ func TestTopologyBuilder_EvaluatesIncomingTrafficSplit(t *testing.T) {
 	assert.Len(t, tsKeys, 2)
 	assert.Len(t, got.TrafficSplits, 2)
 
-	// Sort TrafficSplit keys as order may differ between different run.
-	//
-	//sort.Slice(got.Services[], func(i, j int) bool {
-	//	return strings.Compare(tsKeys[i].Name, tsKeys[j].Name) < 0
-	//})
-
 	assertTopology(t, "testdata/topology-traffic-split-traffic-target.json", got)
 }
 

--- a/pkg/topology/testdata/topology-traffic-split-specs.json
+++ b/pkg/topology/testdata/topology-traffic-split-specs.json
@@ -192,7 +192,7 @@
           "service": "svc-d@my-ns"
         }
       ],
-      "specs": [
+      "rules": [
         {
           "httpRouteGroup": {
             "kind": "HTTPRouteGroup",

--- a/pkg/topology/testdata/topology-traffic-split-specs.json
+++ b/pkg/topology/testdata/topology-traffic-split-specs.json
@@ -1,0 +1,236 @@
+{
+  "services": {
+    "svc-b@my-ns": {
+      "name": "svc-b",
+      "namespace": "my-ns",
+      "selector": {
+        "app": "app-b"
+      },
+      "annotations": {},
+      "ports": [
+        {
+          "name": "port-8080",
+          "protocol": "TCP",
+          "port": 8080,
+          "targetPort": 8080
+        }
+      ],
+      "clusterIp": "10.10.1.16",
+      "pods": [
+        "app-b@my-ns"
+      ],
+      "trafficSplits": [
+        "ts@my-ns"
+      ],
+      "errors": null
+    },
+    "svc-c@my-ns": {
+      "name": "svc-c",
+      "namespace": "my-ns",
+      "selector": {
+        "app": "app-c"
+      },
+      "annotations": {},
+      "ports": [
+        {
+          "name": "port-8080",
+          "protocol": "TCP",
+          "port": 8080,
+          "targetPort": 8080
+        }
+      ],
+      "clusterIp": "10.10.1.17",
+      "pods": [
+        "app-c@my-ns"
+      ],
+      "trafficTargets": [
+        "svc-c@my-ns:tt-c@my-ns"
+      ],
+      "backendOf": [
+        "ts@my-ns"
+      ],
+      "errors": null
+    },
+    "svc-d@my-ns": {
+      "name": "svc-d",
+      "namespace": "my-ns",
+      "selector": {
+        "app": "app-d"
+      },
+      "annotations": {},
+      "ports": [
+        {
+          "name": "port-8080",
+          "protocol": "TCP",
+          "port": 8080,
+          "targetPort": 8080
+        }
+      ],
+      "clusterIp": "10.10.1.18",
+      "pods": [
+        "app-d@my-ns"
+      ],
+      "trafficTargets": [
+        "svc-d@my-ns:tt-d@my-ns"
+      ],
+      "backendOf": [
+        "ts@my-ns"
+      ],
+      "errors": null
+    }
+  },
+  "pods": {
+    "app-a@my-ns": {
+      "name": "app-a",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-a",
+      "ip": "10.10.1.1",
+      "sourceOf": [
+        "svc-c@my-ns:tt-c@my-ns",
+        "svc-d@my-ns:tt-d@my-ns"
+      ]
+    },
+    "app-b@my-ns": {
+      "name": "app-b",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-b",
+      "ip": "10.10.2.1"
+    },
+    "app-c@my-ns": {
+      "name": "app-c",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-c",
+      "ip": "10.10.2.2",
+      "destinationOf": [
+        "svc-c@my-ns:tt-c@my-ns"
+      ]
+    },
+    "app-d@my-ns": {
+      "name": "app-d",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-d",
+      "ip": "10.10.2.3",
+      "destinationOf": [
+        "svc-d@my-ns:tt-d@my-ns"
+      ]
+    }
+  },
+  "serviceTrafficTargets": {
+    "svc-c@my-ns:tt-c@my-ns": {
+      "service": "svc-c@my-ns",
+      "name": "tt-c",
+      "namespace": "my-ns",
+      "sources": [
+        {
+          "serviceAccount": "service-account-a",
+          "namespace": "my-ns",
+          "pods": [
+            "app-a@my-ns"
+          ]
+        }
+      ],
+      "destination": {
+        "serviceAccount": "service-account-c",
+        "namespace": "my-ns",
+        "ports": [
+          {
+            "name": "port-8080",
+            "protocol": "TCP",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "pods": [
+          "app-c@my-ns"
+        ]
+      },
+      "errors": null
+    },
+    "svc-d@my-ns:tt-d@my-ns": {
+      "service": "svc-d@my-ns",
+      "name": "tt-d",
+      "namespace": "my-ns",
+      "sources": [
+        {
+          "serviceAccount": "service-account-a",
+          "namespace": "my-ns",
+          "pods": [
+            "app-a@my-ns"
+          ]
+        }
+      ],
+      "destination": {
+        "serviceAccount": "service-account-d",
+        "namespace": "my-ns",
+        "ports": [
+          {
+            "name": "port-8080",
+            "protocol": "TCP",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "pods": [
+          "app-d@my-ns"
+        ]
+      },
+      "errors": null
+    }
+  },
+  "trafficSplits": {
+    "ts@my-ns": {
+      "name": "ts",
+      "namespace": "my-ns",
+      "service": "svc-b@my-ns",
+      "backends": [
+        {
+          "weight": 80,
+          "service": "svc-c@my-ns"
+        },
+        {
+          "weight": 20,
+          "service": "svc-d@my-ns"
+        }
+      ],
+      "specs": [
+        {
+          "httpRouteGroup": {
+            "kind": "HTTPRouteGroup",
+            "apiVersion": "specs.smi-spec.io/v1alpha3",
+            "metadata": {
+              "name": "http-rt-grp",
+              "namespace": "my-ns",
+              "creationTimestamp": null
+            },
+            "spec": {
+              "matches": [
+                {
+                  "name": "api",
+                  "methods": [
+                    "GET",
+                    "POST"
+                  ],
+                  "pathRegex": "/api"
+                }
+              ]
+            }
+          },
+          "httpMatches": [
+            {
+              "name": "api",
+              "methods": [
+                "GET",
+                "POST"
+              ],
+              "pathRegex": "/api"
+            }
+          ]
+        }
+      ],
+      "incoming": [
+        "app-a@my-ns"
+      ],
+      "errors": null
+    }
+  }
+}

--- a/pkg/topology/testdata/topology-traffic-split-traffic-target.json
+++ b/pkg/topology/testdata/topology-traffic-split-traffic-target.json
@@ -1,16 +1,12 @@
 {
   "services": {
-    "svc-b1@my-ns": {
-      "name": "svc-b1",
+    "svc-b@my-ns": {
+      "name": "svc-b",
       "namespace": "my-ns",
       "selector": {
-        "app": "app-b1"
+        "app": "app-b"
       },
-      "annotations": {
-        "maesh.containo.us/ratelimit-average": "100",
-        "maesh.containo.us/ratelimit-burst": "200",
-        "maesh.containo.us/traffic-type": "http"
-      },
+      "annotations": {},
       "ports": [
         {
           "name": "port-8080",
@@ -21,38 +17,16 @@
       ],
       "clusterIp": "10.10.1.16",
       "pods": [
-        "app-b1@my-ns"
-      ],
-      "trafficSplits": [
-        "ts@my-ns"
-      ]
-    },
-    "svc-b2@my-ns": {
-      "name": "svc-b2",
-      "namespace": "my-ns",
-      "selector": {
-        "app": "app-b2"
-      },
-      "annotations": {
-        "maesh.containo.us/ratelimit-average": "100",
-        "maesh.containo.us/ratelimit-burst": "200",
-        "maesh.containo.us/traffic-type": "http"
-      },
-      "ports": [
-        {
-          "name": "port-8080",
-          "protocol": "TCP",
-          "port": 8080,
-          "targetPort": 8080
-        }
-      ],
-      "clusterIp": "10.10.3.16",
-      "pods": [
-        "app-b2@my-ns"
+        "app-b@my-ns"
       ],
       "trafficTargets": [
-        "svc-b2@my-ns:tt@my-ns"
-      ]
+        "svc-b@my-ns:tt-b@my-ns"
+      ],
+      "trafficSplits": [
+        "ts2@my-ns",
+        "ts@my-ns"
+      ],
+      "errors": null
     },
     "svc-c@my-ns": {
       "name": "svc-c",
@@ -60,11 +34,7 @@
       "selector": {
         "app": "app-c"
       },
-      "annotations": {
-        "maesh.containo.us/ratelimit-average": "100",
-        "maesh.containo.us/ratelimit-burst": "200",
-        "maesh.containo.us/traffic-type": "http"
-      },
+      "annotations": {},
       "ports": [
         {
           "name": "port-8080",
@@ -77,9 +47,14 @@
       "pods": [
         "app-c@my-ns"
       ],
+      "trafficTargets": [
+        "svc-c@my-ns:tt-c@my-ns"
+      ],
       "backendOf": [
+        "ts2@my-ns",
         "ts@my-ns"
-      ]
+      ],
+      "errors": null
     },
     "svc-d@my-ns": {
       "name": "svc-d",
@@ -87,11 +62,7 @@
       "selector": {
         "app": "app-d"
       },
-      "annotations": {
-        "maesh.containo.us/ratelimit-average": "100",
-        "maesh.containo.us/ratelimit-burst": "200",
-        "maesh.containo.us/traffic-type": "http"
-      },
+      "annotations": {},
       "ports": [
         {
           "name": "port-8080",
@@ -104,53 +75,105 @@
       "pods": [
         "app-d@my-ns"
       ],
+      "trafficTargets": [
+        "svc-d@my-ns:tt-d@my-ns"
+      ],
       "backendOf": [
         "ts@my-ns"
-      ]
+      ],
+      "errors": null
+    },
+    "svc-e@my-ns": {
+      "name": "svc-e",
+      "namespace": "my-ns",
+      "selector": {
+        "app": "app-e"
+      },
+      "annotations": {},
+      "ports": [
+        {
+          "name": "port-8080",
+          "protocol": "TCP",
+          "port": 8080,
+          "targetPort": 8080
+        }
+      ],
+      "clusterIp": "10.10.1.19",
+      "pods": [
+        "app-e@my-ns"
+      ],
+      "trafficTargets": [
+        "svc-e@my-ns:tt-e@my-ns"
+      ],
+      "backendOf": [
+        "ts2@my-ns"
+      ],
+      "errors": null
     }
   },
   "pods": {
+    "app-a-2@my-ns": {
+      "name": "app-a-2",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-a-2",
+      "ip": "10.10.1.2",
+      "sourceOf": [
+        "svc-c@my-ns:tt-c@my-ns",
+        "svc-e@my-ns:tt-e@my-ns"
+      ]
+    },
     "app-a@my-ns": {
       "name": "app-a",
       "namespace": "my-ns",
       "serviceAccount": "service-account-a",
       "ip": "10.10.1.1",
       "sourceOf": [
-        "svc-b2@my-ns:tt@my-ns"
+        "svc-b@my-ns:tt-b@my-ns",
+        "svc-c@my-ns:tt-c@my-ns",
+        "svc-d@my-ns:tt-d@my-ns"
       ]
     },
-    "app-b1@my-ns": {
-      "name": "app-b1",
+    "app-b@my-ns": {
+      "name": "app-b",
       "namespace": "my-ns",
       "serviceAccount": "service-account-b",
-      "ip": "10.10.2.1"
-    },
-    "app-b2@my-ns": {
-      "name": "app-b2",
-      "namespace": "my-ns",
-      "serviceAccount": "service-account-b",
-      "ip": "10.10.3.1",
+      "ip": "10.10.2.1",
       "destinationOf": [
-        "svc-b2@my-ns:tt@my-ns"
+        "svc-b@my-ns:tt-b@my-ns"
       ]
     },
     "app-c@my-ns": {
       "name": "app-c",
       "namespace": "my-ns",
       "serviceAccount": "service-account-c",
-      "ip": "10.10.2.2"
+      "ip": "10.10.2.2",
+      "destinationOf": [
+        "svc-c@my-ns:tt-c@my-ns"
+      ]
     },
     "app-d@my-ns": {
       "name": "app-d",
       "namespace": "my-ns",
       "serviceAccount": "service-account-d",
-      "ip": "10.10.2.3"
+      "ip": "10.10.2.3",
+      "destinationOf": [
+        "svc-d@my-ns:tt-d@my-ns"
+      ]
+    },
+    "app-e@my-ns": {
+      "name": "app-e",
+      "namespace": "my-ns",
+      "serviceAccount": "service-account-e",
+      "ip": "10.10.2.4",
+      "destinationOf": [
+        "svc-e@my-ns:tt-e@my-ns"
+      ]
     }
   },
   "serviceTrafficTargets": {
-    "svc-b2@my-ns:tt@my-ns": {
-      "service": "svc-b2@my-ns",
-      "name": "tt",
+    "svc-b@my-ns:tt-b@my-ns": {
+      "service": "svc-b@my-ns",
+      "name": "tt-b",
       "namespace": "my-ns",
       "sources": [
         {
@@ -173,7 +196,230 @@
           }
         ],
         "pods": [
-          "app-b2@my-ns"
+          "app-b@my-ns"
+        ]
+      },
+      "specs": [
+        {
+          "httpRouteGroup": {
+            "kind": "HTTPRouteGroup",
+            "apiVersion": "specs.smi-spec.io/v1alpha3",
+            "metadata": {
+              "name": "http-rt-grp",
+              "namespace": "my-ns",
+              "creationTimestamp": null
+            },
+            "spec": {
+              "matches": [
+                {
+                  "name": "api",
+                  "methods": [
+                    "GET",
+                    "POST"
+                  ],
+                  "pathRegex": "/api"
+                },
+                {
+                  "name": "metric",
+                  "methods": [
+                    "GET"
+                  ],
+                  "pathRegex": "/metric"
+                }
+              ]
+            }
+          },
+          "httpMatches": [
+            {
+              "name": "api",
+              "methods": [
+                "GET",
+                "POST"
+              ],
+              "pathRegex": "/api"
+            }
+          ]
+        }
+      ],
+      "errors": null
+    },
+    "svc-c@my-ns:tt-c@my-ns": {
+      "service": "svc-c@my-ns",
+      "name": "tt-c",
+      "namespace": "my-ns",
+      "sources": [
+        {
+          "serviceAccount": "service-account-a",
+          "namespace": "my-ns",
+          "pods": [
+            "app-a@my-ns"
+          ]
+        },
+        {
+          "serviceAccount": "service-account-a-2",
+          "namespace": "my-ns",
+          "pods": [
+            "app-a-2@my-ns"
+          ]
+        }
+      ],
+      "destination": {
+        "serviceAccount": "service-account-c",
+        "namespace": "my-ns",
+        "ports": [
+          {
+            "name": "port-8080",
+            "protocol": "TCP",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "pods": [
+          "app-c@my-ns"
+        ]
+      },
+      "specs": [
+        {
+          "httpRouteGroup": {
+            "kind": "HTTPRouteGroup",
+            "apiVersion": "specs.smi-spec.io/v1alpha3",
+            "metadata": {
+              "name": "http-rt-grp",
+              "namespace": "my-ns",
+              "creationTimestamp": null
+            },
+            "spec": {
+              "matches": [
+                {
+                  "name": "api",
+                  "methods": [
+                    "GET",
+                    "POST"
+                  ],
+                  "pathRegex": "/api"
+                },
+                {
+                  "name": "metric",
+                  "methods": [
+                    "GET"
+                  ],
+                  "pathRegex": "/metric"
+                }
+              ]
+            }
+          },
+          "httpMatches": [
+            {
+              "name": "api",
+              "methods": [
+                "GET",
+                "POST"
+              ],
+              "pathRegex": "/api"
+            }
+          ]
+        }
+      ],
+      "errors": null
+    },
+    "svc-d@my-ns:tt-d@my-ns": {
+      "service": "svc-d@my-ns",
+      "name": "tt-d",
+      "namespace": "my-ns",
+      "sources": [
+        {
+          "serviceAccount": "service-account-a",
+          "namespace": "my-ns",
+          "pods": [
+            "app-a@my-ns"
+          ]
+        }
+      ],
+      "destination": {
+        "serviceAccount": "service-account-d",
+        "namespace": "my-ns",
+        "ports": [
+          {
+            "name": "port-8080",
+            "protocol": "TCP",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "pods": [
+          "app-d@my-ns"
+        ]
+      },
+      "specs": [
+        {
+          "httpRouteGroup": {
+            "kind": "HTTPRouteGroup",
+            "apiVersion": "specs.smi-spec.io/v1alpha3",
+            "metadata": {
+              "name": "http-rt-grp",
+              "namespace": "my-ns",
+              "creationTimestamp": null
+            },
+            "spec": {
+              "matches": [
+                {
+                  "name": "api",
+                  "methods": [
+                    "GET",
+                    "POST"
+                  ],
+                  "pathRegex": "/api"
+                },
+                {
+                  "name": "metric",
+                  "methods": [
+                    "GET"
+                  ],
+                  "pathRegex": "/metric"
+                }
+              ]
+            }
+          },
+          "httpMatches": [
+            {
+              "name": "api",
+              "methods": [
+                "GET",
+                "POST"
+              ],
+              "pathRegex": "/api"
+            }
+          ]
+        }
+      ],
+      "errors": null
+    },
+    "svc-e@my-ns:tt-e@my-ns": {
+      "service": "svc-e@my-ns",
+      "name": "tt-e",
+      "namespace": "my-ns",
+      "sources": [
+        {
+          "serviceAccount": "service-account-a-2",
+          "namespace": "my-ns",
+          "pods": [
+            "app-a-2@my-ns"
+          ]
+        }
+      ],
+      "destination": {
+        "serviceAccount": "service-account-e",
+        "namespace": "my-ns",
+        "ports": [
+          {
+            "name": "port-8080",
+            "protocol": "TCP",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "pods": [
+          "app-e@my-ns"
         ]
       },
       "rules": [
@@ -222,10 +468,29 @@
     }
   },
   "trafficSplits": {
+    "ts2@my-ns": {
+      "name": "ts2",
+      "namespace": "my-ns",
+      "service": "svc-b@my-ns",
+      "backends": [
+        {
+          "weight": 80,
+          "service": "svc-c@my-ns"
+        },
+        {
+          "weight": 20,
+          "service": "svc-e@my-ns"
+        }
+      ],
+      "incoming": [
+        "app-a-2@my-ns"
+      ],
+      "errors": null
+    },
     "ts@my-ns": {
       "name": "ts",
       "namespace": "my-ns",
-      "service": "svc-b1@my-ns",
+      "service": "svc-b@my-ns",
       "backends": [
         {
           "weight": 80,
@@ -235,7 +500,11 @@
           "weight": 20,
           "service": "svc-d@my-ns"
         }
-      ]
+      ],
+      "incoming": [
+        "app-a@my-ns"
+      ],
+      "errors": null
     }
   }
 }

--- a/pkg/topology/testdata/topology-traffic-split-traffic-target.json
+++ b/pkg/topology/testdata/topology-traffic-split-traffic-target.json
@@ -199,7 +199,7 @@
           "app-b@my-ns"
         ]
       },
-      "specs": [
+      "rules": [
         {
           "httpRouteGroup": {
             "kind": "HTTPRouteGroup",
@@ -278,7 +278,7 @@
           "app-c@my-ns"
         ]
       },
-      "specs": [
+      "rules": [
         {
           "httpRouteGroup": {
             "kind": "HTTPRouteGroup",
@@ -350,7 +350,7 @@
           "app-d@my-ns"
         ]
       },
-      "specs": [
+      "rules": [
         {
           "httpRouteGroup": {
             "kind": "HTTPRouteGroup",

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -213,7 +213,7 @@ type TrafficSplit struct {
 
 	Service  Key                   `json:"service"`
 	Backends []TrafficSplitBackend `json:"backends,omitempty"`
-	Specs    []TrafficSpec         `json:"specs,omitempty"`
+	Rules    []TrafficSpec         `json:"rules,omitempty"`
 
 	// List of Pods that are explicitly allowed to pass through the TrafficSplit.
 	Incoming []Key `json:"incoming,omitempty"`

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -193,15 +193,6 @@ type ServiceTrafficTargetDestination struct {
 	Pods           []Key                `json:"pods,omitempty"`
 }
 
-// TrafficSpec represents a spec which can be used for restricting access to a route in a TrafficTarget.
-type TrafficSpec struct {
-	HTTPRouteGroup *specs.HTTPRouteGroup `json:"httpRouteGroup,omitempty"`
-	TCPRoute       *specs.TCPRoute       `json:"tcpRoute,omitempty"`
-
-	// HTTPMatches is the list of HTTPMatch selected from the HTTPRouteGroup.
-	HTTPMatches []*specs.HTTPMatch `json:"httpMatches,omitempty"`
-}
-
 // Pod is a node of the graph representing a kubernetes pod.
 type Pod struct {
 	Name            string                 `json:"name"`
@@ -222,11 +213,21 @@ type TrafficSplit struct {
 
 	Service  Key                   `json:"service"`
 	Backends []TrafficSplitBackend `json:"backends,omitempty"`
+	Specs    []TrafficSpec         `json:"specs,omitempty"`
 
 	// List of Pods that are explicitly allowed to pass through the TrafficSplit.
 	Incoming []Key `json:"incoming,omitempty"`
 
 	Errors []string `json:"errors"`
+}
+
+// TrafficSpec represents a Spec which can be used for restricting access to a route in a TrafficTarget or a TrafficSplit.
+type TrafficSpec struct {
+	HTTPRouteGroup *specs.HTTPRouteGroup `json:"httpRouteGroup,omitempty"`
+	TCPRoute       *specs.TCPRoute       `json:"tcpRoute,omitempty"`
+
+	// HTTPMatches is the list of HTTPMatch selected from the HTTPRouteGroup.
+	HTTPMatches []*specs.HTTPMatch `json:"httpMatches,omitempty"`
 }
 
 // AddError adds the given error to this TrafficSplit.


### PR DESCRIPTION
## What does this PR do?

This PR:
- Add new property `Rules` in the `TrafficSplit` struct
- Build SMI specs rules for each `TrafficSplit` in the TopologyBuilder.
- Update topology tests

Fixes #598 

### How to test it
- `make test`
- Look at the specification (split.v1alpha3) and play with the new feature.