### PR TITLE
Add app and release selector to the controller service

### DIFF
--- a/helm/chart/maesh/templates/controller/controller-service.yaml
+++ b/helm/chart/maesh/templates/controller/controller-service.yaml
@@ -14,4 +14,6 @@ spec:
       name: mesh-controller-api
       targetPort: api
   selector:
+    app: maesh
     component: controller
+    release: {{ .Release.Name | quote }}

--- a/helm/chart/maesh/templates/coredns/coredns-deployment.yaml
+++ b/helm/chart/maesh/templates/coredns/coredns-deployment.yaml
@@ -21,11 +21,13 @@ spec:
     matchLabels:
       app: maesh
       component: coredns
+      release: {{ .Release.Name | quote }}
   template:
     metadata:
       labels:
         app: maesh
         component: coredns
+        release: {{ .Release.Name | quote }}
     spec:
       serviceAccountName: maesh-coredns
       affinity:

--- a/helm/chart/maesh/templates/coredns/coredns-service.yaml
+++ b/helm/chart/maesh/templates/coredns/coredns-service.yaml
@@ -18,6 +18,7 @@ spec:
   selector:
     app: maesh
     component: coredns
+    release: {{ .Release.Name | quote }}
   type: ClusterIP
   ports:
     - name: dns

--- a/helm/chart/maesh/templates/mesh/mesh-service.yaml
+++ b/helm/chart/maesh/templates/mesh/mesh-service.yaml
@@ -16,3 +16,4 @@ spec:
   selector:
     app: maesh
     component: maesh-mesh
+    release: {{ .Release.Name | quote }}


### PR DESCRIPTION
## What does this PR do?

This PR:

- Adds app and release selector to the controller service
- Adds release selector to the mesh service
- Adds release selector to maesh coredns pods

Fixes #725

### How to test it

* make test-integration