### PR TITLE
chore(security): run image as non-root and disable CI checkout credential persistence

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Package documentation
         run: make docs-package

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,6 @@ RUN addgroup -g 1000 -S app && \
 COPY --from=base-image /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=maker /go/src/github.com/traefik/mesh/dist/traefik-mesh /app/
 
+USER app
+
 ENTRYPOINT ["/app/traefik-mesh"]

--- a/tmpl.Dockerfile
+++ b/tmpl.Dockerfile
@@ -36,4 +36,6 @@ RUN addgroup -g 1000 -S app && \
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/traefik/mesh/dist/traefik-mesh /app/
 
+USER app
+
 ENTRYPOINT ["/app/traefik-mesh"]


### PR DESCRIPTION
# Motivation

The runtime images already define a non-root `app` user (uid 1000) but never switch to it, so the entrypoint runs as root. Separately, the `actions/checkout` steps persist the GitHub token in `.git/config` for the whole job (CWE-522/200). This adds `USER app` to both Dockerfiles and `persist-credentials: false` to the two workflow checkouts (neither runs authenticated git afterwards).
