### PR TITLE
Fix controller signal handling

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -7,6 +7,23 @@ import (
 	"syscall"
 )
 
+// ContextWithStopChan creates a context canceled when the given stopCh receives a message
+// or get closed.
+func ContextWithStopChan(ctx context.Context, stopCh <-chan struct{}) context.Context {
+	ctx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		defer cancel()
+
+		select {
+		case <-ctx.Done():
+		case <-stopCh:
+		}
+	}()
+
+	return ctx
+}
+
 // ContextWithSignal creates a context canceled when SIGINT or SIGTERM are notified.
 func ContextWithSignal(ctx context.Context) context.Context {
 	newCtx, cancel := context.WithCancel(ctx)

--- a/cmd/maesh/maesh.go
+++ b/cmd/maesh/maesh.go
@@ -118,8 +118,8 @@ func maeshCommand(config *cmd.MaeshConfiguration) error {
 
 	var wg sync.WaitGroup
 
-	apiErrCh := make(chan error)
-	ctrlErrCh := make(chan error)
+	apiErrCh := make(chan error, 1)
+	ctrlErrCh := make(chan error, 1)
 
 	// Start the API server.
 	wg.Add(1)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containous/maesh/cmd"
 	"github.com/containous/maesh/pkg/annotations"
 	"github.com/containous/maesh/pkg/k8s"
 	"github.com/containous/maesh/pkg/provider"
@@ -249,7 +250,7 @@ func (c *Controller) Shutdown() {
 
 // startInformers starts the controller informers.
 func (c *Controller) startInformers(syncTimeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(contextWithStopChan(context.Background(), c.stopCh), syncTimeout)
+	ctx, cancel := context.WithTimeout(cmd.ContextWithStopChan(context.Background(), c.stopCh), syncTimeout)
 	defer cancel()
 
 	c.logger.Debug("Starting Informers")
@@ -401,19 +402,4 @@ func (c *Controller) handleErr(key interface{}, err error) {
 
 	c.logger.Errorf("Unable to complete work %q: %v", key, err)
 	c.workQueue.Forget(key)
-}
-
-func contextWithStopChan(ctx context.Context, stopCh <-chan struct{}) context.Context {
-	ctx, cancel := context.WithCancel(ctx)
-
-	go func() {
-		defer cancel()
-
-		select {
-		case <-ctx.Done():
-		case <-stopCh:
-		}
-	}()
-
-	return ctx
 }


### PR DESCRIPTION
## What does this PR do?

Fix a bug in `cmd/maesh` package where a WaitGroup was getting stuck forever. If the `controller` failed after the program received a signal (e.g. CTRL-C), the error couldn't be sent to the error chan and would block forever.

Fixes #702 

### How to test it

* Run locally the controller with the `MAESH_KUBECONFIG` variable set to a k8s cluster with no SMI CRDs. After few seconds, send a signal. It should stop immediately. 