### PR TITLE
chore(docs): upgrade Alpine and PyYAML to fix doc build

### DIFF
--- a/docs/docs.Dockerfile
+++ b/docs/docs.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.18
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -30,7 +30,7 @@ Pygments==2.11.2
 pymdown-extensions==7.0
 pyparsing==2.4.7
 python-dateutil==2.8.2
-PyYAML==6.0.1
+PyYAML==6.0.2
 pyyaml-env-tag==0.1
 requests==2.26.0
 retrying==1.3.3


### PR DESCRIPTION
## What does this PR do?

Fixes the documentation build pipeline that fails with `AttributeError: cython_sources` during `pip install`.
cf. https://github.com/traefik/mesh/actions/runs/23431874908/job/68160009068

### Root cause

The `docs.Dockerfile` uses Alpine 3.15 which ships Python 3.7 (EOL) with pip 20.1.1 and old setuptools. PyYAML 6.0.1's Cython-based build is incompatible with this old toolchain.

This also creates a **circular dependency** with the structor-based publish workflow:
- Structor builds documentation for **every versioned branch** (`v1.4`, `master`, etc.) using each branch's own `docs.Dockerfile`
- Even if `master` is fixed, structor still fails when building `v1.4` (which has the old Dockerfile)
- And `v1.4` can't be fixed because the master pipeline blocks merges

This PR fixes the `master` side. A corresponding fix for `v1.4` is in #873.

### Changes

- Upgrade base image from Alpine 3.15 to Alpine 3.18 (Python 3.11, modern pip/setuptools)
- Bump PyYAML from 6.0.1 to 6.0.2 (includes the cython_sources fix)