### PR TITLE
Update apiVersion of RBAC resources in Helm

### DIFF
--- a/docs/content/compatibility.md
+++ b/docs/content/compatibility.md
@@ -2,9 +2,9 @@
 
 Maesh supports [similiar to Kubernetes](https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions) at least the latest 3 minor versions of Kubernetes, therefore currently:
 
-* 1.16
 * 1.17
 * 1.18
+* 1.19
 
 General functionality can not be guaranted for versions older than that. However, we expect it to work with Kubernetes down to 1.11 currently.
 
@@ -12,7 +12,7 @@ General functionality can not be guaranted for versions older than that. However
 
 Some of Maesh's features are only supported on certain Kubernetes versions. Please see the table below.
 
- | Features              | K8s 1.16 | K8s 1.17 | K8s 1.18 |
+ | Features              | K8s 1.17 | K8s 1.18 | K8s 1.19 |
  |-----------------------|----------|----------|----------|
  | General functionality | ✔        | ✔        | ✔        |
- | Service Topology      | ✘        | ✔        | ✔        |
+ | Service Topology      | ✔        | ✔        | ✔        |

--- a/helm/chart/maesh/templates/controller/controller-rbac.yaml
+++ b/helm/chart/maesh/templates/controller/controller-rbac.yaml
@@ -1,6 +1,6 @@
 ---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: maesh-controller-role
   namespace: {{ .Release.Namespace }}
@@ -60,8 +60,8 @@ rules:
       - list
       - watch
 ---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: maesh-controller
   namespace: {{ .Release.Namespace }}

--- a/helm/chart/maesh/templates/coredns/coredns-rbac.yaml
+++ b/helm/chart/maesh/templates/coredns/coredns-rbac.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.kubedns }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -30,7 +30,7 @@ rules:
       - get
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: maesh-coredns


### PR DESCRIPTION
## What does this PR do?

This PR:

- Updates the supported versions of Kubernetes in the documentation because of the [1.19](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#v1190) release.
- Updates the RBAC apiVersion which has been deprecated since version [1.17](https://v1-17.docs.kubernetes.io/docs/setup/release/notes/#deprecations-and-removals).

### How to test it

* make test-integration