### PR TITLE
Upgrade golangci-lint version to v1.30

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -43,6 +43,10 @@
     "goconst", # Too many false positives
     "testpackage", # Does not allow testing private funcs
     "goerr113", # Forces wrapping all errors
+    "noctx", # Too strict
+    "exhaustive", # Too strict
+    "nlreturn", # Too strict
+    "exportloopref", # Too strict
   ]
 
 [issues]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /go/src/github.com/containous/maesh
 RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
 
 # Download golangci-lint binary to bin folder in $GOPATH
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.27.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.30.0
 
 ENV GO111MODULE on
 COPY go.mod go.sum ./

--- a/integration/k3d/k3d.go
+++ b/integration/k3d/k3d.go
@@ -211,7 +211,6 @@ func (c *Cluster) WaitReadyDeployment(name, namespace string, timeout time.Durat
 
 		return errors.New("deployment not ready")
 	}, timeout)
-
 	if err != nil {
 		return fmt.Errorf("deployment %q in namespace %q is not ready: %w", name, namespace, err)
 	}
@@ -239,7 +238,6 @@ func (c *Cluster) WaitReadyDaemonSet(name, namespace string, timeout time.Durati
 
 		return errors.New("daemonset not ready")
 	}, timeout)
-
 	if err != nil {
 		return fmt.Errorf("daemonset %q in namespace %q is not ready: %w", name, namespace, err)
 	}
@@ -268,7 +266,6 @@ func (c *Cluster) WaitReadyPod(name, namespace string, timeout time.Duration) er
 
 		return nil
 	}, timeout)
-
 	if err != nil {
 		return fmt.Errorf("pod %q in namespace %q is not ready: %w", name, namespace, err)
 	}
@@ -277,16 +274,13 @@ func (c *Cluster) WaitReadyPod(name, namespace string, timeout time.Duration) er
 }
 
 func isPodReady(pod *corev1.Pod) bool {
-	var readyCondition *corev1.PodCondition
-
 	for _, condition := range pod.Status.Conditions {
 		if condition.Type == corev1.PodReady {
-			readyCondition = &condition
-			break
+			return condition.Status == corev1.ConditionTrue
 		}
 	}
 
-	return readyCondition != nil && readyCondition.Status == corev1.ConditionTrue
+	return false
 }
 
 func createCluster(logger logrus.FieldLogger, clusterName string, cmdOpts []string) error {
@@ -405,7 +399,6 @@ func waitClusterReady(client k8s.Client) error {
 		_, _, err := client.KubernetesClient().Discovery().ServerGroupsAndResources()
 		return err
 	}, 60*time.Second)
-
 	if err != nil {
 		return fmt.Errorf("timed out waiting for the cluster to be ready: %w", err)
 	}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -15,9 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-var (
-	localhost = "127.0.0.1"
-)
+var localhost = "127.0.0.1"
 
 func TestEnableReadiness(t *testing.T) {
 	log := logrus.New()
@@ -234,8 +232,8 @@ func startTestAPIServer(port string, statusCode int, bodyData []byte) (ts *httpt
 
 		_, _ = w.Write(bodyData)
 	})
-	listener, err := net.Listen("tcp", "127.0.0.1:"+port)
 
+	listener, err := net.Listen("tcp", "127.0.0.1:"+port)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -35,7 +35,7 @@ const (
 
 	// maxRetries is the number of times a work task will be retried before it is dropped out of the queue.
 	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the times a
-	// work task is going to be re-queued: 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s
+	// work task is going to be re-queued: 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s.
 	maxRetries = 12
 )
 

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -261,7 +261,8 @@ func TestRestoreCoreDNS(t *testing.T) {
 		{
 			desc:             "CoreDNS config patched",
 			mockFile:         "restorecoredns_patched.yaml",
-			expectedCorefile: ".:53 {\n        errors\n        health {\n            lameduck 5s\n        }\n        ready\n        kubernetes {{ pillar['dns_domain'] }} in-addr.arpa ip6.arpa {\n            pods insecure\n            fallthrough in-addr.arpa ip6.arpa\n            ttl 30\n        }\n        prometheus :9153\n        forward . /etc/resolv.conf\n        cache 30\n        loop\n        reload\n        loadbalance\n    }\n\n# This is test data that must be present\n"},
+			expectedCorefile: ".:53 {\n        errors\n        health {\n            lameduck 5s\n        }\n        ready\n        kubernetes {{ pillar['dns_domain'] }} in-addr.arpa ip6.arpa {\n            pods insecure\n            fallthrough in-addr.arpa ip6.arpa\n            ttl 30\n        }\n        prometheus :9153\n        forward . /etc/resolv.conf\n        cache 30\n        loop\n        reload\n        loadbalance\n    }\n\n# This is test data that must be present\n",
+		},
 		{
 			desc:             "CoreDNS config not patched",
 			mockFile:         "restorecoredns_not_patched.yaml",

--- a/pkg/k8s/client_mock.go
+++ b/pkg/k8s/client_mock.go
@@ -104,8 +104,8 @@ func MustParseYaml(content []byte) []runtime.Object {
 		}
 
 		decode := scheme.Codecs.UniversalDeserializer().Decode
-		obj, groupVersionKind, err := decode([]byte(file), nil, nil)
 
+		obj, groupVersionKind, err := decode([]byte(file), nil, nil)
 		if err != nil {
 			panic(fmt.Sprintf("Error while decoding YAML object. Err was: %s", err))
 		}

--- a/pkg/topology/builder_test.go
+++ b/pkg/topology/builder_test.go
@@ -954,6 +954,7 @@ func buildKeySorter(keys []Key) func(i, j int) bool {
 		return strings.Compare(keys[i].String(), keys[j].String()) < 0
 	}
 }
+
 func buildServiceTrafficTargetKeySorter(keys []ServiceTrafficTargetKey) func(i, j int) bool {
 	return func(i, j int) bool {
 		return strings.Compare(keys[i].String(), keys[j].String()) < 0


### PR DESCRIPTION
## What does this PR do?

This PR:

- Upgrades `golangci-lint` version to v1.30.

### How to test it

* make check